### PR TITLE
Add context compaction tools

### DIFF
--- a/memory/add-context-compaction-tools/clarifications.md
+++ b/memory/add-context-compaction-tools/clarifications.md
@@ -1,0 +1,7 @@
+No blocking clarifications were required after Phase 1.
+
+Implementation choices recorded:
+
+- Add the requested compaction behavior to the merged `src/tools/` extension surface instead of waiting on the older unmerged `src/agents` branch.
+- Introduce a small explicit agent-context model so "parameter" entries, tool calls, tool results, and summary entries can be manipulated deterministically.
+- Expose `log_compaction` through a factory that accepts an injected summarizer callable, because the requested behavior depends on a separate LLM/agent pass.

--- a/memory/add-context-compaction-tools/internalization.md
+++ b/memory/add-context-compaction-tools/internalization.md
@@ -1,0 +1,77 @@
+# Internalization
+
+## 1a: Structural Survey
+
+Repository shape:
+
+- `src/` is a small Python package centered around two merged concerns today:
+- `src/tools/` owns canonical tool metadata, runtime handlers, and deterministic registry/validation behavior.
+- `src/providers/` owns provider-agnostic message normalization plus provider-specific request builders and clients for OpenAI, Grok, Anthropic, and Gemini.
+- `src/shared/` holds reusable type definitions and constants shared across the tool and provider layers.
+- `tests/` contains `unittest` coverage for tools, provider helpers, provider clients, and LangSmith tracing helpers.
+- `artifacts/file_index.md` is the maintained architecture artifact for this repository.
+
+Technology and conventions:
+
+- Plain Python package with standard-library `unittest`.
+- Runtime abstractions are intentionally lightweight: dataclasses, typed dicts, protocols, and pure helper functions.
+- Tooling is modeled canonically as `ToolDefinition` + `RegisteredTool`, executed through `ToolRegistry`.
+- Public API exposure is curated through package `__init__.py` files.
+- There is no configured linter or type checker in the repository root; code quality is enforced through annotations, small functions, and tests.
+
+Relevant existing architecture:
+
+- `src/shared/tools.py` defines the current canonical tool contracts, including `ToolDefinition`, `ToolCall`, `ToolResult`, and `RegisteredTool`.
+- `src/tools/builtin.py` contains the default built-in runtime tools, currently only `echo_text` and `add_numbers`.
+- `src/tools/registry.py` validates arguments and executes registered tools deterministically.
+- Provider request builders consume tool definitions, but there is no merged agent runtime or transcript model on `main`.
+
+Important repository-state finding:
+
+- Older remote branches `origin/issue-2` and `origin/issue-3` contain an unmerged `src/agents/base.py`, but that work is not present on `main`.
+- That means the current branch has no first-class concept of an agent context window, parameter messages, or transcript compaction.
+
+## 1b: Task Cross-Reference
+
+User request mapping:
+
+- The requested additions are new custom tool functions:
+- `remove_tool_results`: remove tool-result entries from an agent context window.
+- `remove_tools`: remove both tool-call and tool-result entries from an agent context window.
+- `heavy_compaction`: retain only the agent's leading parameter messages and strip the rest of the context window.
+- `log_compaction`: summarize the full context window through a separate summarizer/LLM call, append that summary after the parameter messages, then strip the rest.
+
+Concrete code impact on the merged codebase:
+
+- `src/shared/`: add a small agent-context data model because current shared types only model provider chat messages, not tool-call/result transcript items.
+- `src/tools/`: add reusable compaction helpers and register the new context-compaction tools alongside the existing built-ins.
+- `src/tools/__init__.py`: export the new public tool constants and factory surface.
+- `tests/`: add coverage for context compaction behavior and registry integration.
+
+Why the change should land here:
+
+- The user asked for injectable tooling functions, and the merged codebase's existing extension point for injectable runtime behavior is `RegisteredTool` inside the `src/tools/` layer.
+- Adding a narrow shared agent-context model plus compaction tools is the smallest merged-codebase change that supports the requested behavior without depending on the unmerged `src/agents` branch.
+
+Behavior to preserve:
+
+- Existing built-in tool keys and execution semantics must remain stable.
+- Existing provider payload builders must remain unaffected because they consume tool definitions only, not runtime compaction behavior.
+
+## 1c: Assumption & Risk Inventory
+
+Assumptions:
+
+- The requested compaction functions should be added to the merged `main` branch as reusable tool/runtime primitives, not only to the older unmerged agent branch.
+- A generic agent-context-window representation can be introduced without implementing the full agent harness in this task.
+- "parameters at the beginning of the context window" should be represented explicitly in the new context model so compaction behavior is deterministic rather than inferred from free-form message text.
+- `log_compaction` should support an injected summarizer callable because the repository's tool registry supports injectable runtime handlers, while the summarization behavior requires a separate model/agent call.
+
+Risks and edge cases:
+
+- If the future merged agent runtime chooses a transcript shape incompatible with the new context model, adapters will be required. Keeping the model small and explicit reduces this risk.
+- A built-in registry cannot construct `log_compaction` correctly without a summarizer dependency; the implementation needs a factory surface rather than hard-wiring a fake summary behavior.
+- Compaction helpers must preserve leading parameter entries exactly and maintain stable ordering for all retained items.
+- The repository currently has no tool-execution error type beyond validation and key lookup errors, so summarizer dependency failures must use clear existing exception behavior or avoid default registration without a summarizer.
+
+Phase 1 complete

--- a/memory/add-context-compaction-tools/tickets/index.md
+++ b/memory/add-context-compaction-tools/tickets/index.md
@@ -1,0 +1,4 @@
+# Tickets Index
+
+1. Ticket 1: Add reusable agent-context compaction tools
+   - Define a canonical context-window model, add the four compaction tools, and cover them with unit tests.

--- a/memory/add-context-compaction-tools/tickets/ticket-1-critique.md
+++ b/memory/add-context-compaction-tools/tickets/ticket-1-critique.md
@@ -1,0 +1,10 @@
+# Ticket 1 Critique
+
+## Findings
+- The initial implementation exposed `log_compaction` as a tool that required a precomputed `summary`, but it did not allow callers to inject a summarizer-backed handler even though the requested behavior described a separate summarizer pass.
+- The first implementation also stopped at generic tool helpers and did not wire compaction-tool outputs back into the local `BaseAgent` state, which would have left the tools inert for the in-workspace agent harness.
+
+## Improvements Applied
+- `create_context_compaction_tools()` now accepts an optional `log_summarizer`, allowing the same `log_compaction` tool key to be registered either in summary-input mode or in injected-summarizer mode.
+- `BaseAgent` now exposes an explicit context-window view, records tool calls as first-class transcript entries, and applies compaction-tool outputs back onto its in-memory parameter/transcript state.
+- Added agent-level tests to confirm compaction results rewrite the next model request as intended.

--- a/memory/add-context-compaction-tools/tickets/ticket-1-quality.md
+++ b/memory/add-context-compaction-tools/tickets/ticket-1-quality.md
@@ -1,0 +1,26 @@
+# Ticket 1 Quality
+
+## Static Analysis
+- `python -m py_compile src/shared/agents.py src/shared/tools.py src/tools/context_compaction.py src/tools/builtin.py src/tools/__init__.py src/agents/base.py tests/test_context_compaction_tools.py tests/test_tools.py tests/test_agents_base.py`
+- Result: passed.
+
+## Type Checking
+- No repository type checker is configured.
+- New code paths were fully annotated and verified through runtime tests.
+
+## Unit Tests
+- `python -m unittest tests.test_context_compaction_tools tests.test_tools tests.test_agents_base -v`
+- Result: passed.
+
+## Integration and Contract Tests
+- `python -m unittest tests.test_linkedin_agent -v`
+- Result: passed.
+- This verified that the local agent harness still runs cleanly after the base-agent transcript and compaction changes.
+
+## Full Suite
+- `python -m unittest -v`
+- Result: passed (70 tests).
+
+## Smoke Notes
+- Verified registry execution for `context.remove_tool_results`, `context.remove_tools`, `context.heavy_compaction`, and `context.log_compaction`.
+- Verified a compaction tool result can rewrite `BaseAgent` in-memory context so the next model request sees the compacted window.

--- a/memory/add-context-compaction-tools/tickets/ticket-1.md
+++ b/memory/add-context-compaction-tools/tickets/ticket-1.md
@@ -1,0 +1,31 @@
+Title: Add reusable agent-context compaction tools
+Intent: Extend the current tool runtime with injectable context-window compaction behavior so future agents can deterministically remove tool noise, reset context down to parameters, and preserve conversation history through summarized logs.
+Scope:
+- Add a small shared context-window model for parameter entries, conversational messages, tool calls, tool results, and summaries.
+- Add `remove_tool_results`, `remove_tools`, `heavy_compaction`, and `log_compaction` tool handlers and definitions.
+- Export the new compaction tool surface through `src/tools/__init__.py`.
+- Add unit tests covering compaction behavior and registry integration.
+- Do not implement a full agent loop or provider response parser in this ticket.
+Relevant Files:
+- `src/shared/agents.py`: canonical agent-context typed dicts and helper aliases.
+- `src/tools/context_compaction.py`: compaction helper functions and registered-tool factories.
+- `src/tools/__init__.py`: public exports for the new compaction tools.
+- `tests/test_context_compaction_tools.py`: coverage for the new compaction behavior.
+Approach: Keep the context model explicit and minimal. Represent context entries with a required `kind` field so compaction behavior does not depend on heuristics about message text. Implement pure helper functions first, then wrap them in `RegisteredTool` factories so the behavior is usable through the existing registry. `log_compaction` will accept an injected summarizer callable and will preserve leading parameter entries before appending a synthesized summary entry.
+Assumptions:
+- The merged branch should gain reusable compaction primitives even though the fuller agent runtime remains unmerged.
+- Parameter entries should be preserved only while they remain the leading contiguous prefix of the context window.
+- A summary entry can be represented as a dedicated `summary` kind rather than overloading an assistant message.
+Acceptance Criteria:
+- [ ] The codebase contains a canonical context-window representation suitable for compaction tools.
+- [ ] `remove_tool_results` removes only tool-result entries and preserves all other ordering.
+- [ ] `remove_tools` removes tool-call and tool-result entries and preserves all other ordering.
+- [ ] `heavy_compaction` preserves only the leading parameter prefix.
+- [ ] `log_compaction` preserves the leading parameter prefix, appends a synthesized summary entry, and removes the remaining prior context entries.
+- [ ] The compaction tools are exposed through the public tool package and covered by unit tests.
+Verification Steps:
+- Run `python -m unittest tests.test_context_compaction_tools -v`.
+- Run `python -m unittest`.
+- Smoke-check the registry by executing the new tool keys against sample context windows.
+Dependencies: None.
+Drift Guard: This ticket must not turn into a full agent runtime implementation, provider adapter, or transcript persistence system. The deliverable is the reusable compaction-tool surface only.

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, Sequence
 
+from src.shared.agents import AgentContextEntry, AgentContextWindow
+from src.shared.tools import HEAVY_COMPACTION, LOG_COMPACTION, REMOVE_TOOL_RESULTS, REMOVE_TOOLS
 from src.shared.tools import ToolCall, ToolDefinition, ToolResult
 
 
@@ -49,7 +51,7 @@ class AgentParameterSection:
         return f"## {self.title}\n{self.content}".rstrip()
 
 
-TranscriptEntryType = Literal["assistant", "tool_call", "tool_result"]
+TranscriptEntryType = Literal["assistant", "tool_call", "tool_result", "summary"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,6 +66,8 @@ class AgentTranscriptEntry:
             label = "[ASSISTANT TURN]"
         elif self.entry_type == "tool_call":
             label = "[TOOL CALL]"
+        elif self.entry_type == "summary":
+            label = "[SUMMARY]"
         else:
             label = "[TOOL RESULT]"
         return f"{label}\n{self.content}".rstrip()
@@ -149,6 +153,15 @@ class AgentToolExecutor(Protocol):
 class BaseAgent(ABC):
     """Shared harness for long-running tool-using agents."""
 
+    _COMPACTION_TOOL_KEYS = frozenset(
+        {
+            REMOVE_TOOL_RESULTS,
+            REMOVE_TOOLS,
+            HEAVY_COMPACTION,
+            LOG_COMPACTION,
+        }
+    )
+
     def __init__(
         self,
         *,
@@ -188,6 +201,18 @@ class BaseAgent(ABC):
     @property
     def reset_count(self) -> int:
         return self._reset_count
+
+    def build_context_window(self) -> AgentContextWindow:
+        """Return the current context window including parameters and transcript entries."""
+        if not self._parameter_sections:
+            self.refresh_parameters()
+        context_window: AgentContextWindow = [
+            {"kind": "parameter", "label": section.title, "content": section.content}
+            for section in self._parameter_sections
+        ]
+        for entry in self._transcript:
+            context_window.append(self._transcript_entry_to_context_entry(entry))
+        return context_window
 
     @abstractmethod
     def build_system_prompt(self) -> str:
@@ -249,6 +274,8 @@ class BaseAgent(ABC):
             pause_signal: AgentPauseSignal | None = None
             for tool_call in response.tool_calls:
                 result = self._execute_tool(tool_call)
+                if self._apply_compaction_result(result):
+                    continue
                 self._record_tool_result(result)
                 if isinstance(result.output, AgentPauseSignal):
                     pause_signal = result.output
@@ -329,6 +356,56 @@ class BaseAgent(ABC):
             tools=request.tools,
         )
         return reset_request.estimated_tokens() < self._runtime_config.reset_token_limit
+
+    def _apply_compaction_result(self, result: ToolResult) -> bool:
+        if result.tool_key not in self._COMPACTION_TOOL_KEYS:
+            return False
+        if not isinstance(result.output, dict):
+            return False
+        context_window = result.output.get("context_window")
+        if not isinstance(context_window, list):
+            return False
+        self._apply_context_window(context_window)
+        return True
+
+    def _apply_context_window(self, context_window: list[dict[str, Any]]) -> None:
+        parameter_sections: list[AgentParameterSection] = []
+        transcript: list[AgentTranscriptEntry] = []
+        for entry in context_window:
+            kind = entry.get("kind")
+            if kind == "parameter":
+                parameter_sections.append(
+                    AgentParameterSection(
+                        title=str(entry.get("label", "Parameters")),
+                        content=str(entry.get("content", "")),
+                    )
+                )
+                continue
+            transcript.append(self._context_entry_to_transcript_entry(entry))
+        self._parameter_sections = tuple(parameter_sections)
+        self._transcript = transcript
+
+    def _context_entry_to_transcript_entry(self, entry: dict[str, Any]) -> AgentTranscriptEntry:
+        kind = entry.get("kind")
+        content = str(entry.get("content", ""))
+        if kind == "message":
+            return AgentTranscriptEntry(entry_type="assistant", content=content)
+        if kind == "tool_call":
+            return AgentTranscriptEntry(entry_type="tool_call", content=content)
+        if kind == "tool_result":
+            return AgentTranscriptEntry(entry_type="tool_result", content=content)
+        if kind == "summary":
+            return AgentTranscriptEntry(entry_type="summary", content=content)
+        raise ValueError(f"Unsupported context entry kind '{kind}'.")
+
+    def _transcript_entry_to_context_entry(self, entry: AgentTranscriptEntry) -> AgentContextEntry:
+        if entry.entry_type == "assistant":
+            return {"kind": "message", "role": "assistant", "content": entry.content}
+        if entry.entry_type == "tool_call":
+            return {"kind": "tool_call", "content": entry.content}
+        if entry.entry_type == "summary":
+            return {"kind": "summary", "content": entry.content}
+        return {"kind": "tool_result", "content": entry.content}
 
 
 __all__ = [

--- a/src/shared/agents.py
+++ b/src/shared/agents.py
@@ -1,0 +1,35 @@
+"""Shared agent-context data models for future harness runtimes."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+AgentContextEntryKind = Literal["parameter", "message", "tool_call", "tool_result", "summary"]
+AgentMessageRole = Literal["system", "user", "assistant"]
+
+
+class _AgentContextEntryRequired(TypedDict):
+    kind: AgentContextEntryKind
+
+
+class AgentContextEntry(_AgentContextEntryRequired, total=False):
+    """A normalized agent context-window entry."""
+
+    role: AgentMessageRole
+    content: str
+    label: str
+    tool_key: str
+    tool_call_id: str
+    arguments: dict[str, Any]
+    output: Any
+    metadata: dict[str, Any]
+
+
+AgentContextWindow = list[AgentContextEntry]
+
+__all__ = [
+    "AgentContextEntry",
+    "AgentContextEntryKind",
+    "AgentContextWindow",
+    "AgentMessageRole",
+]

--- a/src/shared/tools.py
+++ b/src/shared/tools.py
@@ -11,6 +11,10 @@ ToolArguments = dict[str, Any]
 
 ECHO_TEXT = "core.echo_text"
 ADD_NUMBERS = "core.add_numbers"
+REMOVE_TOOL_RESULTS = "context.remove_tool_results"
+REMOVE_TOOLS = "context.remove_tools"
+HEAVY_COMPACTION = "context.heavy_compaction"
+LOG_COMPACTION = "context.log_compaction"
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +78,11 @@ class RegisteredTool:
 __all__ = [
     "ADD_NUMBERS",
     "ECHO_TEXT",
+    "HEAVY_COMPACTION",
     "JsonObject",
+    "LOG_COMPACTION",
+    "REMOVE_TOOL_RESULTS",
+    "REMOVE_TOOLS",
     "RegisteredTool",
     "ToolArguments",
     "ToolCall",

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -3,7 +3,11 @@
 from src.shared.tools import (
     ADD_NUMBERS,
     ECHO_TEXT,
+    HEAVY_COMPACTION,
     JsonObject,
+    LOG_COMPACTION,
+    REMOVE_TOOL_RESULTS,
+    REMOVE_TOOLS,
     RegisteredTool,
     ToolArguments,
     ToolCall,
@@ -13,13 +17,26 @@ from src.shared.tools import (
 )
 
 from .builtin import BUILTIN_TOOLS
+from .context_compaction import (
+    ContextSummarizer,
+    apply_log_compaction,
+    create_context_compaction_tools,
+    heavy_compact_context,
+    remove_tool_entries,
+    remove_tool_result_entries,
+    summarize_and_log_compact,
+)
 from .registry import ToolRegistry, create_builtin_registry
 
 __all__ = [
     "ADD_NUMBERS",
     "BUILTIN_TOOLS",
     "ECHO_TEXT",
+    "HEAVY_COMPACTION",
     "JsonObject",
+    "LOG_COMPACTION",
+    "REMOVE_TOOL_RESULTS",
+    "REMOVE_TOOLS",
     "RegisteredTool",
     "ToolArguments",
     "ToolCall",
@@ -27,5 +44,12 @@ __all__ = [
     "ToolHandler",
     "ToolResult",
     "ToolRegistry",
+    "ContextSummarizer",
+    "apply_log_compaction",
+    "create_context_compaction_tools",
     "create_builtin_registry",
+    "heavy_compact_context",
+    "remove_tool_entries",
+    "remove_tool_result_entries",
+    "summarize_and_log_compact",
 ]

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from src.shared.tools import ADD_NUMBERS, ECHO_TEXT, RegisteredTool, ToolArguments, ToolDefinition
 
+from .context_compaction import create_context_compaction_tools
+
 
 def _echo_text(arguments: ToolArguments) -> dict[str, str]:
     text = str(arguments["text"])
@@ -59,4 +61,5 @@ BUILTIN_TOOLS = (
         ),
         handler=_add_numbers,
     ),
+    *create_context_compaction_tools(),
 )

--- a/src/tools/context_compaction.py
+++ b/src/tools/context_compaction.py
@@ -1,0 +1,248 @@
+"""Context-window compaction helpers and registered tools."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable, Mapping, cast
+
+from src.shared.agents import AgentContextEntry, AgentContextWindow
+from src.shared.tools import (
+    HEAVY_COMPACTION,
+    LOG_COMPACTION,
+    REMOVE_TOOL_RESULTS,
+    REMOVE_TOOLS,
+    RegisteredTool,
+    ToolArguments,
+    ToolDefinition,
+)
+
+ContextSummarizer = Callable[[AgentContextWindow], str | AgentContextEntry]
+_ALLOWED_CONTEXT_KINDS = frozenset({"parameter", "message", "tool_call", "tool_result", "summary"})
+_CONTEXT_WINDOW_PROPERTY: dict[str, object] = {
+    "type": "array",
+    "description": "An ordered list of normalized agent context entries.",
+    "items": {"type": "object"},
+}
+
+
+def remove_tool_result_entries(context_window: list[Mapping[str, Any]]) -> AgentContextWindow:
+    """Return a copy of the context window without tool-result entries."""
+    normalized = _normalize_context_window(context_window)
+    return [entry for entry in normalized if entry["kind"] != "tool_result"]
+
+
+def remove_tool_entries(context_window: list[Mapping[str, Any]]) -> AgentContextWindow:
+    """Return a copy of the context window without tool calls or tool results."""
+    normalized = _normalize_context_window(context_window)
+    return [entry for entry in normalized if entry["kind"] not in {"tool_call", "tool_result"}]
+
+
+def heavy_compact_context(context_window: list[Mapping[str, Any]]) -> AgentContextWindow:
+    """Preserve only the leading parameter block from the context window."""
+    normalized = _normalize_context_window(context_window)
+    return normalized[:_parameter_prefix_length(normalized)]
+
+
+def apply_log_compaction(
+    context_window: list[Mapping[str, Any]],
+    summary: str | Mapping[str, Any],
+) -> AgentContextWindow:
+    """Preserve the parameter prefix and append a summary entry."""
+    normalized = _normalize_context_window(context_window)
+    preserved = normalized[:_parameter_prefix_length(normalized)]
+    return [*preserved, _normalize_summary_entry(summary)]
+
+
+def summarize_and_log_compact(
+    context_window: list[Mapping[str, Any]],
+    summarizer: ContextSummarizer,
+) -> AgentContextWindow:
+    """Summarize the full window through an injected callable, then compact it."""
+    normalized = _normalize_context_window(context_window)
+    summary = summarizer(deepcopy(normalized))
+    return apply_log_compaction(normalized, summary)
+
+
+def create_context_compaction_tools(
+    *,
+    log_summarizer: ContextSummarizer | None = None,
+) -> tuple[RegisteredTool, ...]:
+    """Return the registered tool set for context compaction."""
+    return (
+        RegisteredTool(
+            definition=ToolDefinition(
+                key=REMOVE_TOOL_RESULTS,
+                name="remove_tool_results",
+                description="Remove all tool-result entries from an agent context window.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "context_window": _context_window_property(),
+                    },
+                    "required": ["context_window"],
+                    "additionalProperties": False,
+                },
+            ),
+            handler=_remove_tool_results,
+        ),
+        RegisteredTool(
+            definition=ToolDefinition(
+                key=REMOVE_TOOLS,
+                name="remove_tools",
+                description="Remove all tool-call and tool-result entries from an agent context window.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "context_window": _context_window_property(),
+                    },
+                    "required": ["context_window"],
+                    "additionalProperties": False,
+                },
+            ),
+            handler=_remove_tools,
+        ),
+        RegisteredTool(
+            definition=ToolDefinition(
+                key=HEAVY_COMPACTION,
+                name="heavy_compaction",
+                description="Preserve only the leading parameter entries in an agent context window.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "context_window": _context_window_property(),
+                    },
+                    "required": ["context_window"],
+                    "additionalProperties": False,
+                },
+            ),
+            handler=_heavy_compaction,
+        ),
+        RegisteredTool(
+            definition=ToolDefinition(
+                key=LOG_COMPACTION,
+                name="log_compaction",
+                description=(
+                    "Append a summary after the leading parameter entries and drop the rest "
+                    "of the prior context window."
+                ),
+                input_schema=_log_compaction_input_schema(log_summarizer is None),
+            ),
+            handler=_build_log_compaction_handler(log_summarizer),
+        ),
+    )
+
+
+def _remove_tool_results(arguments: ToolArguments) -> dict[str, AgentContextWindow]:
+    return {"context_window": remove_tool_result_entries(_require_context_window(arguments))}
+
+
+def _remove_tools(arguments: ToolArguments) -> dict[str, AgentContextWindow]:
+    return {"context_window": remove_tool_entries(_require_context_window(arguments))}
+
+
+def _heavy_compaction(arguments: ToolArguments) -> dict[str, AgentContextWindow]:
+    return {"context_window": heavy_compact_context(_require_context_window(arguments))}
+
+
+def _log_compaction(arguments: ToolArguments) -> dict[str, AgentContextWindow]:
+    return {
+        "context_window": apply_log_compaction(
+            _require_context_window(arguments),
+            arguments["summary"],
+        )
+    }
+
+
+def _summarizing_log_compaction(
+    arguments: ToolArguments,
+    summarizer: ContextSummarizer,
+) -> dict[str, AgentContextWindow]:
+    return {
+        "context_window": summarize_and_log_compact(
+            _require_context_window(arguments),
+            summarizer,
+        )
+    }
+
+
+def _build_log_compaction_handler(
+    summarizer: ContextSummarizer | None,
+) -> Callable[[ToolArguments], dict[str, AgentContextWindow]]:
+    if summarizer is None:
+        return _log_compaction
+    return lambda arguments: _summarizing_log_compaction(arguments, summarizer)
+
+
+def _require_context_window(arguments: ToolArguments) -> list[Mapping[str, Any]]:
+    context_window = arguments["context_window"]
+    if not isinstance(context_window, list):
+        raise ValueError("The 'context_window' argument must be a list of context entries.")
+    return cast(list[Mapping[str, Any]], context_window)
+
+
+def _normalize_context_window(context_window: list[Mapping[str, Any]]) -> AgentContextWindow:
+    normalized: AgentContextWindow = []
+    for index, entry in enumerate(context_window):
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"Context entry at index {index} must be a mapping.")
+        kind = entry.get("kind")
+        if kind not in _ALLOWED_CONTEXT_KINDS:
+            raise ValueError(f"Unsupported context entry kind '{kind}' at index {index}.")
+        normalized.append(cast(AgentContextEntry, deepcopy(dict(entry))))
+    return normalized
+
+
+def _normalize_summary_entry(summary: str | Mapping[str, Any]) -> AgentContextEntry:
+    if isinstance(summary, str):
+        return {"kind": "summary", "content": summary}
+    if not isinstance(summary, Mapping):
+        raise ValueError("The 'summary' argument must be a string or mapping.")
+    entry = cast(AgentContextEntry, deepcopy(dict(summary)))
+    if entry.get("kind") != "summary":
+        raise ValueError("Summary mappings must use kind='summary'.")
+    return entry
+
+
+def _parameter_prefix_length(context_window: AgentContextWindow) -> int:
+    count = 0
+    for entry in context_window:
+        if entry["kind"] != "parameter":
+            break
+        count += 1
+    return count
+
+
+def _context_window_property() -> dict[str, object]:
+    return deepcopy(_CONTEXT_WINDOW_PROPERTY)
+
+
+def _log_compaction_input_schema(require_summary: bool) -> dict[str, object]:
+    properties: dict[str, object] = {
+        "context_window": _context_window_property(),
+    }
+    required = ["context_window"]
+    if require_summary:
+        properties["summary"] = {
+            "description": (
+                "A summary generated by a separate LLM or agent pass, either as "
+                "plain text or as a pre-built summary entry."
+            ),
+        }
+        required.append("summary")
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+__all__ = [
+    "ContextSummarizer",
+    "apply_log_compaction",
+    "create_context_compaction_tools",
+    "heavy_compact_context",
+    "remove_tool_entries",
+    "remove_tool_result_entries",
+    "summarize_and_log_compact",
+]

--- a/tests/test_agents_base.py
+++ b/tests/test_agents_base.py
@@ -12,7 +12,8 @@ from src.agents import (
     AgentRuntimeConfig,
     BaseAgent,
 )
-from src.shared.tools import RegisteredTool, ToolCall, ToolDefinition
+from src.shared.tools import HEAVY_COMPACTION, RegisteredTool, ToolCall, ToolDefinition
+from src.tools import create_context_compaction_tools
 from src.tools.registry import ToolRegistry
 
 
@@ -99,6 +100,7 @@ class BaseAgentTests(unittest.TestCase):
         self.assertEqual(len(model.requests), 2)
         self.assertEqual(model.requests[0].transcript, ())
         self.assertEqual(len(model.requests[1].transcript), 3)
+        self.assertEqual(model.requests[1].transcript[0].entry_type, "assistant")
         self.assertEqual(model.requests[1].transcript[1].entry_type, "tool_call")
         self.assertEqual(model.requests[1].transcript[2].entry_type, "tool_result")
         self.assertIn("session.echo", model.requests[1].transcript[1].content)
@@ -160,6 +162,35 @@ class BaseAgentTests(unittest.TestCase):
         self.assertEqual(len(model.requests), 2)
         self.assertEqual(model.requests[1].transcript, ())
         self.assertEqual(model.requests[1].parameter_sections[0].content, "refreshed")
+
+    def test_compaction_tool_result_rewrites_agent_context_window(self) -> None:
+        registry = ToolRegistry(create_context_compaction_tools())
+        compactable_window = [
+            {"kind": "parameter", "label": "State", "content": "initial"},
+            {"kind": "message", "role": "assistant", "content": "Earlier turn"},
+            {"kind": "tool_result", "content": "session.echo\n{\"echoed\": \"hello\"}"},
+        ]
+        model = _FakeModel(
+            [
+                AgentModelResponse(
+                    assistant_message="Use heavy compaction.",
+                    tool_calls=(ToolCall(tool_key=HEAVY_COMPACTION, arguments={"context_window": compactable_window}),),
+                    should_continue=True,
+                ),
+                AgentModelResponse(
+                    assistant_message="Finished.",
+                    should_continue=False,
+                ),
+            ]
+        )
+        agent = _InspectableAgent(model=model, tool_executor=registry)
+
+        result = agent.run(max_cycles=3)
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(model.requests), 2)
+        self.assertEqual(model.requests[1].transcript, ())
+        self.assertEqual(model.requests[1].parameter_sections[0].content, "initial")
 
 
 if __name__ == "__main__":

--- a/tests/test_context_compaction_tools.py
+++ b/tests/test_context_compaction_tools.py
@@ -1,0 +1,180 @@
+"""Tests for agent-context compaction helpers and tools."""
+
+from __future__ import annotations
+
+import unittest
+
+from src.shared.tools import HEAVY_COMPACTION, LOG_COMPACTION, REMOVE_TOOL_RESULTS, REMOVE_TOOLS
+from src.tools import (
+    apply_log_compaction,
+    create_builtin_registry,
+    create_context_compaction_tools,
+    heavy_compact_context,
+    remove_tool_entries,
+    remove_tool_result_entries,
+    summarize_and_log_compact,
+)
+from src.tools.registry import ToolRegistry
+
+
+class ContextCompactionToolsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context_window = [
+            {"kind": "parameter", "label": "identity", "content": "Agent identity"},
+            {"kind": "parameter", "label": "preferences", "content": "Job preferences"},
+            {"kind": "message", "role": "user", "content": "Find a new role."},
+            {
+                "kind": "tool_call",
+                "tool_key": "browser.search_jobs",
+                "tool_call_id": "call_1",
+                "arguments": {"query": "python"},
+            },
+            {
+                "kind": "tool_result",
+                "tool_key": "browser.search_jobs",
+                "tool_call_id": "call_1",
+                "output": {"count": 2},
+            },
+            {"kind": "message", "role": "assistant", "content": "I found two roles."},
+            {
+                "kind": "tool_call",
+                "tool_key": "browser.open_job",
+                "tool_call_id": "call_2",
+                "arguments": {"job_id": "abc"},
+            },
+            {
+                "kind": "tool_result",
+                "tool_key": "browser.open_job",
+                "tool_call_id": "call_2",
+                "output": {"title": "Platform Engineer"},
+            },
+        ]
+
+    def test_remove_tool_result_entries_preserves_non_tool_result_order(self) -> None:
+        compacted = remove_tool_result_entries(self.context_window)
+
+        self.assertEqual([entry["kind"] for entry in compacted], ["parameter", "parameter", "message", "tool_call", "message", "tool_call"])
+        self.assertEqual(self.context_window[4]["kind"], "tool_result")
+
+    def test_remove_tool_entries_removes_calls_and_results(self) -> None:
+        compacted = remove_tool_entries(self.context_window)
+
+        self.assertEqual([entry["kind"] for entry in compacted], ["parameter", "parameter", "message", "message"])
+
+    def test_heavy_compact_context_keeps_only_leading_parameter_prefix(self) -> None:
+        compacted = heavy_compact_context(self.context_window)
+
+        self.assertEqual(compacted, self.context_window[:2])
+
+    def test_apply_log_compaction_appends_string_summary_after_parameters(self) -> None:
+        compacted = apply_log_compaction(self.context_window, "User asked for roles and two jobs were found.")
+
+        self.assertEqual(
+            compacted,
+            [
+                self.context_window[0],
+                self.context_window[1],
+                {
+                    "kind": "summary",
+                    "content": "User asked for roles and two jobs were found.",
+                },
+            ],
+        )
+
+    def test_apply_log_compaction_accepts_prebuilt_summary_entry(self) -> None:
+        summary = {"kind": "summary", "content": "Condensed run log.", "metadata": {"source": "summarizer"}}
+
+        compacted = apply_log_compaction(self.context_window, summary)
+
+        self.assertEqual(compacted[-1], summary)
+
+    def test_summarize_and_log_compact_uses_full_window_copy(self) -> None:
+        observed: list[list[dict[str, object]]] = []
+
+        def summarizer(context_window: list[dict[str, object]]) -> str:
+            observed.append(context_window)
+            context_window[0]["content"] = "mutated"
+            return "Summary from separate agent."
+
+        compacted = summarize_and_log_compact(self.context_window, summarizer)
+
+        self.assertEqual(observed[0][0]["content"], "mutated")
+        self.assertEqual(self.context_window[0]["content"], "Agent identity")
+        self.assertEqual(compacted[-1]["content"], "Summary from separate agent.")
+
+    def test_registry_executes_remove_tool_results_tool(self) -> None:
+        registry = create_builtin_registry()
+
+        result = registry.execute(REMOVE_TOOL_RESULTS, {"context_window": self.context_window})
+
+        self.assertEqual([entry["kind"] for entry in result.output["context_window"]], ["parameter", "parameter", "message", "tool_call", "message", "tool_call"])
+
+    def test_registry_executes_remove_tools_tool(self) -> None:
+        registry = create_builtin_registry()
+
+        result = registry.execute(REMOVE_TOOLS, {"context_window": self.context_window})
+
+        self.assertEqual([entry["kind"] for entry in result.output["context_window"]], ["parameter", "parameter", "message", "message"])
+
+    def test_registry_executes_heavy_compaction_tool(self) -> None:
+        registry = create_builtin_registry()
+
+        result = registry.execute(HEAVY_COMPACTION, {"context_window": self.context_window})
+
+        self.assertEqual(result.output["context_window"], self.context_window[:2])
+
+    def test_registry_executes_log_compaction_tool(self) -> None:
+        registry = create_builtin_registry()
+
+        result = registry.execute(
+            LOG_COMPACTION,
+            {
+                "context_window": self.context_window,
+                "summary": "Context stripped to parameter block and a run log.",
+            },
+        )
+
+        self.assertEqual(
+            result.output["context_window"],
+            [
+                self.context_window[0],
+                self.context_window[1],
+                {
+                    "kind": "summary",
+                    "content": "Context stripped to parameter block and a run log.",
+                },
+            ],
+        )
+
+    def test_custom_log_compaction_tool_can_inject_a_summarizer(self) -> None:
+        observed: list[list[dict[str, object]]] = []
+
+        def summarizer(context_window: list[dict[str, object]]) -> str:
+            observed.append(context_window)
+            return "Injected summary."
+
+        registry = ToolRegistry(create_context_compaction_tools(log_summarizer=summarizer))
+
+        result = registry.execute(LOG_COMPACTION, {"context_window": self.context_window})
+
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0][2]["content"], "Find a new role.")
+        self.assertEqual(
+            result.output["context_window"],
+            [
+                self.context_window[0],
+                self.context_window[1],
+                {
+                    "kind": "summary",
+                    "content": "Injected summary.",
+                },
+            ],
+        )
+
+    def test_invalid_context_entry_kind_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            heavy_compact_context([{"kind": "unknown", "content": "bad"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import unittest
 from copy import deepcopy
 
-from src.shared.tools import ADD_NUMBERS, ECHO_TEXT, RegisteredTool, ToolDefinition
+from src.shared.tools import (
+    ADD_NUMBERS,
+    ECHO_TEXT,
+    HEAVY_COMPACTION,
+    LOG_COMPACTION,
+    REMOVE_TOOL_RESULTS,
+    REMOVE_TOOLS,
+    RegisteredTool,
+    ToolDefinition,
+)
 from src.tools.registry import (
     DuplicateToolError,
     ToolRegistry,
@@ -23,7 +32,17 @@ class ToolRegistryTests(unittest.TestCase):
     def test_builtin_registry_keeps_stable_key_order(self) -> None:
         registry = create_builtin_registry()
 
-        self.assertEqual(registry.keys(), (ECHO_TEXT, ADD_NUMBERS))
+        self.assertEqual(
+            registry.keys(),
+            (
+                ECHO_TEXT,
+                ADD_NUMBERS,
+                REMOVE_TOOL_RESULTS,
+                REMOVE_TOOLS,
+                HEAVY_COMPACTION,
+                LOG_COMPACTION,
+            ),
+        )
 
     def test_definitions_expose_metadata_without_handlers(self) -> None:
         registry = create_builtin_registry()


### PR DESCRIPTION
## Summary
- add reusable context-window compaction helpers and registered tools for removing tool results, removing tool calls plus results, heavy compaction, and log compaction
- add a shared agent-context window model and wire `BaseAgent` so compaction tool outputs can rewrite in-memory context state
- add focused unit coverage for the new tool layer and the base-agent integration path

## Verification
- `python -m unittest discover -s tests -v`
- `python -m py_compile src\\shared\\agents.py src\\shared\\tools.py src\\tools\\context_compaction.py src\\tools\\builtin.py src\\tools\\__init__.py src\\agents\\base.py tests\\test_context_compaction_tools.py tests\\test_tools.py tests\\test_agents_base.py`