### PR TITLE
Add define_tool() factory and @tool decorator with tool_type forward compatibility

### DIFF
--- a/harnessiq/shared/tools.py
+++ b/harnessiq/shared/tools.py
@@ -117,15 +117,33 @@ CORESIGNAL_REQUEST = "coresignal.request"
 
 @dataclass(frozen=True, slots=True)
 class ToolDefinition:
-    """Provider-agnostic metadata for a callable tool."""
+    """Provider-agnostic metadata for a callable tool.
+
+    Attributes:
+        key: Unique tool identifier in ``namespace.name`` format.
+        name: Short human-readable name (snake_case).
+        description: What the tool does and when to use it.
+        input_schema: JSON Schema object describing accepted arguments.
+        tool_type: The execution type for this tool.  Currently only
+            ``"function"`` is supported.  Additional types
+            (``"computer_use"``, ``"code_interpreter"``, ``"multi_agent"``,
+            etc.) will be introduced in future SDK releases.
+    """
 
     key: str
     name: str
     description: str
     input_schema: JsonObject
+    tool_type: str = "function"
 
     def as_dict(self) -> JsonObject:
-        """Return the canonical metadata without executable runtime state."""
+        """Return the canonical metadata without executable runtime state.
+
+        ``tool_type`` is intentionally omitted — it is SDK metadata used to
+        identify the tool's execution model, not part of the model API payload.
+        Provider adapters serialise ``ToolDefinition`` to their own wire format
+        independently of this method.
+        """
         return {
             "key": self.key,
             "name": self.name,

--- a/harnessiq/toolset/__init__.py
+++ b/harnessiq/toolset/__init__.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 from harnessiq.shared.tools import RegisteredTool
 
 from .catalog import ToolEntry
+from .factory import define_tool, tool
 from .registry import ToolsetRegistry
 
 # Shared module-level registry instance — initialized lazily on first access.
@@ -167,8 +168,10 @@ def list_tools() -> list[ToolEntry]:
 __all__ = [
     "ToolEntry",
     "ToolsetRegistry",
+    "define_tool",
     "get_family",
     "get_tool",
     "get_tools",
     "list_tools",
+    "tool",
 ]

--- a/harnessiq/toolset/factory.py
+++ b/harnessiq/toolset/factory.py
@@ -1,0 +1,231 @@
+"""Custom tool creation helpers for Harnessiq.
+
+:func:`define_tool` and the :func:`tool` decorator let you create
+``RegisteredTool`` objects using the same ergonomic style as the built-in tool
+families — without manually constructing ``ToolDefinition`` and the raw
+JSON Schema wrapper.
+
+Example — factory function style::
+
+    from harnessiq.toolset import define_tool
+
+    def shout(args):
+        return args["text"].upper()
+
+    shout_tool = define_tool(
+        key="custom.shout",
+        description="Convert text to uppercase.",
+        parameters={"text": {"type": "string", "description": "The text to shout."}},
+        required=["text"],
+        handler=shout,
+    )
+
+Example — decorator style::
+
+    from harnessiq.toolset import tool
+
+    @tool(
+        key="custom.shout",
+        description="Convert text to uppercase.",
+        parameters={"text": {"type": "string", "description": "The text to shout."}},
+        required=["text"],
+    )
+    def shout(args):
+        return args["text"].upper()
+
+    # shout is now a RegisteredTool, not a plain function.
+
+Both return a ``RegisteredTool`` that can be passed directly to a
+``ToolRegistry`` or used alongside tools retrieved from the toolset catalog::
+
+    from harnessiq.toolset import get_family
+    from harnessiq.tools import ToolRegistry
+
+    registry = ToolRegistry([*get_family("reasoning"), shout_tool])
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from harnessiq.shared.tools import RegisteredTool, ToolDefinition, ToolHandler
+
+# ---------------------------------------------------------------------------
+# Supported tool types
+# ---------------------------------------------------------------------------
+# Only "function" is currently supported.  The set will grow in future SDK
+# releases to include computer_use, code_interpreter, multi_agent, and others.
+_SUPPORTED_TOOL_TYPES: frozenset[str] = frozenset({"function"})
+
+_PLANNED_TOOL_TYPES: frozenset[str] = frozenset(
+    {"computer_use", "code_interpreter", "multi_agent", "sandbox", "web_search"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def define_tool(
+    *,
+    key: str,
+    description: str,
+    parameters: dict[str, Any],
+    handler: ToolHandler,
+    name: str | None = None,
+    required: Sequence[str] | None = None,
+    additional_properties: bool = False,
+    tool_type: str = "function",
+) -> RegisteredTool:
+    """Create and return a :class:`~harnessiq.shared.tools.RegisteredTool`.
+
+    Args:
+        key: Unique tool identifier in ``namespace.name`` format, e.g.
+            ``"custom.shout"``.  Must not clash with any key already in
+            the registry you intend to add this tool to.
+        description: What the tool does and when an agent should use it.
+            Write this as if explaining the tool to the model — be specific.
+        parameters: The tool's input parameters as a flat dict of
+            ``{param_name: json_schema_property}``.  Each value should be a
+            dict with at minimum a ``"type"`` key and ideally a
+            ``"description"`` key, e.g.
+            ``{"text": {"type": "string", "description": "The input text."}}``.
+            This is wrapped into a full JSON Schema object automatically.
+        handler: A callable that accepts a ``ToolArguments`` dict and returns
+            any JSON-serialisable value.  The dict keys match the parameter
+            names declared in *parameters*.
+        name: Short snake_case name for the tool.  Defaults to the last
+            segment of *key* (e.g. ``"custom.shout"`` → ``"shout"``).
+        required: List of parameter names that are required.  Defaults to
+            ``[]`` (no required parameters).  Pass ``list(parameters)`` to
+            require all parameters.
+        additional_properties: Whether the tool's input schema allows
+            extra keys beyond those declared in *parameters*.  Defaults to
+            ``False`` (strict schema).
+        tool_type: The execution type for this tool.  Currently only
+            ``"function"`` is supported.  Passing any other value raises
+            ``ValueError`` with a message explaining future support.
+
+    Returns:
+        A :class:`~harnessiq.shared.tools.RegisteredTool` ready to be added
+        to a :class:`~harnessiq.tools.ToolRegistry`.
+
+    Raises:
+        ValueError: If *tool_type* is not a currently supported type.
+
+    Example::
+
+        my_tool = define_tool(
+            key="custom.reverse",
+            description="Reverse a string.",
+            parameters={"text": {"type": "string", "description": "String to reverse."}},
+            required=["text"],
+            handler=lambda args: args["text"][::-1],
+        )
+    """
+    _validate_tool_type(tool_type)
+    resolved_name = name if name is not None else _name_from_key(key)
+    input_schema = _build_input_schema(
+        parameters=parameters,
+        required=list(required) if required is not None else [],
+        additional_properties=additional_properties,
+    )
+    definition = ToolDefinition(
+        key=key,
+        name=resolved_name,
+        description=description,
+        input_schema=input_schema,
+        tool_type=tool_type,
+    )
+    return RegisteredTool(definition=definition, handler=handler)
+
+
+def tool(
+    *,
+    key: str,
+    description: str,
+    parameters: dict[str, Any],
+    name: str | None = None,
+    required: Sequence[str] | None = None,
+    additional_properties: bool = False,
+    tool_type: str = "function",
+) -> Callable[[ToolHandler], RegisteredTool]:
+    """Decorator that converts a handler function into a :class:`~harnessiq.shared.tools.RegisteredTool`.
+
+    All keyword arguments match :func:`define_tool` exactly.  The decorated
+    function is replaced by the resulting ``RegisteredTool``.
+
+    Example::
+
+        @tool(
+            key="custom.shout",
+            description="Convert text to uppercase.",
+            parameters={"text": {"type": "string", "description": "The text."}},
+            required=["text"],
+        )
+        def shout(args):
+            return args["text"].upper()
+
+        # shout is now a RegisteredTool.
+        result = shout.execute({"text": "hello"})
+    """
+    def decorator(handler: ToolHandler) -> RegisteredTool:
+        return define_tool(
+            key=key,
+            description=description,
+            parameters=parameters,
+            handler=handler,
+            name=name,
+            required=required,
+            additional_properties=additional_properties,
+            tool_type=tool_type,
+        )
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_tool_type(tool_type: str) -> None:
+    if tool_type in _SUPPORTED_TOOL_TYPES:
+        return
+    if tool_type in _PLANNED_TOOL_TYPES:
+        raise ValueError(
+            f"Tool type '{tool_type}' is planned for a future SDK release and is not "
+            f"yet supported.  Currently supported types: {sorted(_SUPPORTED_TOOL_TYPES)}."
+        )
+    raise ValueError(
+        f"Unknown tool type '{tool_type}'.  Currently supported: "
+        f"{sorted(_SUPPORTED_TOOL_TYPES)}.  Additional types "
+        f"({', '.join(sorted(_PLANNED_TOOL_TYPES))}) are planned for future releases."
+    )
+
+
+def _name_from_key(key: str) -> str:
+    """Return the last dot-segment of a key as the tool name."""
+    return key.rsplit(".", 1)[-1]
+
+
+def _build_input_schema(
+    parameters: dict[str, Any],
+    required: list[str],
+    additional_properties: bool,
+) -> dict[str, Any]:
+    """Build a full JSON Schema object from the user-supplied parameters dict."""
+    return {
+        "type": "object",
+        "properties": parameters,
+        "required": required,
+        "additionalProperties": additional_properties,
+    }
+
+
+__all__ = [
+    "define_tool",
+    "tool",
+]

--- a/tests/test_toolset_factory.py
+++ b/tests/test_toolset_factory.py
@@ -1,0 +1,441 @@
+"""Tests for define_tool(), @tool decorator, and ToolDefinition.tool_type (Ticket 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from harnessiq.shared.tools import RegisteredTool, ToolDefinition
+from harnessiq.toolset import define_tool, tool
+from harnessiq.tools import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# define_tool — basic construction
+# ---------------------------------------------------------------------------
+
+
+class TestDefineTool:
+    def test_returns_registered_tool(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout text.",
+            parameters={"text": {"type": "string"}},
+            handler=lambda args: args["text"].upper(),
+        )
+        assert isinstance(t, RegisteredTool)
+
+    def test_key_is_set(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout text.",
+            parameters={"text": {"type": "string"}},
+            handler=lambda args: args["text"].upper(),
+        )
+        assert t.key == "custom.shout"
+
+    def test_description_is_set(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout text.",
+            parameters={"text": {"type": "string"}},
+            handler=lambda args: args["text"].upper(),
+        )
+        assert t.definition.description == "Shout text."
+
+    def test_name_defaults_to_key_suffix(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout.",
+            parameters={},
+            handler=lambda args: None,
+        )
+        assert t.definition.name == "shout"
+
+    def test_name_defaults_to_key_suffix_multi_segment(self):
+        t = define_tool(
+            key="ns.sub.my_tool",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+        )
+        assert t.definition.name == "my_tool"
+
+    def test_explicit_name_overrides_default(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout.",
+            parameters={},
+            handler=lambda args: None,
+            name="MY_EXPLICIT_NAME",
+        )
+        assert t.definition.name == "MY_EXPLICIT_NAME"
+
+    def test_tool_type_defaults_to_function(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+        )
+        assert t.definition.tool_type == "function"
+
+    def test_tool_type_function_explicit(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+            tool_type="function",
+        )
+        assert t.definition.tool_type == "function"
+
+    def test_unsupported_tool_type_raises(self):
+        with pytest.raises(ValueError, match="computer_use"):
+            define_tool(
+                key="custom.x",
+                description="Test.",
+                parameters={},
+                handler=lambda args: None,
+                tool_type="computer_use",
+            )
+
+    def test_unsupported_tool_type_error_mentions_future_support(self):
+        with pytest.raises(ValueError, match="future"):
+            define_tool(
+                key="custom.x",
+                description="Test.",
+                parameters={},
+                handler=lambda args: None,
+                tool_type="computer_use",
+            )
+
+    def test_completely_unknown_tool_type_raises(self):
+        with pytest.raises(ValueError, match="unknown_type"):
+            define_tool(
+                key="custom.x",
+                description="Test.",
+                parameters={},
+                handler=lambda args: None,
+                tool_type="unknown_type",
+            )
+
+
+# ---------------------------------------------------------------------------
+# define_tool — input schema construction
+# ---------------------------------------------------------------------------
+
+
+class TestDefineToolSchema:
+    def test_schema_type_is_object(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={"v": {"type": "string"}},
+            handler=lambda args: None,
+        )
+        assert t.definition.input_schema["type"] == "object"
+
+    def test_parameters_become_properties(self):
+        params = {"text": {"type": "string", "description": "Input."}}
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters=params,
+            handler=lambda args: None,
+        )
+        assert t.definition.input_schema["properties"] == params
+
+    def test_required_defaults_to_empty(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={"v": {"type": "string"}},
+            handler=lambda args: None,
+        )
+        assert t.definition.input_schema["required"] == []
+
+    def test_required_explicit(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={"v": {"type": "string"}},
+            required=["v"],
+            handler=lambda args: None,
+        )
+        assert t.definition.input_schema["required"] == ["v"]
+
+    def test_additional_properties_defaults_false(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+        )
+        assert t.definition.input_schema["additionalProperties"] is False
+
+    def test_additional_properties_true(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+            additional_properties=True,
+        )
+        assert t.definition.input_schema["additionalProperties"] is True
+
+    def test_empty_parameters_produces_valid_schema(self):
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+            handler=lambda args: None,
+        )
+        schema = t.definition.input_schema
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert schema["required"] == []
+
+    def test_multiple_parameters(self):
+        params = {
+            "a": {"type": "string"},
+            "b": {"type": "integer"},
+        }
+        t = define_tool(
+            key="custom.x",
+            description="Test.",
+            parameters=params,
+            required=["a"],
+            handler=lambda args: None,
+        )
+        assert set(t.definition.input_schema["properties"]) == {"a", "b"}
+        assert t.definition.input_schema["required"] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# define_tool — handler execution
+# ---------------------------------------------------------------------------
+
+
+class TestDefineToolExecution:
+    def test_handler_is_called_with_args(self):
+        calls = []
+        def h(args):
+            calls.append(args)
+            return "ok"
+
+        t = define_tool(
+            key="custom.record",
+            description="Record args.",
+            parameters={"x": {"type": "string"}},
+            handler=h,
+        )
+        t.execute({"x": "hello"})
+        assert calls == [{"x": "hello"}]
+
+    def test_handler_return_value_is_output(self):
+        t = define_tool(
+            key="custom.shout",
+            description="Shout.",
+            parameters={"text": {"type": "string"}},
+            required=["text"],
+            handler=lambda args: args["text"].upper(),
+        )
+        result = t.execute({"text": "hello"})
+        assert result.output == "HELLO"
+        assert result.tool_key == "custom.shout"
+
+    def test_handler_can_return_dict(self):
+        t = define_tool(
+            key="custom.wrap",
+            description="Wrap.",
+            parameters={"v": {"type": "integer"}},
+            handler=lambda args: {"value": args["v"] * 2},
+        )
+        result = t.execute({"v": 5})
+        assert result.output == {"value": 10}
+
+
+# ---------------------------------------------------------------------------
+# @tool decorator
+# ---------------------------------------------------------------------------
+
+
+class TestToolDecorator:
+    def test_decorator_produces_registered_tool(self):
+        @tool(
+            key="custom.shout",
+            description="Shout text.",
+            parameters={"text": {"type": "string"}},
+            required=["text"],
+        )
+        def shout(args):
+            return args["text"].upper()
+
+        assert isinstance(shout, RegisteredTool)
+
+    def test_decorator_key_is_set(self):
+        @tool(
+            key="custom.shout",
+            description="Shout.",
+            parameters={"text": {"type": "string"}},
+        )
+        def shout(args):
+            return args["text"].upper()
+
+        assert shout.key == "custom.shout"
+
+    def test_decorator_name_defaults_to_key_suffix(self):
+        @tool(
+            key="custom.my_func",
+            description="Test.",
+            parameters={},
+        )
+        def my_func(args):
+            return None
+
+        assert my_func.definition.name == "my_func"
+
+    def test_decorator_handler_executes(self):
+        @tool(
+            key="custom.double",
+            description="Double a number.",
+            parameters={"n": {"type": "integer"}},
+            required=["n"],
+        )
+        def double(args):
+            return args["n"] * 2
+
+        result = double.execute({"n": 7})
+        assert result.output == 14
+
+    def test_decorator_schema_has_required(self):
+        @tool(
+            key="custom.x",
+            description="Test.",
+            parameters={"a": {"type": "string"}},
+            required=["a"],
+        )
+        def fn(args):
+            return None
+
+        assert fn.definition.input_schema["required"] == ["a"]
+
+    def test_decorator_tool_type_default(self):
+        @tool(
+            key="custom.x",
+            description="Test.",
+            parameters={},
+        )
+        def fn(args):
+            return None
+
+        assert fn.definition.tool_type == "function"
+
+    def test_decorator_unsupported_tool_type_raises(self):
+        with pytest.raises(ValueError):
+            @tool(
+                key="custom.x",
+                description="Test.",
+                parameters={},
+                tool_type="code_interpreter",
+            )
+            def fn(args):
+                return None
+
+
+# ---------------------------------------------------------------------------
+# Integration — custom tool in ToolRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestCustomToolInRegistry:
+    def test_can_register_custom_tool(self):
+        my_tool = define_tool(
+            key="custom.upper",
+            description="Uppercase.",
+            parameters={"text": {"type": "string"}},
+            required=["text"],
+            handler=lambda args: args["text"].upper(),
+        )
+        registry = ToolRegistry([my_tool])
+        assert "custom.upper" in registry
+
+    def test_can_execute_custom_tool_via_registry(self):
+        my_tool = define_tool(
+            key="custom.upper",
+            description="Uppercase.",
+            parameters={"text": {"type": "string"}},
+            required=["text"],
+            handler=lambda args: args["text"].upper(),
+        )
+        registry = ToolRegistry([my_tool])
+        result = registry.execute("custom.upper", {"text": "hello"})
+        assert result.output == "HELLO"
+
+    def test_custom_tool_plus_builtin_tools(self):
+        from harnessiq.toolset import get_family
+        my_tool = define_tool(
+            key="custom.shout",
+            description="Shout.",
+            parameters={"text": {"type": "string"}},
+            handler=lambda args: args["text"].upper(),
+        )
+        registry = ToolRegistry([*get_family("reason"), my_tool])
+        assert "reason.brainstorm" in registry
+        assert "custom.shout" in registry
+
+    def test_registry_validates_required_args(self):
+        from harnessiq.tools.registry import ToolValidationError
+        my_tool = define_tool(
+            key="custom.strict",
+            description="Strict tool.",
+            parameters={"x": {"type": "string"}},
+            required=["x"],
+            handler=lambda args: args["x"],
+        )
+        registry = ToolRegistry([my_tool])
+        with pytest.raises(ToolValidationError, match="missing required"):
+            registry.execute("custom.strict", {})
+
+
+# ---------------------------------------------------------------------------
+# ToolDefinition.tool_type — backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinitionToolType:
+    def test_existing_definitions_default_to_function(self):
+        defn = ToolDefinition(
+            key="test.x",
+            name="x",
+            description="Test.",
+            input_schema={"type": "object", "properties": {}},
+        )
+        assert defn.tool_type == "function"
+
+    def test_as_dict_does_not_include_tool_type(self):
+        # tool_type is SDK metadata, not model API payload — excluded from as_dict()
+        defn = ToolDefinition(
+            key="test.x",
+            name="x",
+            description="Test.",
+            input_schema={"type": "object", "properties": {}},
+        )
+        d = defn.as_dict()
+        assert "tool_type" not in d
+
+    def test_as_dict_has_standard_keys(self):
+        defn = ToolDefinition(
+            key="test.x",
+            name="x",
+            description="Test.",
+            input_schema={"type": "object", "properties": {}},
+        )
+        assert set(defn.as_dict().keys()) == {"key", "name", "description", "input_schema"}
+
+    def test_all_existing_builtin_tools_have_function_type(self):
+        from harnessiq.tools.builtin import BUILTIN_TOOLS
+        for t in BUILTIN_TOOLS:
+            assert t.definition.tool_type == "function", (
+                f"Tool {t.key!r} has unexpected tool_type {t.definition.tool_type!r}"
+            )


### PR DESCRIPTION
Adds tool_type: str = 'function' to ToolDefinition, define_tool() factory, and @tool decorator for ergonomic custom tool creation. 37 tests added. Closes #109.