### PR TITLE
feat: add harnessiq/providers/arxiv/ — transport config, HTTP client, Atom XML parser, and operation catalog

### DIFF
--- a/harnessiq/providers/arxiv/__init__.py
+++ b/harnessiq/providers/arxiv/__init__.py
@@ -1,0 +1,12 @@
+"""arXiv academic paper search API — transport config, client, and operation catalog."""
+
+from .client import ArxivClient, ArxivConfig
+from .operations import ArxivOperation, build_arxiv_operation_catalog, get_arxiv_operation
+
+__all__ = [
+    "ArxivClient",
+    "ArxivConfig",
+    "ArxivOperation",
+    "build_arxiv_operation_catalog",
+    "get_arxiv_operation",
+]

--- a/harnessiq/providers/arxiv/api.py
+++ b/harnessiq/providers/arxiv/api.py
@@ -1,0 +1,171 @@
+"""arXiv API endpoint constants, URL builders, and Atom feed parser."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+from urllib import parse
+
+DEFAULT_BASE_URL = "https://export.arxiv.org"
+_PDF_BASE_URL = "https://arxiv.org"
+
+# Atom 1.0 and arXiv-extension namespaces used in feed responses.
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_ARXIV_NS = "http://arxiv.org/schemas/atom"
+
+# Clark-notation tag shortcuts — avoids repetitive f-string construction.
+_ENTRY = f"{{{_ATOM_NS}}}entry"
+_ID = f"{{{_ATOM_NS}}}id"
+_TITLE = f"{{{_ATOM_NS}}}title"
+_SUMMARY = f"{{{_ATOM_NS}}}summary"
+_PUBLISHED = f"{{{_ATOM_NS}}}published"
+_UPDATED = f"{{{_ATOM_NS}}}updated"
+_AUTHOR = f"{{{_ATOM_NS}}}author"
+_AUTHOR_NAME = f"{{{_ATOM_NS}}}name"
+_CATEGORY = f"{{{_ATOM_NS}}}category"
+_LINK = f"{{{_ATOM_NS}}}link"
+_PRIMARY_CATEGORY = f"{{{_ARXIV_NS}}}primary_category"
+
+# Matches a version suffix like "v1", "v12" at the end of an arXiv ID.
+_VERSION_SUFFIX_RE = re.compile(r"v\d+$")
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+def search_url(
+    base_url: str,
+    *,
+    query: str,
+    max_results: int,
+    start: int,
+    sort_by: str,
+    sort_order: str,
+) -> str:
+    """Build a fully-qualified arXiv search URL."""
+    base = base_url.rstrip("/")
+    encoded = parse.urlencode(
+        {
+            "search_query": query,
+            "start": start,
+            "max_results": max_results,
+            "sortBy": sort_by,
+            "sortOrder": sort_order,
+        }
+    )
+    return f"{base}/api/query?{encoded}"
+
+
+def get_paper_url(base_url: str, paper_id: str) -> str:
+    """Build the URL to retrieve a single paper by arXiv ID."""
+    base = base_url.rstrip("/")
+    encoded = parse.urlencode({"search_query": f"id:{paper_id}", "max_results": 1})
+    return f"{base}/api/query?{encoded}"
+
+
+def pdf_url(paper_id: str) -> str:
+    """Return the direct PDF download URL for an arXiv paper."""
+    return f"{_PDF_BASE_URL}/pdf/{paper_id}"
+
+
+# ---------------------------------------------------------------------------
+# Atom XML parser
+# ---------------------------------------------------------------------------
+
+
+def parse_arxiv_feed(xml_text: str) -> list[dict[str, Any]]:
+    """Parse an Atom 1.0 arXiv feed into a list of normalized paper records.
+
+    Returns an empty list for zero-result feeds.
+
+    Raises:
+        ValueError: If *xml_text* cannot be parsed as valid XML.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"arXiv feed is not valid XML: {exc}") from exc
+
+    return [parse_arxiv_entry(entry) for entry in root.findall(_ENTRY)]
+
+
+def parse_arxiv_entry(entry: ET.Element) -> dict[str, Any]:
+    """Extract a normalized paper record from a single Atom <entry> element.
+
+    Returned keys: ``id``, ``arxiv_id``, ``title``, ``authors``,
+    ``summary``, ``published``, ``updated``, ``categories``,
+    ``primary_category``, ``pdf_url``, ``abs_url``.
+    """
+    raw_id = _text(entry, _ID) or ""
+    arxiv_id = _extract_arxiv_id(raw_id)
+
+    abs_url = ""
+    entry_pdf_url = ""
+    for link in entry.findall(_LINK):
+        rel = link.get("rel", "")
+        href = link.get("href", "")
+        link_type = link.get("type", "")
+        if rel == "alternate" and "html" in link_type:
+            abs_url = href
+        elif rel == "related" and "pdf" in link_type:
+            entry_pdf_url = href
+
+    if not entry_pdf_url and arxiv_id:
+        entry_pdf_url = pdf_url(arxiv_id)
+
+    return {
+        "id": raw_id,
+        "arxiv_id": arxiv_id,
+        "title": _text(entry, _TITLE) or "",
+        "authors": [
+            _text(author, _AUTHOR_NAME) or ""
+            for author in entry.findall(_AUTHOR)
+        ],
+        "summary": (_text(entry, _SUMMARY) or "").strip(),
+        "published": _text(entry, _PUBLISHED) or "",
+        "updated": _text(entry, _UPDATED) or "",
+        "categories": [cat.get("term", "") for cat in entry.findall(_CATEGORY)],
+        "primary_category": _primary_category(entry),
+        "pdf_url": entry_pdf_url,
+        "abs_url": abs_url,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _text(element: ET.Element, tag: str) -> str | None:
+    """Return stripped text of the first matching child, or ``None``."""
+    child = element.find(tag)
+    if child is None:
+        return None
+    return (child.text or "").strip() or None
+
+
+def _extract_arxiv_id(raw_id: str) -> str:
+    """Extract the bare arXiv ID from a canonical abs URL.
+
+    Examples::
+
+        "http://arxiv.org/abs/2301.12345v1"  →  "2301.12345"
+        "http://arxiv.org/abs/hep-ph/9901257v2"  →  "hep-ph/9901257"
+    """
+    if "/abs/" in raw_id:
+        arxiv_id = raw_id.split("/abs/", 1)[1]
+    else:
+        arxiv_id = raw_id
+    return _VERSION_SUFFIX_RE.sub("", arxiv_id)
+
+
+def _primary_category(entry: ET.Element) -> str:
+    """Return the primary_category term for an entry, or empty string."""
+    pc = entry.find(_PRIMARY_CATEGORY)
+    if pc is None:
+        first_cat = entry.find(_CATEGORY)
+        return first_cat.get("term", "") if first_cat is not None else ""
+    return pc.get("term", "")

--- a/harnessiq/providers/arxiv/client.py
+++ b/harnessiq/providers/arxiv/client.py
@@ -1,0 +1,176 @@
+"""arXiv transport configuration and HTTP client."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from urllib import error, request
+
+from harnessiq.providers.arxiv.api import (
+    DEFAULT_BASE_URL,
+    get_paper_url,
+    parse_arxiv_feed,
+    pdf_url,
+    search_url,
+)
+from harnessiq.providers.http import ProviderHTTPError, RequestExecutor, request_json
+
+
+@dataclass(frozen=True, slots=True)
+class ArxivConfig:
+    """Transport configuration for the arXiv API.
+
+    arXiv search requires no authentication — this config holds only
+    transport parameters.
+
+    ``delay_seconds`` defaults to ``0.0``.  Set it to ``3.0`` to comply
+    with arXiv's Terms of Use (≤ 1 request per 3 seconds).
+    """
+
+    base_url: str = DEFAULT_BASE_URL
+    timeout_seconds: float = 30.0
+    delay_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not self.base_url.strip():
+            raise ValueError("ArxivConfig.base_url must not be blank.")
+        if self.timeout_seconds <= 0:
+            raise ValueError("ArxivConfig.timeout_seconds must be greater than zero.")
+        if self.delay_seconds < 0:
+            raise ValueError("ArxivConfig.delay_seconds must be zero or greater.")
+
+
+@dataclass(frozen=True, slots=True)
+class ArxivClient:
+    """Minimal arXiv HTTP client for tool execution and tests.
+
+    All search and retrieval operations use the public arXiv export API
+    (no API key required).  ``download_paper`` fetches PDF bytes via a
+    separate binary HTTP request that bypasses ``request_executor``.
+
+    Inject a custom ``request_executor`` in tests to avoid real network I/O.
+    """
+
+    config: ArxivConfig = field(default_factory=ArxivConfig)
+    request_executor: RequestExecutor = request_json
+
+    def search(
+        self,
+        *,
+        query: str,
+        max_results: int = 10,
+        start: int = 0,
+        sort_by: str = "relevance",
+        sort_order: str = "descending",
+    ) -> list[dict[str, Any]]:
+        """Search arXiv papers and return normalized paper records.
+
+        ``query`` supports arXiv field prefixes: ``ti:`` (title), ``au:``
+        (author), ``abs:`` (abstract), ``cat:`` (category), ``all:`` (all
+        fields).  Boolean operators: ``AND``, ``OR``, ``ANDNOT``.
+        """
+        url = search_url(
+            self.config.base_url,
+            query=query,
+            max_results=max_results,
+            start=start,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        xml_text = self._fetch_xml(url)
+        return parse_arxiv_feed(xml_text)
+
+    def search_raw(
+        self,
+        *,
+        query: str,
+        max_results: int = 10,
+        start: int = 0,
+        sort_by: str = "relevance",
+        sort_order: str = "descending",
+    ) -> str:
+        """Search arXiv papers and return the raw Atom 1.0 XML string."""
+        url = search_url(
+            self.config.base_url,
+            query=query,
+            max_results=max_results,
+            start=start,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        return self._fetch_xml(url)
+
+    def get_paper(self, paper_id: str) -> dict[str, Any] | None:
+        """Retrieve a single paper by arXiv ID.
+
+        Returns a normalized paper record dict, or ``None`` if the paper is
+        not found.
+        """
+        url = get_paper_url(self.config.base_url, paper_id)
+        xml_text = self._fetch_xml(url)
+        records = parse_arxiv_feed(xml_text)
+        return records[0] if records else None
+
+    def download_paper(self, paper_id: str, save_path: str) -> str:
+        """Download the PDF for *paper_id* and write it to *save_path*.
+
+        Returns *save_path* on success.  Uses ``urllib.request`` directly
+        because the PDF response is binary, not JSON or XML.
+        """
+        if self.config.delay_seconds > 0:
+            time.sleep(self.config.delay_seconds)
+
+        download_url = pdf_url(paper_id)
+        try:
+            with request.urlopen(
+                download_url, timeout=self.config.timeout_seconds
+            ) as resp:
+                pdf_bytes: bytes = resp.read()
+        except error.HTTPError as exc:
+            raise ProviderHTTPError(
+                provider="arxiv",
+                message=exc.reason or "HTTP error",
+                status_code=exc.code,
+                url=download_url,
+            ) from exc
+        except error.URLError as exc:
+            raise ProviderHTTPError(
+                provider="arxiv",
+                message=str(exc.reason),
+                url=download_url,
+            ) from exc
+
+        with open(save_path, "wb") as fh:
+            fh.write(pdf_bytes)
+        return save_path
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_xml(self, url: str) -> str:
+        """Apply optional rate-limit delay then execute the request.
+
+        ``request_json`` falls back to returning the raw text string when
+        the response body is not valid JSON — which Atom XML is not.
+        """
+        if self.config.delay_seconds > 0:
+            time.sleep(self.config.delay_seconds)
+
+        result = self.request_executor(
+            "GET",
+            url,
+            headers={"Accept": "application/atom+xml"},
+            timeout_seconds=self.config.timeout_seconds,
+        )
+        if not isinstance(result, str):
+            raise ProviderHTTPError(
+                provider="arxiv",
+                message=(
+                    f"Expected XML string response from arXiv, "
+                    f"got {type(result).__name__}."
+                ),
+                url=url,
+            )
+        return result

--- a/harnessiq/providers/arxiv/operations.py
+++ b/harnessiq/providers/arxiv/operations.py
@@ -1,0 +1,87 @@
+"""arXiv operation catalog."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ArxivOperation:
+    """Declarative metadata for one arXiv client operation."""
+
+    name: str
+    category: str
+    description: str
+
+    def summary(self) -> str:
+        return self.name
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+_CATALOG: OrderedDict[str, ArxivOperation] = OrderedDict(
+    [
+        (
+            "search",
+            ArxivOperation(
+                name="search",
+                category="Search",
+                description=(
+                    "Search arXiv papers by keyword, author, title, or category; "
+                    "returns normalized paper records."
+                ),
+            ),
+        ),
+        (
+            "search_raw",
+            ArxivOperation(
+                name="search_raw",
+                category="Search",
+                description="Search arXiv papers; returns raw Atom 1.0 XML.",
+            ),
+        ),
+        (
+            "get_paper",
+            ArxivOperation(
+                name="get_paper",
+                category="Retrieval",
+                description=(
+                    "Retrieve a single arXiv paper by ID; "
+                    "returns a normalized paper record."
+                ),
+            ),
+        ),
+        (
+            "download_paper",
+            ArxivOperation(
+                name="download_paper",
+                category="Download",
+                description="Download a paper PDF to a local path.",
+            ),
+        ),
+    ]
+)
+
+
+def build_arxiv_operation_catalog() -> tuple[ArxivOperation, ...]:
+    """Return all registered arXiv operations in insertion order."""
+    return tuple(_CATALOG.values())
+
+
+def get_arxiv_operation(name: str) -> ArxivOperation:
+    """Return the ``ArxivOperation`` for *name*.
+
+    Raises:
+        ValueError: If *name* is not a known operation, with the known
+            names listed in the message.
+    """
+    try:
+        return _CATALOG[name]
+    except KeyError:
+        known = ", ".join(_CATALOG)
+        raise ValueError(
+            f"Unknown arXiv operation '{name}'. Known operations: {known}."
+        ) from None

--- a/tests/test_arxiv_provider.py
+++ b/tests/test_arxiv_provider.py
@@ -1,0 +1,476 @@
+"""Tests for the arXiv provider layer.
+
+Covers ``ArxivConfig``, ``ArxivClient``, ``parse_arxiv_feed``,
+``parse_arxiv_entry``, URL builders, and the operation catalog.
+Tool factory and registry integration tests are added in the
+registration ticket (issue-141).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from harnessiq.providers.arxiv.api import (
+    _extract_arxiv_id,
+    get_paper_url,
+    parse_arxiv_entry,
+    parse_arxiv_feed,
+    pdf_url,
+    search_url,
+)
+from harnessiq.providers.arxiv.client import ArxivClient, ArxivConfig
+from harnessiq.providers.arxiv.operations import (
+    build_arxiv_operation_catalog,
+    get_arxiv_operation,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixture data
+# ---------------------------------------------------------------------------
+
+_SAMPLE_ATOM = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2301.12345v1</id>
+    <title>Attention Is All You Need</title>
+    <summary>  A landmark transformer paper.  </summary>
+    <published>2017-06-12T00:00:00Z</published>
+    <updated>2017-06-12T00:00:00Z</updated>
+    <author><name>Ashish Vaswani</name></author>
+    <author><name>Noam Shazeer</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+    <arxiv:primary_category term="cs.LG"
+      scheme="http://arxiv.org/schemas/atom"/>
+    <link rel="alternate" href="https://arxiv.org/abs/2301.12345"
+      type="text/html"/>
+    <link rel="related" href="https://arxiv.org/pdf/2301.12345"
+      type="application/pdf" title="pdf"/>
+  </entry>
+</feed>"""
+
+_EMPTY_ATOM = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+
+_MULTI_ENTRY_ATOM = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/1706.03762v5</id>
+    <title>Paper One</title>
+    <summary>First paper.</summary>
+    <published>2017-06-12T00:00:00Z</published>
+    <updated>2017-06-12T00:00:00Z</updated>
+    <author><name>Author A</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <arxiv:primary_category term="cs.LG"
+      scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/1810.04805v2</id>
+    <title>Paper Two</title>
+    <summary>Second paper.</summary>
+    <published>2018-10-11T00:00:00Z</published>
+    <updated>2018-10-11T00:00:00Z</updated>
+    <author><name>Author B</name></author>
+    <category term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+    <arxiv:primary_category term="cs.CL"
+      scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"""
+
+
+# ---------------------------------------------------------------------------
+# ArxivConfigTests
+# ---------------------------------------------------------------------------
+
+
+class ArxivConfigTests(unittest.TestCase):
+    def test_default_construction_succeeds(self) -> None:
+        c = ArxivConfig()
+        self.assertEqual(c.base_url, "https://export.arxiv.org")
+        self.assertEqual(c.timeout_seconds, 30.0)
+        self.assertEqual(c.delay_seconds, 0.0)
+
+    def test_custom_values_accepted(self) -> None:
+        c = ArxivConfig(
+            base_url="https://custom.arxiv.org",
+            timeout_seconds=15.0,
+            delay_seconds=3.0,
+        )
+        self.assertEqual(c.base_url, "https://custom.arxiv.org")
+        self.assertEqual(c.timeout_seconds, 15.0)
+        self.assertEqual(c.delay_seconds, 3.0)
+
+    def test_blank_base_url_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="blank base_url"):
+            ArxivConfig(base_url="")
+
+    def test_whitespace_base_url_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="whitespace base_url"):
+            ArxivConfig(base_url="   ")
+
+    def test_zero_timeout_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ArxivConfig(timeout_seconds=0.0)
+
+    def test_negative_timeout_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ArxivConfig(timeout_seconds=-1.0)
+
+    def test_negative_delay_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ArxivConfig(delay_seconds=-0.1)
+
+    def test_zero_delay_accepted(self) -> None:
+        c = ArxivConfig(delay_seconds=0.0)
+        self.assertEqual(c.delay_seconds, 0.0)
+
+    def test_config_is_frozen(self) -> None:
+        c = ArxivConfig()
+        with self.assertRaises((AttributeError, TypeError)):
+            c.timeout_seconds = 99.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ArxivApiTests
+# ---------------------------------------------------------------------------
+
+
+class ArxivApiTests(unittest.TestCase):
+    def test_search_url_contains_query(self) -> None:
+        url = search_url(
+            "https://export.arxiv.org",
+            query="ti:attention",
+            max_results=10,
+            start=0,
+            sort_by="relevance",
+            sort_order="descending",
+        )
+        self.assertIn("search_query=ti%3Aattention", url)
+        self.assertIn("max_results=10", url)
+        self.assertIn("sortBy=relevance", url)
+        self.assertIn("sortOrder=descending", url)
+        self.assertIn("start=0", url)
+
+    def test_search_url_pagination(self) -> None:
+        url = search_url(
+            "https://export.arxiv.org",
+            query="all:transformer",
+            max_results=50,
+            start=100,
+            sort_by="submittedDate",
+            sort_order="ascending",
+        )
+        self.assertIn("start=100", url)
+        self.assertIn("max_results=50", url)
+        self.assertIn("sortBy=submittedDate", url)
+        self.assertIn("sortOrder=ascending", url)
+
+    def test_search_url_base_trailing_slash_stripped(self) -> None:
+        url = search_url(
+            "https://export.arxiv.org/",
+            query="au:hinton",
+            max_results=5,
+            start=0,
+            sort_by="relevance",
+            sort_order="descending",
+        )
+        self.assertFalse(url.startswith("https://export.arxiv.org//"))
+
+    def test_get_paper_url_contains_id(self) -> None:
+        url = get_paper_url("https://export.arxiv.org", "2301.12345")
+        self.assertIn("id%3A2301.12345", url)
+        self.assertIn("max_results=1", url)
+
+    def test_pdf_url_format(self) -> None:
+        self.assertEqual(pdf_url("2301.12345"), "https://arxiv.org/pdf/2301.12345")
+
+    def test_pdf_url_old_style_id(self) -> None:
+        self.assertEqual(
+            pdf_url("hep-ph/9901257"), "https://arxiv.org/pdf/hep-ph/9901257"
+        )
+
+    def test_extract_arxiv_id_strips_version(self) -> None:
+        self.assertEqual(
+            _extract_arxiv_id("http://arxiv.org/abs/2301.12345v1"), "2301.12345"
+        )
+
+    def test_extract_arxiv_id_old_style(self) -> None:
+        self.assertEqual(
+            _extract_arxiv_id("http://arxiv.org/abs/hep-ph/9901257v2"),
+            "hep-ph/9901257",
+        )
+
+    def test_extract_arxiv_id_no_version(self) -> None:
+        self.assertEqual(
+            _extract_arxiv_id("http://arxiv.org/abs/2301.12345"), "2301.12345"
+        )
+
+    def test_parse_arxiv_feed_single_entry(self) -> None:
+        results = parse_arxiv_feed(_SAMPLE_ATOM)
+        self.assertEqual(len(results), 1)
+
+    def test_parse_arxiv_feed_empty_returns_empty_list(self) -> None:
+        self.assertEqual(parse_arxiv_feed(_EMPTY_ATOM), [])
+
+    def test_parse_arxiv_feed_multiple_entries(self) -> None:
+        results = parse_arxiv_feed(_MULTI_ENTRY_ATOM)
+        self.assertEqual(len(results), 2)
+
+    def test_parse_arxiv_feed_invalid_xml_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_arxiv_feed("<not valid xml><<")
+
+    def test_parse_arxiv_entry_fields(self) -> None:
+        results = parse_arxiv_feed(_SAMPLE_ATOM)
+        r = results[0]
+        self.assertEqual(r["arxiv_id"], "2301.12345")
+        self.assertEqual(r["title"], "Attention Is All You Need")
+        self.assertEqual(r["authors"], ["Ashish Vaswani", "Noam Shazeer"])
+        self.assertEqual(r["summary"], "A landmark transformer paper.")
+        self.assertEqual(r["published"], "2017-06-12T00:00:00Z")
+        self.assertEqual(r["updated"], "2017-06-12T00:00:00Z")
+        self.assertIn("cs.LG", r["categories"])
+        self.assertIn("cs.CL", r["categories"])
+        self.assertEqual(r["primary_category"], "cs.LG")
+        self.assertEqual(r["pdf_url"], "https://arxiv.org/pdf/2301.12345")
+        self.assertEqual(r["abs_url"], "https://arxiv.org/abs/2301.12345")
+
+    def test_parse_arxiv_entry_summary_stripped(self) -> None:
+        """Summary whitespace is stripped."""
+        results = parse_arxiv_feed(_SAMPLE_ATOM)
+        self.assertFalse(results[0]["summary"].startswith(" "))
+        self.assertFalse(results[0]["summary"].endswith(" "))
+
+    def test_parse_arxiv_entry_missing_pdf_link_falls_back(self) -> None:
+        """When the feed omits the pdf link, pdf_url is derived from arxiv_id."""
+        no_pdf_link = """\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/1234.56789v1</id>
+    <title>No PDF Link</title>
+    <summary>Abstract.</summary>
+    <published>2020-01-01T00:00:00Z</published>
+    <updated>2020-01-01T00:00:00Z</updated>
+    <author><name>Someone</name></author>
+  </entry>
+</feed>"""
+        results = parse_arxiv_feed(no_pdf_link)
+        self.assertEqual(results[0]["pdf_url"], "https://arxiv.org/pdf/1234.56789")
+
+
+# ---------------------------------------------------------------------------
+# ArxivOperationTests
+# ---------------------------------------------------------------------------
+
+
+class ArxivOperationTests(unittest.TestCase):
+    def test_catalog_has_four_operations(self) -> None:
+        ops = build_arxiv_operation_catalog()
+        self.assertEqual(len(ops), 4)
+
+    def test_catalog_insertion_order(self) -> None:
+        names = [op.name for op in build_arxiv_operation_catalog()]
+        self.assertEqual(names, ["search", "search_raw", "get_paper", "download_paper"])
+
+    def test_get_operation_search(self) -> None:
+        op = get_arxiv_operation("search")
+        self.assertEqual(op.name, "search")
+        self.assertEqual(op.category, "Search")
+
+    def test_get_operation_search_raw(self) -> None:
+        op = get_arxiv_operation("search_raw")
+        self.assertEqual(op.category, "Search")
+
+    def test_get_operation_get_paper(self) -> None:
+        op = get_arxiv_operation("get_paper")
+        self.assertEqual(op.category, "Retrieval")
+
+    def test_get_operation_download_paper(self) -> None:
+        op = get_arxiv_operation("download_paper")
+        self.assertEqual(op.category, "Download")
+
+    def test_unknown_operation_raises_with_available_names(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            get_arxiv_operation("nonexistent")
+        self.assertIn("nonexistent", str(ctx.exception))
+        self.assertIn("search", str(ctx.exception))
+
+    def test_summary_returns_name(self) -> None:
+        op = get_arxiv_operation("search")
+        self.assertEqual(op.summary(), "search")
+
+    def test_operations_are_frozen(self) -> None:
+        op = get_arxiv_operation("search")
+        with self.assertRaises((AttributeError, TypeError)):
+            op.name = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ArxivClientTests
+# ---------------------------------------------------------------------------
+
+
+def _fake_executor(xml_text: str) -> Any:
+    """Return a request executor that always returns *xml_text*."""
+
+    def _exec(
+        method: str,
+        url: str,
+        *,
+        headers: Any = None,
+        json_body: Any = None,
+        timeout_seconds: float = 30.0,
+    ) -> str:
+        return xml_text
+
+    return _exec
+
+
+class ArxivClientTests(unittest.TestCase):
+    def _client(self, xml: str = _SAMPLE_ATOM) -> ArxivClient:
+        return ArxivClient(
+            config=ArxivConfig(),
+            request_executor=_fake_executor(xml),
+        )
+
+    def test_default_client_constructs(self) -> None:
+        client = ArxivClient()
+        self.assertIsNotNone(client.config)
+
+    def test_search_returns_parsed_records(self) -> None:
+        results = self._client().search(query="ti:attention")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["arxiv_id"], "2301.12345")
+
+    def test_search_passes_all_params_to_url(self) -> None:
+        captured: list[str] = []
+
+        def _exec(
+            method: str,
+            url: str,
+            *,
+            headers: Any = None,
+            json_body: Any = None,
+            timeout_seconds: float = 30.0,
+        ) -> str:
+            captured.append(url)
+            return _EMPTY_ATOM
+
+        client = ArxivClient(config=ArxivConfig(), request_executor=_exec)
+        client.search(
+            query="au:hinton",
+            max_results=25,
+            start=50,
+            sort_by="submittedDate",
+            sort_order="ascending",
+        )
+        self.assertEqual(len(captured), 1)
+        self.assertIn("max_results=25", captured[0])
+        self.assertIn("start=50", captured[0])
+        self.assertIn("submittedDate", captured[0])
+        self.assertIn("ascending", captured[0])
+
+    def test_search_empty_results(self) -> None:
+        results = self._client(xml=_EMPTY_ATOM).search(query="zzz_no_results")
+        self.assertEqual(results, [])
+
+    def test_search_raw_returns_string(self) -> None:
+        xml = self._client().search_raw(query="ti:attention")
+        self.assertIsInstance(xml, str)
+        self.assertIn("<feed", xml)
+
+    def test_get_paper_found(self) -> None:
+        result = self._client().get_paper("2301.12345")
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["arxiv_id"], "2301.12345")
+
+    def test_get_paper_not_found_returns_none(self) -> None:
+        result = self._client(xml=_EMPTY_ATOM).get_paper("0000.00000")
+        self.assertIsNone(result)
+
+    def test_download_paper_writes_bytes(self) -> None:
+        pdf_bytes = b"%PDF-1.4 fake pdf content"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.read.return_value = pdf_bytes
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                save_path = os.path.join(tmpdir, "paper.pdf")
+                client = ArxivClient(config=ArxivConfig())
+                returned = client.download_paper("2301.12345", save_path)
+
+                self.assertEqual(returned, save_path)
+                with open(save_path, "rb") as fh:
+                    self.assertEqual(fh.read(), pdf_bytes)
+
+    def test_non_string_executor_response_raises(self) -> None:
+        def _json_executor(
+            method: str,
+            url: str,
+            *,
+            headers: Any = None,
+            json_body: Any = None,
+            timeout_seconds: float = 30.0,
+        ) -> dict[str, object]:
+            return {"unexpected": "json"}
+
+        client = ArxivClient(config=ArxivConfig(), request_executor=_json_executor)
+        from harnessiq.providers.http import ProviderHTTPError
+
+        with self.assertRaises(ProviderHTTPError):
+            client.search(query="test")
+
+    def test_delay_is_applied_before_request(self) -> None:
+        """When delay_seconds > 0, time.sleep is called."""
+        calls: list[float] = []
+
+        def _exec(
+            method: str,
+            url: str,
+            *,
+            headers: Any = None,
+            json_body: Any = None,
+            timeout_seconds: float = 30.0,
+        ) -> str:
+            return _EMPTY_ATOM
+
+        client = ArxivClient(
+            config=ArxivConfig(delay_seconds=0.01),
+            request_executor=_exec,
+        )
+        with patch("harnessiq.providers.arxiv.client.time.sleep") as mock_sleep:
+            client.search(query="test")
+            mock_sleep.assert_called_once()
+            self.assertAlmostEqual(mock_sleep.call_args[0][0], 0.01)
+
+    def test_no_delay_when_zero(self) -> None:
+        """When delay_seconds == 0.0, time.sleep is not called."""
+
+        def _exec(
+            method: str,
+            url: str,
+            *,
+            headers: Any = None,
+            json_body: Any = None,
+            timeout_seconds: float = 30.0,
+        ) -> str:
+            return _EMPTY_ATOM
+
+        client = ArxivClient(config=ArxivConfig(delay_seconds=0.0), request_executor=_exec)
+        with patch("harnessiq.providers.arxiv.client.time.sleep") as mock_sleep:
+            client.search(query="test")
+            mock_sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Ticket 1: arXiv Provider Core

## Title
Add `harnessiq/providers/arxiv/` — credentials config, HTTP client, API helpers, and operation catalog

## Intent
Establish the foundational provider layer for arXiv so that downstream tickets can build the tool factory and registration on top of a clean, tested provider contract. This is the data-access layer only — no tool wiring.

## Scope
**Creates:**
- `harnessiq/providers/arxiv/__init__.py`
- `harnessiq/providers/arxiv/client.py` — `ArxivConfig` transport-config dataclass + `ArxivClient`
- `harnessiq/providers/arxiv/api.py` — URL builders, Atom XML parser (`parse_arxiv_feed`, `parse_arxiv_entry`)
- `harnessiq/providers/arxiv/operations.py` — `ArxivOperation` frozen dataclass + `_CATALOG` + `build_arxiv_operation_catalog()` + `get_arxiv_operation()`

**Does not touch:** tool factories, shared/tools.py constants, catalog.py, registry.py, tests, or file_index.md.

## Relevant Files
| File | Change |
|------|--------|
| `harnessiq/providers/arxiv/__init__.py` | New — re-exports `ArxivConfig`, `ArxivClient`, `ArxivOperation`, `build_arxiv_operation_catalog`, `get_arxiv_operation` |
| `harnessiq/providers/arxiv/client.py` | New — `ArxivConfig` + `ArxivClient` |
| `harnessiq/providers/arxiv/api.py` | New — URL builders + Atom XML parser |
| `harnessiq/providers/arxiv/operations.py` | New — operation catalog |

## Approach

### `ArxivConfig` (in `client.py`)
No authentication fields — arXiv search API is fully public. Config holds only transport options:
```python
@dataclass(frozen=True, slots=True)
class ArxivConfig:
    base_url: str = DEFAULT_BASE_URL        # "https://export.arxiv.org"
    timeout_seconds: float = 30.0
    delay_seconds: float = 0.0              # caller sets 3.0 to respect arXiv ToS
```
Validation in `__post_init__`: base_url non-blank, timeout > 0, delay >= 0.

### `ArxivClient` (in `client.py`)
```python
@dataclass(frozen=True, slots=True)
class ArxivClient:
    config: ArxivConfig = field(default_factory=ArxivConfig)
    request_executor: RequestExecutor = request_json
```
Methods:
- `search(*, query, max_results=10, start=0, sort_by="relevance", sort_order="descending") -> list[dict[str, Any]]` — builds query URL, calls executor, parses Atom XML → normalized paper records
- `search_raw(*, query, max_results=10, start=0, sort_by="relevance", sort_order="descending") -> str` — same URL, returns raw XML string
- `get_paper(paper_id: str) -> dict[str, Any] | None` — fetches `id:{paper_id}` query, parses → single record or None
- `download_paper(paper_id: str, save_path: str) -> str` — fetches PDF bytes from `https://arxiv.org/pdf/{paper_id}`, writes to `save_path`, returns save_path

`download_paper` uses `urllib.request` directly (not `request_executor`) because it fetches binary PDF, not JSON/XML.

`delay_seconds` sleep (when > 0) is applied before each `request_executor` call.

### `api.py`
```python
DEFAULT_BASE_URL = "https://export.arxiv.org"
ARXIV_ATOM_NS = "http://www.w3.org/2005/Atom"
ARXIV_NS = "http://arxiv.org/schemas/atom"
OPENSEARCH_NS = "http://a9.com/-/spec/opensearch/1.1/"

def search_url(base_url: str, *, query: str, max_results: int, start: int,
               sort_by: str, sort_order: str) -> str: ...
def get_paper_url(base_url: str, paper_id: str) -> str: ...
def pdf_url(paper_id: str) -> str: ...  # https://arxiv.org/pdf/{paper_id}

def parse_arxiv_feed(xml_text: str) -> list[dict[str, Any]]: ...
def parse_arxiv_entry(entry: ET.Element) -> dict[str, Any]: ...
```

Each parsed paper record shape:
```python
{
    "id": "http://arxiv.org/abs/2301.12345v1",
    "arxiv_id": "2301.12345",
    "title": "...",
    "authors": ["Author Name", ...],
    "summary": "Abstract text...",
    "published": "2023-01-30T00:00:00Z",
    "updated": "2023-01-30T00:00:00Z",
    "categories": ["cs.LG", "cs.AI"],
    "primary_category": "cs.LG",
    "pdf_url": "https://arxiv.org/pdf/2301.12345",
    "abs_url": "https://arxiv.org/abs/2301.12345",
}
```
Uses `xml.etree.ElementTree` (stdlib) — no new dependencies.

### `operations.py`
Four operations matching the four client methods:
```python
@dataclass(frozen=True, slots=True)
class ArxivOperation:
    name: str
    category: str
    description: str
    def summary(self) -> str: return self.name
```
Catalog:
- `search` — "Search" — "Search arXiv papers by keyword, author, title, or category; returns normalized paper records."
- `search_raw` — "Search" — "Search arXiv papers; returns raw Atom 1.0 XML."
- `get_paper` — "Retrieval" — "Retrieve a single arXiv paper by ID; returns normalized paper record."
- `download_paper` — "Download" — "Download a paper PDF to a local path."

## Assumptions
- `request_json` returns raw XML string when arXiv responds with Atom XML (confirmed: `_decode_response` falls back to raw text on `JSONDecodeError`).
- `download_paper` is the only operation that uses binary HTTP; it bypasses `request_executor` and uses stdlib `urllib.request` directly.
- `delay_seconds` defaults to `0.0` to avoid slowing tests and respect that enforcement is the caller's responsibility.

## Acceptance Criteria
- [ ] `ArxivConfig()` with no arguments constructs successfully with defaults
- [ ] `ArxivConfig(base_url="")` raises `ValueError`
- [ ] `ArxivConfig(timeout_seconds=0)` raises `ValueError`
- [ ] `ArxivConfig(delay_seconds=-1)` raises `ValueError`
- [ ] `ArxivClient(config=ArxivConfig())` constructs successfully
- [ ] `parse_arxiv_feed(sample_atom_xml)` returns a list of dicts with all normalized fields
- [ ] `parse_arxiv_feed` handles zero-result feeds (empty list, no error)
- [ ] `build_arxiv_operation_catalog()` returns 4 operations in insertion order
- [ ] `get_arxiv_operation("search")` returns the correct operation
- [ ] `get_arxiv_operation("unknown")` raises `ValueError` listing available names
- [ ] `search_url(...)` builds correct URL with all params encoded
- [ ] `pdf_url("2301.12345")` returns `"https://arxiv.org/pdf/2301.12345"`

## Verification Steps
1. `python -m py_compile harnessiq/providers/arxiv/*.py` — no syntax errors
2. `mypy harnessiq/providers/arxiv/` — no type errors
3. `python -m pytest tests/test_arxiv_provider.py::ArxivConfigTests -v`
4. `python -m pytest tests/test_arxiv_provider.py::ArxivApiTests -v`
5. `python -m pytest tests/test_arxiv_provider.py::ArxivOperationTests -v`
6. `python -m pytest tests/test_arxiv_provider.py::ArxivClientTests -v`

## Dependencies
None.

## Drift Guard
This ticket must not create any tool factory code, touch `shared/tools.py`, `toolset/catalog.py`, `toolset/registry.py`, or any test file other than the new `tests/test_arxiv_provider.py`.

## Quality Pipeline Results

## Quality Pipeline Results — Ticket 1

### Stage 1 — Static Analysis
`python -m py_compile harnessiq/providers/arxiv/*.py` — no errors on all four files.

### Stage 2 — Type Checking
`mypy` not installed in project venv. All new code uses explicit type annotations throughout:
- Return types annotated on every function (`-> list[dict[str, Any]]`, `-> str | None`, etc.)
- `from __future__ import annotations` in all files for deferred evaluation
- Dataclass fields typed; `RequestExecutor` protocol type from `harnessiq.providers.http`
- `ET.Element` parameter type on `parse_arxiv_entry`

### Stage 3 — Unit Tests
`python -m unittest tests.test_arxiv_provider -v`
**Ran 45 tests in 0.028s — OK**

Test classes:
- `ArxivConfigTests` (9 tests) — default construction, custom values, all validation paths, immutability
- `ArxivApiTests` (16 tests) — URL builders, pagination, trailing slash, PDF URL, version stripping, feed parsing happy/empty/multi/invalid, field extraction, summary stripping, missing pdf link fallback
- `ArxivOperationTests` (8 tests) — catalog size, insertion order, all four operations, error message, summary, immutability
- `ArxivClientTests` (12 tests) — construction, search/search_raw/get_paper/download_paper dispatch, params forwarded to URL, delay applied/not applied, non-string response raises

### Stage 4 — Integration Tests
No external services required — request executor is fully injectable. `ArxivClient(config=ArxivConfig())` imports and constructs cleanly without network access.

### Stage 5 — Smoke Verification
```
from harnessiq.providers.arxiv import ArxivConfig, ArxivClient, build_arxiv_operation_catalog
c = ArxivConfig()          # → base_url='https://export.arxiv.org' timeout=30.0 delay=0.0
build_arxiv_operation_catalog()   # → 4 operations: search, search_raw, get_paper, download_paper
```
All verified interactively.

## Post-Critique Changes

## Self-Critique — Ticket 1

### Issues found and fixed

**1. `_fetch_xml` called twice in `search_raw`**
`search_raw` and `search` both call `_fetch_xml` which applies the delay. No duplication — both call their own URL variant. `search_raw` returns the string directly; `search` parses it. Clean.

**2. `download_paper` bypasses delay**
Originally missed: `download_paper` applies `time.sleep` before `urllib.request.urlopen` directly. Confirmed the delay IS applied in `download_paper`. The rate-limit sleep happens before every network call. Correct.

**3. Non-string response guard in `_fetch_xml`**
The guard `if not isinstance(result, str)` correctly handles the case where a test executor accidentally returns a dict instead of XML text. Covered by `test_non_string_executor_response_raises`. Good.

**4. `parse_arxiv_entry` exposes as public API**
`parse_arxiv_entry` is exposed in `__init__.py`? No — it's NOT re-exported from `__init__.py`. It's importable directly from `api.py` for tests. The `__init__.py` exports only the top-level user-facing names. This is correct. Tests import from `harnessiq.providers.arxiv.api` directly.

**5. Atom namespace prefix in `<feed>` root**
`ET.fromstring` on a namespaced root like `<feed xmlns="...">` correctly handles namespace expansion. The `_ENTRY = f"{{{_ATOM_NS}}}entry"` Clark notation is the right approach. Verified with the sample XML fixture.

**6. `_extract_arxiv_id` exposed in module for testing**
`_extract_arxiv_id` is a private helper (underscore prefix) but imported directly in tests. Acceptable — it's complex enough to warrant direct unit testing. Not re-exported from `__init__.py`. This is standard Python convention for "private but testable".

**7. Error message clarity in `ArxivConfig` validation**
All three validation error messages include the field name (`ArxivConfig.base_url`, `ArxivConfig.timeout_seconds`, `ArxivConfig.delay_seconds`). Clean.

**No improvements needed.** Code is clean, tested, and follows codebase conventions throughout.