### PR TITLE
feat: ExaOutreach shared types, memory store, and tool key constants

### DIFF
--- a/harnessiq/shared/exa_outreach.py
+++ b/harnessiq/shared/exa_outreach.py
@@ -1,0 +1,474 @@
+"""Shared data models, memory store, and storage backend for ExaOutreachAgent."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# File name constants
+# ---------------------------------------------------------------------------
+
+QUERY_CONFIG_FILENAME = "query_config.json"
+AGENT_IDENTITY_FILENAME = "agent_identity.txt"
+ADDITIONAL_PROMPT_FILENAME = "additional_prompt.txt"
+RUNS_DIRNAME = "runs"
+
+DEFAULT_AGENT_IDENTITY = (
+    "A disciplined outreach specialist who finds relevant prospects via Exa neural "
+    "search, selects the most appropriate email template for each lead, personalizes "
+    "the message with specific details from their profile, and sends concise, "
+    "value-first cold emails."
+)
+
+DEFAULT_SEARCH_QUERY = "(search query not configured)"
+
+# ---------------------------------------------------------------------------
+# EmailTemplate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EmailTemplate:
+    """A deployable cold email template with metadata for agent selection.
+
+    Attributes:
+        id: Unique identifier used to reference this template.
+        title: Human-readable template name.
+        subject: Email subject line.
+        description: When and for whom to use this template.
+        actual_email: Full email body — use ``{{name}}``, ``{{company}}`` etc. for personalization.
+        links: Optional URLs to include or reference in the email.
+        pain_points: Target pain points this template addresses.
+        icp: Ideal customer profile this template is written for.
+        extra: Open-ended additional metadata.
+    """
+
+    id: str
+    title: str
+    subject: str
+    description: str
+    actual_email: str
+    links: tuple[str, ...] = ()
+    pain_points: tuple[str, ...] = ()
+    icp: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("EmailTemplate id must not be blank.")
+        if not self.title.strip():
+            raise ValueError("EmailTemplate title must not be blank.")
+        if not self.subject.strip():
+            raise ValueError("EmailTemplate subject must not be blank.")
+        if not self.actual_email.strip():
+            raise ValueError("EmailTemplate actual_email must not be blank.")
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "subject": self.subject,
+            "description": self.description,
+            "actual_email": self.actual_email,
+            "links": list(self.links),
+            "pain_points": list(self.pain_points),
+            "icp": self.icp,
+            "extra": dict(self.extra),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmailTemplate":
+        """Construct an ``EmailTemplate`` from a raw dict (e.g. parsed from JSON)."""
+        return cls(
+            id=str(data["id"]),
+            title=str(data["title"]),
+            subject=str(data["subject"]),
+            description=str(data.get("description", "")),
+            actual_email=str(data["actual_email"]),
+            links=tuple(str(v) for v in data.get("links", [])),
+            pain_points=tuple(str(v) for v in data.get("pain_points", [])),
+            icp=str(data.get("icp", "")),
+            extra=dict(data.get("extra", {})),
+        )
+
+
+# ---------------------------------------------------------------------------
+# LeadRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class LeadRecord:
+    """A prospect discovered via Exa search."""
+
+    url: str
+    name: str
+    found_at: str
+    email_address: str | None = None
+    notes: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "url": self.url,
+            "name": self.name,
+            "found_at": self.found_at,
+            "email_address": self.email_address,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LeadRecord":
+        return cls(
+            url=str(data["url"]),
+            name=str(data["name"]),
+            found_at=str(data["found_at"]),
+            email_address=str(data["email_address"]) if data.get("email_address") else None,
+            notes=str(data["notes"]) if data.get("notes") else None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# EmailSentRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class EmailSentRecord:
+    """A record of one email sent to a prospect."""
+
+    to_email: str
+    to_name: str
+    subject: str
+    template_id: str
+    sent_at: str
+    notes: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "to_email": self.to_email,
+            "to_name": self.to_name,
+            "subject": self.subject,
+            "template_id": self.template_id,
+            "sent_at": self.sent_at,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmailSentRecord":
+        return cls(
+            to_email=str(data["to_email"]),
+            to_name=str(data["to_name"]),
+            subject=str(data["subject"]),
+            template_id=str(data["template_id"]),
+            sent_at=str(data["sent_at"]),
+            notes=str(data["notes"]) if data.get("notes") else None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# OutreachRunLog
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class OutreachRunLog:
+    """Captures all activity from a single ExaOutreachAgent run."""
+
+    run_id: str
+    started_at: str
+    query: str
+    leads_found: list[LeadRecord] = field(default_factory=list)
+    emails_sent: list[EmailSentRecord] = field(default_factory=list)
+    completed_at: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "query": self.query,
+            "leads_found": [r.as_dict() for r in self.leads_found],
+            "emails_sent": [r.as_dict() for r in self.emails_sent],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "OutreachRunLog":
+        return cls(
+            run_id=str(data["run_id"]),
+            started_at=str(data["started_at"]),
+            query=str(data["query"]),
+            leads_found=[LeadRecord.from_dict(r) for r in data.get("leads_found", [])],
+            emails_sent=[EmailSentRecord.from_dict(r) for r in data.get("emails_sent", [])],
+            completed_at=str(data["completed_at"]) if data.get("completed_at") else None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# StorageBackend protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Pluggable persistence layer for ExaOutreachAgent run data.
+
+    The default implementation is :class:`FileSystemStorageBackend`.
+    Custom implementations can route to any backend (database, spreadsheet,
+    CRM, etc.) by implementing this protocol.
+    """
+
+    def start_run(self, run_id: str, query: str) -> None:
+        """Initialise storage for a new run before the agent loop starts."""
+        ...
+
+    def finish_run(self, run_id: str, completed_at: str) -> None:
+        """Mark a run as complete after the agent loop exits."""
+        ...
+
+    def log_lead(self, run_id: str, lead: LeadRecord) -> None:
+        """Persist a newly discovered lead.  Called deterministically inside the tool handler."""
+        ...
+
+    def log_email_sent(self, run_id: str, record: EmailSentRecord) -> None:
+        """Persist a sent email record.  Called deterministically inside the tool handler."""
+        ...
+
+    def is_contacted(self, url: str) -> bool:
+        """Return True if the Exa profile URL has appeared in any prior run."""
+        ...
+
+    def current_run_id(self) -> str | None:
+        """Return the active run ID, or None if no run has been started."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FileSystemStorageBackend
+# ---------------------------------------------------------------------------
+
+
+class FileSystemStorageBackend:
+    """Default :class:`StorageBackend` that writes ``run_N.json`` files to disk.
+
+    Each run gets its own file under ``memory_path/runs/run_N.json``.
+    The run number N is the next integer after the highest existing run file.
+    ``is_contacted`` scans all existing run files for a matching URL.
+    """
+
+    def __init__(self, memory_path: Path) -> None:
+        self._memory_path = Path(memory_path)
+        self._runs_dir = self._memory_path / RUNS_DIRNAME
+        self._current_run_id: str | None = None
+        self._current_run_path: Path | None = None
+
+    # ------------------------------------------------------------------
+    # StorageBackend implementation
+    # ------------------------------------------------------------------
+
+    def start_run(self, run_id: str, query: str) -> None:
+        self._runs_dir.mkdir(parents=True, exist_ok=True)
+        self._current_run_id = run_id
+        run_log = OutreachRunLog(
+            run_id=run_id,
+            started_at=_utcnow(),
+            query=query,
+        )
+        path = self._run_path(run_id)
+        self._current_run_path = path
+        _write_json(path, run_log.as_dict())
+
+    def finish_run(self, run_id: str, completed_at: str) -> None:
+        path = self._run_path(run_id)
+        run_log = self._read_run_log(path)
+        run_log.completed_at = completed_at
+        _write_json(path, run_log.as_dict())
+
+    def log_lead(self, run_id: str, lead: LeadRecord) -> None:
+        path = self._run_path(run_id)
+        run_log = self._read_run_log(path)
+        run_log.leads_found.append(lead)
+        _write_json(path, run_log.as_dict())
+
+    def log_email_sent(self, run_id: str, record: EmailSentRecord) -> None:
+        path = self._run_path(run_id)
+        run_log = self._read_run_log(path)
+        run_log.emails_sent.append(record)
+        _write_json(path, run_log.as_dict())
+
+    def is_contacted(self, url: str) -> bool:
+        if not self._runs_dir.exists():
+            return False
+        for run_path in self._list_run_paths():
+            try:
+                run_log = self._read_run_log(run_path)
+            except (json.JSONDecodeError, KeyError, ValueError):
+                continue
+            for lead in run_log.leads_found:
+                if lead.url == url:
+                    return True
+        return False
+
+    def current_run_id(self) -> str | None:
+        return self._current_run_id
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_path(self, run_id: str) -> Path:
+        return self._runs_dir / f"{run_id}.json"
+
+    def _read_run_log(self, path: Path) -> OutreachRunLog:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return OutreachRunLog.from_dict(data)
+
+    def _list_run_paths(self) -> list[Path]:
+        """Return run JSON files sorted by run number ascending."""
+        paths = list(self._runs_dir.glob("run_*.json"))
+        return sorted(paths, key=_run_file_sort_key)
+
+
+# ---------------------------------------------------------------------------
+# ExaOutreachMemoryStore
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ExaOutreachMemoryStore:
+    """Manage the durable state files used by the ExaOutreach harness."""
+
+    memory_path: Path
+
+    def __post_init__(self) -> None:
+        self.memory_path = Path(self.memory_path)
+
+    @property
+    def query_config_path(self) -> Path:
+        return self.memory_path / QUERY_CONFIG_FILENAME
+
+    @property
+    def agent_identity_path(self) -> Path:
+        return self.memory_path / AGENT_IDENTITY_FILENAME
+
+    @property
+    def additional_prompt_path(self) -> Path:
+        return self.memory_path / ADDITIONAL_PROMPT_FILENAME
+
+    @property
+    def runs_dir(self) -> Path:
+        return self.memory_path / RUNS_DIRNAME
+
+    def prepare(self) -> None:
+        """Create the memory directory structure and initialise default files."""
+        self.memory_path.mkdir(parents=True, exist_ok=True)
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+        _ensure_json_file(self.query_config_path, {})
+        _ensure_text_file(self.agent_identity_path, DEFAULT_AGENT_IDENTITY)
+        _ensure_text_file(self.additional_prompt_path, "")
+
+    def next_run_id(self) -> str:
+        """Return the next sequential run ID (e.g. ``run_1``, ``run_2``, ...)."""
+        existing = self.list_run_files()
+        return f"run_{len(existing) + 1}"
+
+    def list_run_files(self) -> list[Path]:
+        """Return run JSON files sorted by run number ascending."""
+        if not self.runs_dir.exists():
+            return []
+        paths = list(self.runs_dir.glob("run_*.json"))
+        return sorted(paths, key=_run_file_sort_key)
+
+    def read_run(self, run_id: str) -> OutreachRunLog:
+        """Read and return a run log by run ID."""
+        path = self.runs_dir / f"{run_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"Run file for '{run_id}' not found at '{path}'.")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return OutreachRunLog.from_dict(data)
+
+    def read_query_config(self) -> dict[str, Any]:
+        return _read_json_file(self.query_config_path, expected_type=dict)
+
+    def write_query_config(self, config: dict[str, Any]) -> None:
+        _write_json(self.query_config_path, config)
+
+    def read_agent_identity(self) -> str:
+        return self.agent_identity_path.read_text(encoding="utf-8").strip()
+
+    def write_agent_identity(self, text: str) -> None:
+        _write_text(self.agent_identity_path, text)
+
+    def read_additional_prompt(self) -> str:
+        return self.additional_prompt_path.read_text(encoding="utf-8").strip()
+
+    def write_additional_prompt(self, text: str) -> None:
+        _write_text(self.additional_prompt_path, text)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    rendered = text if not text or text.endswith("\n") else f"{text}\n"
+    path.write_text(rendered, encoding="utf-8")
+
+
+def _ensure_json_file(path: Path, default_payload: Any) -> None:
+    if not path.exists():
+        _write_json(path, default_payload)
+
+
+def _ensure_text_file(path: Path, default_content: str) -> None:
+    if not path.exists():
+        path.write_text(default_content, encoding="utf-8")
+
+
+def _read_json_file(path: Path, *, expected_type: type) -> Any:
+    if not path.exists():
+        return expected_type()
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return expected_type()
+    payload = json.loads(raw)
+    if not isinstance(payload, expected_type):
+        raise ValueError(f"Expected JSON {expected_type.__name__} in '{path.name}'.")
+    return payload
+
+
+def _run_file_sort_key(path: Path) -> int:
+    """Extract the run number from ``run_N.json`` for deterministic sorting."""
+    match = re.search(r"run_(\d+)\.json$", path.name)
+    return int(match.group(1)) if match else 0
+
+
+__all__ = [
+    "ADDITIONAL_PROMPT_FILENAME",
+    "AGENT_IDENTITY_FILENAME",
+    "DEFAULT_AGENT_IDENTITY",
+    "DEFAULT_SEARCH_QUERY",
+    "EmailSentRecord",
+    "EmailTemplate",
+    "ExaOutreachMemoryStore",
+    "FileSystemStorageBackend",
+    "LeadRecord",
+    "OutreachRunLog",
+    "QUERY_CONFIG_FILENAME",
+    "RUNS_DIRNAME",
+    "StorageBackend",
+]

--- a/harnessiq/shared/tools.py
+++ b/harnessiq/shared/tools.py
@@ -98,6 +98,13 @@ REASONING_TREND_EXTRAPOLATION = "reasoning.trend_extrapolation"
 REASONING_VARIABLE_ISOLATION = "reasoning.variable_isolation"
 REASONING_WORST_IDEA_GENERATION = "reasoning.worst_idea_generation"
 
+# ExaOutreach agent internal tool key constants
+EXA_OUTREACH_LIST_TEMPLATES = "exa_outreach.list_templates"
+EXA_OUTREACH_GET_TEMPLATE = "exa_outreach.get_template"
+EXA_OUTREACH_CHECK_CONTACTED = "exa_outreach.check_contacted"
+EXA_OUTREACH_LOG_LEAD = "exa_outreach.log_lead"
+EXA_OUTREACH_LOG_EMAIL_SENT = "exa_outreach.log_email_sent"
+
 # Provider tool key constants
 ARCADS_REQUEST = "arcads.request"
 CREATIFY_REQUEST = "creatify.request"
@@ -180,6 +187,11 @@ __all__ = [
     "CORESIGNAL_REQUEST",
     "CREATIFY_REQUEST",
     "ECHO_TEXT",
+    "EXA_OUTREACH_CHECK_CONTACTED",
+    "EXA_OUTREACH_GET_TEMPLATE",
+    "EXA_OUTREACH_LIST_TEMPLATES",
+    "EXA_OUTREACH_LOG_EMAIL_SENT",
+    "EXA_OUTREACH_LOG_LEAD",
     "EXA_REQUEST",
     "FILESYSTEM_APPEND_TEXT_FILE",
     "FILESYSTEM_COPY_PATH",

--- a/tests/test_exa_outreach_shared.py
+++ b/tests/test_exa_outreach_shared.py
@@ -1,0 +1,392 @@
+"""Tests for ExaOutreach shared types, memory store, and storage backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harnessiq.shared.exa_outreach import (
+    DEFAULT_AGENT_IDENTITY,
+    EmailSentRecord,
+    EmailTemplate,
+    ExaOutreachMemoryStore,
+    FileSystemStorageBackend,
+    LeadRecord,
+    OutreachRunLog,
+    StorageBackend,
+)
+from harnessiq.shared.tools import (
+    EXA_OUTREACH_CHECK_CONTACTED,
+    EXA_OUTREACH_GET_TEMPLATE,
+    EXA_OUTREACH_LIST_TEMPLATES,
+    EXA_OUTREACH_LOG_EMAIL_SENT,
+    EXA_OUTREACH_LOG_LEAD,
+)
+
+
+# ---------------------------------------------------------------------------
+# EmailTemplate
+# ---------------------------------------------------------------------------
+
+
+class TestEmailTemplate:
+    def test_minimal_construction(self):
+        t = EmailTemplate(
+            id="t1",
+            title="Test",
+            subject="Hello",
+            description="A test template",
+            actual_email="Hi there",
+        )
+        assert t.id == "t1"
+        assert t.links == ()
+        assert t.pain_points == ()
+        assert t.icp == ""
+        assert t.extra == {}
+
+    def test_full_round_trip(self):
+        original = EmailTemplate(
+            id="cold-intro",
+            title="Cold Intro",
+            subject="Quick intro",
+            description="Short cold intro",
+            actual_email="Hi {{name}}, I wanted to reach out...",
+            links=("https://example.com",),
+            pain_points=("slow hiring",),
+            icp="Series B SaaS",
+            extra={"tone": "casual"},
+        )
+        d = original.as_dict()
+        restored = EmailTemplate.from_dict(d)
+        assert restored.id == original.id
+        assert restored.title == original.title
+        assert restored.subject == original.subject
+        assert restored.actual_email == original.actual_email
+        assert restored.links == original.links
+        assert restored.pain_points == original.pain_points
+        assert restored.icp == original.icp
+        assert restored.extra == original.extra
+
+    def test_from_dict_minimal(self):
+        d = {"id": "x", "title": "T", "subject": "S", "actual_email": "body"}
+        t = EmailTemplate.from_dict(d)
+        assert t.id == "x"
+        assert t.description == ""
+
+    def test_blank_id_raises(self):
+        with pytest.raises(ValueError, match="id must not be blank"):
+            EmailTemplate(id="  ", title="T", subject="S", description="D", actual_email="B")
+
+    def test_blank_subject_raises(self):
+        with pytest.raises(ValueError, match="subject must not be blank"):
+            EmailTemplate(id="t", title="T", subject="  ", description="D", actual_email="B")
+
+    def test_blank_actual_email_raises(self):
+        with pytest.raises(ValueError, match="actual_email must not be blank"):
+            EmailTemplate(id="t", title="T", subject="S", description="D", actual_email="  ")
+
+
+# ---------------------------------------------------------------------------
+# LeadRecord
+# ---------------------------------------------------------------------------
+
+
+class TestLeadRecord:
+    def test_round_trip(self):
+        lead = LeadRecord(
+            url="https://linkedin.com/in/janedoe",
+            name="Jane Doe",
+            found_at="2025-03-16T12:00:00Z",
+            email_address="jane@example.com",
+            notes="VP Engineering at Acme",
+        )
+        d = lead.as_dict()
+        restored = LeadRecord.from_dict(d)
+        assert restored.url == lead.url
+        assert restored.name == lead.name
+        assert restored.email_address == lead.email_address
+        assert restored.notes == lead.notes
+
+    def test_optional_fields_none(self):
+        lead = LeadRecord(url="https://example.com", name="Alice", found_at="2025-01-01T00:00:00Z")
+        assert lead.email_address is None
+        assert lead.notes is None
+        d = lead.as_dict()
+        restored = LeadRecord.from_dict(d)
+        assert restored.email_address is None
+
+
+# ---------------------------------------------------------------------------
+# EmailSentRecord
+# ---------------------------------------------------------------------------
+
+
+class TestEmailSentRecord:
+    def test_round_trip(self):
+        record = EmailSentRecord(
+            to_email="jane@example.com",
+            to_name="Jane Doe",
+            subject="Quick intro",
+            template_id="cold-intro",
+            sent_at="2025-03-16T12:05:00Z",
+            notes="Personalized with conference reference",
+        )
+        d = record.as_dict()
+        restored = EmailSentRecord.from_dict(d)
+        assert restored.to_email == record.to_email
+        assert restored.template_id == record.template_id
+        assert restored.notes == record.notes
+
+    def test_notes_optional(self):
+        record = EmailSentRecord(
+            to_email="a@b.com",
+            to_name="A B",
+            subject="S",
+            template_id="t1",
+            sent_at="2025-01-01T00:00:00Z",
+        )
+        assert record.notes is None
+
+
+# ---------------------------------------------------------------------------
+# OutreachRunLog
+# ---------------------------------------------------------------------------
+
+
+class TestOutreachRunLog:
+    def test_round_trip(self):
+        log = OutreachRunLog(
+            run_id="run_1",
+            started_at="2025-03-16T12:00:00Z",
+            query="VPs at SaaS startups",
+        )
+        log.leads_found.append(
+            LeadRecord(url="https://example.com/1", name="Alice", found_at="2025-03-16T12:01:00Z")
+        )
+        log.emails_sent.append(
+            EmailSentRecord(
+                to_email="alice@example.com",
+                to_name="Alice",
+                subject="Hi",
+                template_id="t1",
+                sent_at="2025-03-16T12:02:00Z",
+            )
+        )
+        d = log.as_dict()
+        restored = OutreachRunLog.from_dict(d)
+        assert restored.run_id == "run_1"
+        assert len(restored.leads_found) == 1
+        assert len(restored.emails_sent) == 1
+        assert restored.completed_at is None
+
+    def test_completed_at_round_trip(self):
+        log = OutreachRunLog(
+            run_id="run_2",
+            started_at="2025-01-01T00:00:00Z",
+            query="test",
+            completed_at="2025-01-01T01:00:00Z",
+        )
+        restored = OutreachRunLog.from_dict(log.as_dict())
+        assert restored.completed_at == "2025-01-01T01:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# FileSystemStorageBackend
+# ---------------------------------------------------------------------------
+
+
+class TestFileSystemStorageBackend:
+    def test_start_run_creates_file(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "VPs in NYC")
+        run_path = tmp_path / "runs" / "run_1.json"
+        assert run_path.exists()
+        data = json.loads(run_path.read_text())
+        assert data["run_id"] == "run_1"
+        assert data["query"] == "VPs in NYC"
+        assert data["leads_found"] == []
+        assert data["emails_sent"] == []
+
+    def test_log_lead_appends_to_run(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test query")
+        lead = LeadRecord(
+            url="https://linkedin.com/in/alice",
+            name="Alice",
+            found_at="2025-01-01T00:00:00Z",
+        )
+        backend.log_lead("run_1", lead)
+        data = json.loads((tmp_path / "runs" / "run_1.json").read_text())
+        assert len(data["leads_found"]) == 1
+        assert data["leads_found"][0]["url"] == "https://linkedin.com/in/alice"
+
+    def test_log_email_sent_appends_to_run(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test query")
+        record = EmailSentRecord(
+            to_email="alice@example.com",
+            to_name="Alice",
+            subject="Hi",
+            template_id="cold-intro",
+            sent_at="2025-01-01T00:01:00Z",
+        )
+        backend.log_email_sent("run_1", record)
+        data = json.loads((tmp_path / "runs" / "run_1.json").read_text())
+        assert len(data["emails_sent"]) == 1
+        assert data["emails_sent"][0]["to_email"] == "alice@example.com"
+
+    def test_finish_run_sets_completed_at(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test query")
+        backend.finish_run("run_1", "2025-01-01T01:00:00Z")
+        data = json.loads((tmp_path / "runs" / "run_1.json").read_text())
+        assert data["completed_at"] == "2025-01-01T01:00:00Z"
+
+    def test_is_contacted_true_when_url_exists(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test")
+        backend.log_lead("run_1", LeadRecord(url="https://example.com/profile", name="Bob", found_at="2025-01-01T00:00:00Z"))
+        assert backend.is_contacted("https://example.com/profile") is True
+
+    def test_is_contacted_false_when_url_absent(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test")
+        assert backend.is_contacted("https://example.com/unknown") is False
+
+    def test_is_contacted_false_with_no_runs(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        assert backend.is_contacted("https://example.com") is False
+
+    def test_current_run_id_after_start(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        assert backend.current_run_id() is None
+        backend.start_run("run_3", "test")
+        assert backend.current_run_id() == "run_3"
+
+    def test_multiple_leads_and_sends(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "test")
+        for i in range(3):
+            backend.log_lead("run_1", LeadRecord(url=f"https://example.com/{i}", name=f"Person {i}", found_at="2025-01-01T00:00:00Z"))
+        data = json.loads((tmp_path / "runs" / "run_1.json").read_text())
+        assert len(data["leads_found"]) == 3
+
+    def test_is_contacted_scans_across_runs(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        backend.start_run("run_1", "q1")
+        backend.log_lead("run_1", LeadRecord(url="https://example.com/alice", name="Alice", found_at="2025-01-01T00:00:00Z"))
+        backend.start_run("run_2", "q2")
+        # alice was in run_1, should still be detected
+        assert backend.is_contacted("https://example.com/alice") is True
+
+
+# ---------------------------------------------------------------------------
+# ExaOutreachMemoryStore
+# ---------------------------------------------------------------------------
+
+
+class TestExaOutreachMemoryStore:
+    def test_prepare_creates_directories_and_files(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        assert store.memory_path.exists()
+        assert store.runs_dir.exists()
+        assert store.query_config_path.exists()
+        assert store.agent_identity_path.exists()
+        assert store.additional_prompt_path.exists()
+
+    def test_prepare_is_idempotent(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        store.prepare()  # second call must not fail or overwrite
+        assert store.agent_identity_path.exists()
+
+    def test_next_run_id_empty(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        assert store.next_run_id() == "run_1"
+
+    def test_next_run_id_increments(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        # create two synthetic run files
+        (store.runs_dir / "run_1.json").write_text("{}")
+        (store.runs_dir / "run_2.json").write_text("{}")
+        assert store.next_run_id() == "run_3"
+
+    def test_list_run_files_sorted(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        for n in [3, 1, 2]:
+            (store.runs_dir / f"run_{n}.json").write_text("{}")
+        files = store.list_run_files()
+        names = [f.name for f in files]
+        assert names == ["run_1.json", "run_2.json", "run_3.json"]
+
+    def test_write_and_read_query_config(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        store.write_query_config({"query": "VPs in NYC", "max_tokens": 80000})
+        loaded = store.read_query_config()
+        assert loaded["query"] == "VPs in NYC"
+        assert loaded["max_tokens"] == 80000
+
+    def test_write_and_read_agent_identity(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        store.write_agent_identity("Custom persona here")
+        assert store.read_agent_identity() == "Custom persona here"
+
+    def test_default_agent_identity(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        assert store.read_agent_identity() == DEFAULT_AGENT_IDENTITY
+
+    def test_read_run_missing_raises(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        with pytest.raises(FileNotFoundError):
+            store.read_run("run_99")
+
+    def test_write_and_read_additional_prompt(self, tmp_path):
+        store = ExaOutreachMemoryStore(memory_path=tmp_path / "outreach")
+        store.prepare()
+        store.write_additional_prompt("Keep emails under 80 words.")
+        assert store.read_additional_prompt() == "Keep emails under 80 words."
+
+
+# ---------------------------------------------------------------------------
+# StorageBackend protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestStorageBackendProtocol:
+    def test_filesystem_backend_conforms_to_protocol(self, tmp_path):
+        backend = FileSystemStorageBackend(tmp_path)
+        assert isinstance(backend, StorageBackend)
+
+
+# ---------------------------------------------------------------------------
+# Tool key constants
+# ---------------------------------------------------------------------------
+
+
+class TestToolKeyConstants:
+    def test_all_constants_have_expected_values(self):
+        assert EXA_OUTREACH_LIST_TEMPLATES == "exa_outreach.list_templates"
+        assert EXA_OUTREACH_GET_TEMPLATE == "exa_outreach.get_template"
+        assert EXA_OUTREACH_CHECK_CONTACTED == "exa_outreach.check_contacted"
+        assert EXA_OUTREACH_LOG_LEAD == "exa_outreach.log_lead"
+        assert EXA_OUTREACH_LOG_EMAIL_SENT == "exa_outreach.log_email_sent"
+
+    def test_constants_importable_from_shared_tools(self):
+        from harnessiq.shared.tools import (
+            EXA_OUTREACH_CHECK_CONTACTED,
+            EXA_OUTREACH_GET_TEMPLATE,
+            EXA_OUTREACH_LIST_TEMPLATES,
+            EXA_OUTREACH_LOG_EMAIL_SENT,
+            EXA_OUTREACH_LOG_LEAD,
+        )
+        assert EXA_OUTREACH_LIST_TEMPLATES.startswith("exa_outreach.")


### PR DESCRIPTION
## Summary
- Adds `harnessiq/shared/exa_outreach.py` with all shared data types for the ExaOutreach agent
- `EmailTemplate` (frozen dataclass with `from_dict`/`as_dict`, supports `title`, `subject`, `description`, `actual_email`, `links`, `pain_points`, `icp`, `extra`)
- `LeadRecord`, `EmailSentRecord`, `OutreachRunLog` for per-run persistence
- `StorageBackend` `@runtime_checkable` Protocol enabling pluggable persistence (filesystem, database, CRM, etc.)
- `FileSystemStorageBackend` — writes `run_N.json` under `memory_path/runs/`, `is_contacted` scans all existing run files
- `ExaOutreachMemoryStore` — file-backed store for query config, agent identity, additional prompt, and run files
- Adds 5 new tool key constants to `harnessiq/shared/tools.py`
- 35 tests, all passing

## Test plan
- [x] `py -m pytest tests/test_exa_outreach_shared.py -v` — 35/35 pass

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)