### PR TITLE
Surface custom instructions cleanly and rename context window section

### DIFF
--- a/harnessiq/agents/linkedin/agent.py
+++ b/harnessiq/agents/linkedin/agent.py
@@ -480,7 +480,7 @@ class LinkedInJobApplierAgent(BaseAgent):
             sections.append(AgentParameterSection(title="Custom Parameters", content=_json_block(custom_parameters)))
         additional_prompt = self._memory_store.read_additional_prompt()
         if additional_prompt:
-            sections.append(AgentParameterSection(title="Additional Prompt Data", content=additional_prompt))
+            sections.append(AgentParameterSection(title="Custom Instructions", content=additional_prompt))
         managed_files = [entry.as_dict() for entry in self._memory_store.read_managed_files()]
         if managed_files:
             sections.append(AgentParameterSection(title="Managed Files", content=_json_block(managed_files)))

--- a/harnessiq/cli/linkedin/commands.py
+++ b/harnessiq/cli/linkedin/commands.py
@@ -37,7 +37,7 @@ def register_linkedin_commands(subparsers: argparse._SubParsersAction[argparse.A
     _add_text_or_file_options(configure_parser, "job_preferences", "Job preferences")
     _add_text_or_file_options(configure_parser, "user_profile", "User profile")
     _add_text_or_file_options(configure_parser, "agent_identity", "Agent identity")
-    _add_text_or_file_options(configure_parser, "additional_prompt", "Additional prompt")
+    _add_text_or_file_options(configure_parser, "custom_instructions", "Custom instructions")
     # Job description: accepts plain text or a JSON object (auto-detected).
     job_desc_group = configure_parser.add_mutually_exclusive_group()
     job_desc_group.add_argument(
@@ -161,10 +161,10 @@ def _handle_configure(args: argparse.Namespace) -> int:
         store.write_agent_identity(agent_identity)
         updated.append("agent_identity")
 
-    additional_prompt = _resolve_text_argument(args.additional_prompt_text, args.additional_prompt_file)
-    if additional_prompt is not None:
-        store.write_additional_prompt(additional_prompt)
-        updated.append("additional_prompt")
+    custom_instructions = _resolve_text_argument(args.custom_instructions_text, args.custom_instructions_file)
+    if custom_instructions is not None:
+        store.write_additional_prompt(custom_instructions)
+        updated.append("custom_instructions")
 
     raw_job_description = _resolve_text_argument(args.job_description, args.job_description_file)
     if raw_job_description is not None:

--- a/tests/test_linkedin_agent.py
+++ b/tests/test_linkedin_agent.py
@@ -98,7 +98,7 @@ class LinkedInJobApplierAgentTests(unittest.TestCase):
             self.assertFalse(agent.config.notify_on_pause)
             self.assertIn("Runtime Parameters", sections)
             self.assertIn("Custom Parameters", sections)
-            self.assertIn("Additional Prompt Data", sections)  # section title updated in ticket 3
+            self.assertIn("Custom Instructions", sections)
             self.assertIn("Managed Files", sections)
             self.assertIn("resume.txt", sections["Managed Files"])
             self.assertIn("cover-letter.txt", sections["Managed Files"])


### PR DESCRIPTION
## Summary
- CLI configure command now exposes `--custom-instructions-text` and `--custom-instructions-file` instead of `--additional-prompt-text/file`; the underlying `additional_prompt.md` file is preserved for backward compatibility with any existing persisted state
- Context window section title renamed from `"Additional Prompt Data"` to `"Custom Instructions"` — the user-facing name that matches the parameter intent
- Test updated to assert `"Custom Instructions"` in parameter sections

Closes #128

## Quality Pipeline Results
- All 9 LinkedIn agent tests pass
- Pre-existing failures in `test_toolset_registry.py` confirmed to be unrelated to this change (also present on `main`)

## Post-Critique Changes
No behavior changes needed — this is a clean rename at the CLI and display layer only. The underlying file and method names remain stable so existing persisted state is not broken.