### PR TITLE
Add structured job_search_config parameter mirroring LinkedIn's filter UI

### DIFF
--- a/harnessiq/agents/__init__.py
+++ b/harnessiq/agents/__init__.py
@@ -16,6 +16,7 @@ from harnessiq.shared.agents import (
 from harnessiq.shared.linkedin import (
     ActionLogEntry,
     JobApplicationRecord,
+    JobSearchConfig,
     LinkedInAgentConfig,
     ScreenshotPersistor,
 )
@@ -55,6 +56,7 @@ __all__ = [
     "KnowtMemoryStore",
     "EmailAgentConfig",
     "JobApplicationRecord",
+    "JobSearchConfig",
     "LinkedInAgentConfig",
     "LinkedInJobApplierAgent",
     "LinkedInMemoryStore",

--- a/harnessiq/agents/linkedin/agent.py
+++ b/harnessiq/agents/linkedin/agent.py
@@ -22,26 +22,28 @@ from harnessiq.shared.agents import (
 )
 from harnessiq.shared.linkedin import (
     ACTION_LOG_FILENAME,
+    ADDITIONAL_PROMPT_FILENAME,
     AGENT_IDENTITY_FILENAME,
     APPLIED_JOBS_FILENAME,
-    ADDITIONAL_PROMPT_FILENAME,
+    CUSTOM_PARAMETERS_FILENAME,
     DEFAULT_AGENT_IDENTITY,
     DEFAULT_JOB_PREFERENCES,
     DEFAULT_LINKEDIN_ACTION_LOG_WINDOW,
     DEFAULT_LINKEDIN_NOTIFY_ON_PAUSE,
     DEFAULT_LINKEDIN_START_URL,
     DEFAULT_USER_PROFILE,
-    CUSTOM_PARAMETERS_FILENAME,
     JOB_PREFERENCES_FILENAME,
+    JOB_SEARCH_CONFIG_FILENAME,
     MANAGED_FILES_DIRNAME,
     MANAGED_FILES_INDEX_FILENAME,
+    RUNTIME_PARAMETERS_FILENAME,
     SCREENSHOT_DIRNAME,
     USER_PROFILE_FILENAME,
     ActionLogEntry,
     JobApplicationRecord,
+    JobSearchConfig,
     LinkedInAgentConfig,
     LinkedInManagedFile,
-    RUNTIME_PARAMETERS_FILENAME,
     ScreenshotPersistor,
 )
 from harnessiq.shared.tools import RegisteredTool, ToolDefinition
@@ -109,6 +111,10 @@ class LinkedInMemoryStore:
     def managed_files_index_path(self) -> Path:
         return self.memory_path / MANAGED_FILES_INDEX_FILENAME
 
+    @property
+    def job_search_config_path(self) -> Path:
+        return self.memory_path / JOB_SEARCH_CONFIG_FILENAME
+
     def prepare(self) -> None:
         self.memory_path.mkdir(parents=True, exist_ok=True)
         self.screenshot_dir.mkdir(parents=True, exist_ok=True)
@@ -120,6 +126,7 @@ class LinkedInMemoryStore:
         _ensure_json_file(self.custom_parameters_path, {})
         _ensure_text_file(self.additional_prompt_path, "")
         _ensure_json_file(self.managed_files_index_path, [])
+        _ensure_json_file(self.job_search_config_path, {})
         _ensure_text_file(self.applied_jobs_path, "")
         _ensure_text_file(self.action_log_path, "")
 
@@ -158,6 +165,26 @@ class LinkedInMemoryStore:
 
     def write_additional_prompt(self, content: str) -> Path:
         return self._write_text(self.additional_prompt_path, content)
+
+    def read_job_search_config(self) -> JobSearchConfig | None:
+        """Return the persisted job search config, or ``None`` if not set."""
+        payload = self._read_json_file(self.job_search_config_path, expected_type=dict)
+        if not payload:
+            return None
+        return JobSearchConfig.from_dict(payload)
+
+    def write_job_search_config(
+        self,
+        config: str | dict[str, Any] | JobSearchConfig,
+    ) -> Path:
+        """Persist a job search config from a string, dict, or ``JobSearchConfig``."""
+        if isinstance(config, str):
+            resolved = JobSearchConfig.from_string(config)
+        elif isinstance(config, dict):
+            resolved = JobSearchConfig.from_dict(config)
+        else:
+            resolved = config
+        return self._write_json_file(self.job_search_config_path, resolved.as_dict())
 
     def read_applied_jobs_raw(self) -> str:
         return self.applied_jobs_path.read_text(encoding="utf-8").strip()
@@ -329,6 +356,7 @@ class LinkedInJobApplierAgent(BaseAgent):
         memory_path: str | Path | None = None,
         browser_tools: Iterable[RegisteredTool] = (),
         screenshot_persistor: ScreenshotPersistor | None = None,
+        job_search_config: str | dict[str, Any] | JobSearchConfig | None = None,
         max_tokens: int = DEFAULT_AGENT_MAX_TOKENS,
         reset_threshold: float = DEFAULT_AGENT_RESET_THRESHOLD,
         action_log_window: int = DEFAULT_LINKEDIN_ACTION_LOG_WINDOW,
@@ -350,6 +378,7 @@ class LinkedInJobApplierAgent(BaseAgent):
             action_log_window=self._config.action_log_window,
         )
         self._screenshot_persistor = screenshot_persistor
+        self._initial_job_search_config = job_search_config
 
         tool_registry = ToolRegistry(
             _merge_tools(
@@ -385,6 +414,7 @@ class LinkedInJobApplierAgent(BaseAgent):
         memory_path: str | Path | None = None,
         browser_tools: Iterable[RegisteredTool] = (),
         screenshot_persistor: ScreenshotPersistor | None = None,
+        job_search_config: str | dict[str, Any] | JobSearchConfig | None = None,
         runtime_overrides: Mapping[str, Any] | None = None,
     ) -> "LinkedInJobApplierAgent":
         resolved_path = _resolve_memory_path(memory_path)
@@ -398,11 +428,14 @@ class LinkedInJobApplierAgent(BaseAgent):
             memory_path=resolved_path,
             browser_tools=browser_tools,
             screenshot_persistor=screenshot_persistor,
+            job_search_config=job_search_config,
             **normalize_linkedin_runtime_parameters(runtime_parameters),
         )
 
     def prepare(self) -> None:
         self._memory_store.prepare()
+        if self._initial_job_search_config is not None:
+            self._memory_store.write_job_search_config(self._initial_job_search_config)
 
     def build_system_prompt(self) -> str:
         template = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
@@ -420,6 +453,10 @@ class LinkedInJobApplierAgent(BaseAgent):
         recent_actions_text = "\n".join(json.dumps(entry.as_dict(), sort_keys=True) for entry in recent_actions)
         sections: list[AgentParameterSection] = [
             AgentParameterSection(
+                title="Jobs Already Applied To",
+                content=_or_placeholder(self._memory_store.read_applied_jobs_raw(), "(no applications recorded yet)"),
+            ),
+            AgentParameterSection(
                 title="Job Preferences",
                 content=_or_placeholder(self._memory_store.read_job_preferences(), "(job preferences not set)"),
             ),
@@ -428,14 +465,13 @@ class LinkedInJobApplierAgent(BaseAgent):
                 content=_or_placeholder(self._memory_store.read_user_profile(), "(user profile not set)"),
             ),
             AgentParameterSection(
-                title="Jobs Already Applied To",
-                content=_or_placeholder(self._memory_store.read_applied_jobs_raw(), "(no applications recorded yet)"),
-            ),
-            AgentParameterSection(
                 title=f"Recent Actions (last {self._config.action_log_window})",
                 content=_or_placeholder(recent_actions_text, "(no recent actions recorded yet)"),
             ),
         ]
+        job_search_config = self._memory_store.read_job_search_config()
+        if job_search_config is not None and not job_search_config.is_empty():
+            sections.insert(1, AgentParameterSection(title="Job Search Config", content=job_search_config.render()))
         runtime_parameters = self._memory_store.read_runtime_parameters()
         if runtime_parameters:
             sections.append(AgentParameterSection(title="Runtime Parameters", content=_json_block(runtime_parameters)))
@@ -919,6 +955,7 @@ def _timestamp_for_filename() -> str:
 __all__ = [
     "ActionLogEntry",
     "JobApplicationRecord",
+    "JobSearchConfig",
     "LinkedInAgentConfig",
     "LinkedInManagedFile",
     "LinkedInJobApplierAgent",

--- a/harnessiq/cli/linkedin/commands.py
+++ b/harnessiq/cli/linkedin/commands.py
@@ -15,6 +15,7 @@ from harnessiq.agents import LinkedInJobApplierAgent, LinkedInMemoryStore
 from harnessiq.agents.linkedin import (
     SUPPORTED_LINKEDIN_RUNTIME_PARAMETERS,
     JobApplicationRecord,
+    JobSearchConfig,
     normalize_linkedin_runtime_parameters,
 )
 
@@ -37,6 +38,23 @@ def register_linkedin_commands(subparsers: argparse._SubParsersAction[argparse.A
     _add_text_or_file_options(configure_parser, "user_profile", "User profile")
     _add_text_or_file_options(configure_parser, "agent_identity", "Agent identity")
     _add_text_or_file_options(configure_parser, "additional_prompt", "Additional prompt")
+    # Job description: accepts plain text or a JSON object (auto-detected).
+    job_desc_group = configure_parser.add_mutually_exclusive_group()
+    job_desc_group.add_argument(
+        "--job-description",
+        metavar="TEXT_OR_JSON",
+        help=(
+            "Job search criteria as plain text or a JSON object with LinkedIn filter fields "
+            "(title, location, remote_type, experience_levels, date_posted, easy_apply_only, "
+            "salary_min, salary_max, job_type, companies, industries). "
+            "Mutually exclusive with --job-description-file."
+        ),
+    )
+    job_desc_group.add_argument(
+        "--job-description-file",
+        metavar="PATH",
+        help="Path to a file containing the job description as plain text or JSON.",
+    )
     configure_parser.add_argument(
         "--runtime-param",
         action="append",
@@ -147,6 +165,11 @@ def _handle_configure(args: argparse.Namespace) -> int:
     if additional_prompt is not None:
         store.write_additional_prompt(additional_prompt)
         updated.append("additional_prompt")
+
+    raw_job_description = _resolve_text_argument(args.job_description, args.job_description_file)
+    if raw_job_description is not None:
+        store.write_job_search_config(_parse_job_description(raw_job_description))
+        updated.append("job_search_config")
 
     runtime_parameters = store.read_runtime_parameters()
     runtime_parameters.update(_parse_runtime_assignments(args.runtime_param))
@@ -327,12 +350,30 @@ def _parse_scalar(value: str) -> Any:
         return value
 
 
+def _parse_job_description(raw: str) -> JobSearchConfig:
+    """Parse a raw CLI job description string into a ``JobSearchConfig``.
+
+    If the string is a valid JSON object, it is treated as structured filter data.
+    Otherwise it is treated as a free-form description string.
+    """
+    stripped = raw.strip()
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict):
+            return JobSearchConfig.from_dict(parsed)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return JobSearchConfig.from_string(stripped)
+
+
 def _build_summary(store: LinkedInMemoryStore) -> dict[str, Any]:
+    job_search_config = store.read_job_search_config()
     return {
         "additional_prompt": store.read_additional_prompt(),
         "agent_identity": store.read_agent_identity(),
         "custom_parameters": store.read_custom_parameters(),
         "job_preferences": store.read_job_preferences(),
+        "job_search_config": job_search_config.as_dict() if job_search_config is not None else {},
         "managed_files": [record.as_dict() for record in store.read_managed_files()],
         "memory_path": str(store.memory_path.resolve()),
         "runtime_parameters": store.read_runtime_parameters(),

--- a/harnessiq/shared/linkedin.py
+++ b/harnessiq/shared/linkedin.py
@@ -54,8 +54,130 @@ RUNTIME_PARAMETERS_FILENAME = "runtime_parameters.json"
 CUSTOM_PARAMETERS_FILENAME = "custom_parameters.json"
 ADDITIONAL_PROMPT_FILENAME = "additional_prompt.md"
 MANAGED_FILES_INDEX_FILENAME = "managed_files.json"
+JOB_SEARCH_CONFIG_FILENAME = "job_search_config.json"
 SCREENSHOT_DIRNAME = "screenshots"
 MANAGED_FILES_DIRNAME = "managed_files"
+
+
+@dataclass(frozen=True, slots=True)
+class JobSearchConfig:
+    """Structured LinkedIn job search configuration mirroring LinkedIn's filter UI.
+
+    All fields are optional.  Pass ``description`` alone for a free-form fallback
+    when structured filter fields are not provided.
+
+    Valid values for ``remote_type``: ``"onsite"``, ``"remote"``, ``"hybrid"``.
+    Valid values for ``experience_levels``: ``"internship"``, ``"entry"``,
+    ``"associate"``, ``"mid_senior"``, ``"director"``, ``"executive"``.
+    Valid values for ``date_posted``: ``"past_24_hours"``, ``"past_week"``,
+    ``"past_month"``, ``"any_time"``.
+    Valid values for ``job_type``: ``"full_time"``, ``"part_time"``,
+    ``"contract"``, ``"temporary"``, ``"volunteer"``, ``"other"``.
+    """
+
+    title: str | None = None
+    location: str | None = None
+    remote_type: str | None = None
+    experience_levels: tuple[str, ...] = ()
+    date_posted: str | None = None
+    easy_apply_only: bool = False
+    salary_min: int | None = None
+    salary_max: int | None = None
+    job_type: tuple[str, ...] = ()
+    companies: tuple[str, ...] = ()
+    industries: tuple[str, ...] = ()
+    description: str | None = None
+
+    def is_empty(self) -> bool:
+        """Return True when no field carries a meaningful value."""
+        return not self.as_dict()
+
+    def render(self) -> str:
+        """Human-readable string suitable for injection into the agent context window."""
+        lines: list[str] = []
+        if self.description:
+            lines.append(self.description)
+            lines.append("")
+        if self.title:
+            lines.append(f"Title: {self.title}")
+        if self.location:
+            lines.append(f"Location: {self.location}")
+        if self.remote_type:
+            lines.append(f"Remote Type: {self.remote_type.replace('_', ' ').title()}")
+        if self.experience_levels:
+            formatted = ", ".join(lvl.replace("_", " ").title() for lvl in self.experience_levels)
+            lines.append(f"Experience Levels: {formatted}")
+        if self.date_posted:
+            lines.append(f"Date Posted: {self.date_posted.replace('_', ' ').title()}")
+        if self.easy_apply_only:
+            lines.append("Easy Apply Only: Yes")
+        if self.salary_min is not None and self.salary_max is not None:
+            lines.append(f"Salary Range: ${self.salary_min:,} \u2013 ${self.salary_max:,}")
+        elif self.salary_min is not None:
+            lines.append(f"Salary: ${self.salary_min:,}+")
+        elif self.salary_max is not None:
+            lines.append(f"Salary: Up to ${self.salary_max:,}")
+        if self.job_type:
+            formatted = ", ".join(jt.replace("_", " ").title() for jt in self.job_type)
+            lines.append(f"Job Types: {formatted}")
+        if self.companies:
+            lines.append(f"Companies: {', '.join(self.companies)}")
+        if self.industries:
+            lines.append(f"Industries: {', '.join(self.industries)}")
+        return "\n".join(lines) if lines else "(job search config not set)"
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if self.title:
+            payload["title"] = self.title
+        if self.location:
+            payload["location"] = self.location
+        if self.remote_type:
+            payload["remote_type"] = self.remote_type
+        if self.experience_levels:
+            payload["experience_levels"] = list(self.experience_levels)
+        if self.date_posted:
+            payload["date_posted"] = self.date_posted
+        if self.easy_apply_only:
+            payload["easy_apply_only"] = True
+        if self.salary_min is not None:
+            payload["salary_min"] = self.salary_min
+        if self.salary_max is not None:
+            payload["salary_max"] = self.salary_max
+        if self.job_type:
+            payload["job_type"] = list(self.job_type)
+        if self.companies:
+            payload["companies"] = list(self.companies)
+        if self.industries:
+            payload["industries"] = list(self.industries)
+        if self.description:
+            payload["description"] = self.description
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "JobSearchConfig":
+        return cls(
+            title=payload.get("title") or None,
+            location=payload.get("location") or None,
+            remote_type=payload.get("remote_type") or None,
+            experience_levels=tuple(payload.get("experience_levels") or ()),
+            date_posted=payload.get("date_posted") or None,
+            easy_apply_only=bool(payload.get("easy_apply_only", False)),
+            salary_min=int(payload["salary_min"]) if payload.get("salary_min") is not None else None,
+            salary_max=int(payload["salary_max"]) if payload.get("salary_max") is not None else None,
+            job_type=tuple(payload.get("job_type") or ()),
+            companies=tuple(payload.get("companies") or ()),
+            industries=tuple(payload.get("industries") or ()),
+            description=payload.get("description") or None,
+        )
+
+    @classmethod
+    def from_string(cls, description: str) -> "JobSearchConfig":
+        """Construct a config with only a free-form description string."""
+        stripped = description.strip()
+        if not stripped:
+            raise ValueError("Job search description must not be empty.")
+        return cls(description=stripped)
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,7 +302,9 @@ __all__ = [
     "DEFAULT_LINKEDIN_START_URL",
     "DEFAULT_USER_PROFILE",
     "JOB_PREFERENCES_FILENAME",
+    "JOB_SEARCH_CONFIG_FILENAME",
     "JobApplicationRecord",
+    "JobSearchConfig",
     "LinkedInAgentConfig",
     "LinkedInManagedFile",
     "MANAGED_FILES_DIRNAME",

--- a/tests/test_linkedin_agent.py
+++ b/tests/test_linkedin_agent.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from harnessiq.agents import (
     AgentModelRequest,
     AgentModelResponse,
+    JobSearchConfig,
     LinkedInJobApplierAgent,
     build_linkedin_browser_tool_definitions,
 )
@@ -65,12 +66,13 @@ class LinkedInJobApplierAgentTests(unittest.TestCase):
             self.assertIn("navigate", model.requests[0].system_prompt)
             self.assertIn("pause_and_notify", model.requests[0].system_prompt)
             self.assertEqual(agent.config.action_log_window, DEFAULT_LINKEDIN_ACTION_LOG_WINDOW)
+            self.assertTrue(Path(temp_dir, "job_search_config.json").exists())
             self.assertEqual(
                 [section.title for section in model.requests[0].parameter_sections],
                 [
+                    "Jobs Already Applied To",
                     "Job Preferences",
                     "User Profile",
-                    "Jobs Already Applied To",
                     "Recent Actions (last 10)",
                 ],
             )
@@ -96,7 +98,7 @@ class LinkedInJobApplierAgentTests(unittest.TestCase):
             self.assertFalse(agent.config.notify_on_pause)
             self.assertIn("Runtime Parameters", sections)
             self.assertIn("Custom Parameters", sections)
-            self.assertIn("Additional Prompt Data", sections)
+            self.assertIn("Additional Prompt Data", sections)  # section title updated in ticket 3
             self.assertIn("Managed Files", sections)
             self.assertIn("resume.txt", sections["Managed Files"])
             self.assertIn("cover-letter.txt", sections["Managed Files"])
@@ -162,6 +164,75 @@ class LinkedInJobApplierAgentTests(unittest.TestCase):
             self.assertEqual(len(agent.memory_store.read_applied_jobs()), 3)
             self.assertEqual(agent.memory_store.current_jobs()["job-1"].status, "failed")
             self.assertEqual(agent.memory_store.current_jobs()["job-2"].status, "skipped")
+
+    def test_job_search_config_injected_into_context_window(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+
+            # String description is persisted during prepare() and rendered into context.
+            agent = LinkedInJobApplierAgent(
+                model=model,
+                memory_path=temp_dir,
+                job_search_config="Senior software engineer, remote, salary > $150k",
+            )
+            result = agent.run(max_cycles=1)
+
+            self.assertEqual(result.status, "completed")
+            sections = {s.title: s.content for s in model.requests[0].parameter_sections}
+            self.assertIn("Job Search Config", sections)
+            self.assertIn("Senior software engineer", sections["Job Search Config"])
+            # Applied jobs is still first even when job_search_config is present.
+            self.assertEqual(model.requests[0].parameter_sections[0].title, "Jobs Already Applied To")
+            self.assertEqual(model.requests[0].parameter_sections[1].title, "Job Search Config")
+
+    def test_job_search_config_structured_fields_render_correctly(self) -> None:
+        config = JobSearchConfig(
+            title="Staff Engineer",
+            location="San Francisco, CA",
+            remote_type="remote",
+            experience_levels=("mid_senior", "director"),
+            date_posted="past_week",
+            easy_apply_only=True,
+            salary_min=200_000,
+            salary_max=350_000,
+            job_type=("full_time", "contract"),
+        )
+        rendered = config.render()
+        self.assertIn("Staff Engineer", rendered)
+        self.assertIn("San Francisco, CA", rendered)
+        self.assertIn("Remote", rendered)
+        self.assertIn("Mid Senior", rendered)
+        self.assertIn("Past Week", rendered)
+        self.assertIn("Easy Apply Only: Yes", rendered)
+        self.assertIn("$200,000", rendered)
+        self.assertIn("$350,000", rendered)
+        self.assertIn("Full Time", rendered)
+
+        roundtripped = JobSearchConfig.from_dict(config.as_dict())
+        self.assertEqual(roundtripped.title, config.title)
+        self.assertEqual(roundtripped.remote_type, config.remote_type)
+        self.assertEqual(roundtripped.experience_levels, config.experience_levels)
+        self.assertEqual(roundtripped.easy_apply_only, config.easy_apply_only)
+        self.assertEqual(roundtripped.salary_min, config.salary_min)
+
+    def test_job_search_config_from_memory_override_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+            store = LinkedInJobApplierAgent(model=model, memory_path=temp_dir).memory_store
+            store.prepare()
+            # Persist one config via the store.
+            store.write_job_search_config({"title": "Product Manager"})
+
+            # Override via from_memory() with a different config.
+            override_config = JobSearchConfig(title="Engineering Manager", location="NYC")
+            agent = LinkedInJobApplierAgent.from_memory(
+                model=model,
+                memory_path=temp_dir,
+                job_search_config=override_config,
+            )
+            agent.run(max_cycles=1)
+            sections = {s.title: s.content for s in model.requests[0].parameter_sections}
+            self.assertIn("Engineering Manager", sections["Job Search Config"])
 
     def test_context_reset_reloads_recent_actions_from_memory(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Adds `JobSearchConfig` dataclass to `harnessiq/shared/linkedin.py` with all LinkedIn filter fields: title, location, remote_type, experience_levels, date_posted, easy_apply_only, salary_min, salary_max, job_type, companies, industries, description
- `render()` produces a human-readable string for context window injection; `as_dict()` / `from_dict()` round-trip cleanly for JSON storage
- Adds `write_job_search_config()` / `read_job_search_config()` to `LinkedInMemoryStore`; `prepare()` initializes `job_search_config.json`
- Agent constructor and `from_memory()` accept `job_search_config: str | dict | JobSearchConfig | None`; constructor value is written to memory during `prepare()` so it persists for the run
- `load_parameter_sections()` inserts "Job Search Config" as section index 1 (after "Jobs Already Applied To") when non-empty
- CLI `--job-description TEXT_OR_JSON` auto-detects plain text vs JSON object; `--job-description-file PATH` reads from a file
- `_build_summary()` in commands.py now includes `job_search_config` field

Closes #127

## Quality Pipeline Results
- All 9 LinkedIn agent tests pass (6 existing + 3 new)
- New tests: `test_job_search_config_injected_into_context_window`, `test_job_search_config_structured_fields_render_correctly`, `test_job_search_config_from_memory_override_takes_precedence`
- Existing test `test_run_bootstraps_memory_files_and_injects_linkedin_prompt_sections` updated: section order now starts with "Jobs Already Applied To"

## Post-Critique Changes
Verified `is_empty()` delegates to `as_dict()` rather than duplicating field checks. `from_string()` raises `ValueError` on empty strings rather than silently storing empty description.