### PR TITLE
add instagram keyword discovery agent

### DIFF
--- a/harnessiq/agents/__init__.py
+++ b/harnessiq/agents/__init__.py
@@ -26,6 +26,8 @@ from harnessiq.shared.knowt import KnowtMemoryStore
 
 from .exa_outreach import ExaOutreachAgent
 from harnessiq.shared.exa_outreach import ExaOutreachMemoryStore
+from .instagram import InstagramKeywordDiscoveryAgent
+from harnessiq.shared.instagram import InstagramMemoryStore
 from .knowt import KnowtAgent
 from .linkedin import (
     LinkedInJobApplierAgent,
@@ -51,6 +53,8 @@ __all__ = [
     "ExaOutreachAgent",
     "ExaOutreachMemoryStore",
     "DEFAULT_EMAIL_AGENT_IDENTITY",
+    "InstagramKeywordDiscoveryAgent",
+    "InstagramMemoryStore",
     "KnowtAgent",
     "KnowtMemoryStore",
     "EmailAgentConfig",

--- a/harnessiq/agents/instagram/__init__.py
+++ b/harnessiq/agents/instagram/__init__.py
@@ -1,0 +1,5 @@
+"""Instagram keyword discovery agent harness."""
+
+from .agent import InstagramKeywordDiscoveryAgent
+
+__all__ = ["InstagramKeywordDiscoveryAgent"]

--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -1,0 +1,294 @@
+"""Instagram keyword discovery agent harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from harnessiq.agents.base import BaseAgent
+from harnessiq.shared.agents import (
+    DEFAULT_AGENT_MAX_TOKENS,
+    DEFAULT_AGENT_RESET_THRESHOLD,
+    AgentModel,
+    AgentParameterSection,
+    AgentRuntimeConfig,
+)
+from harnessiq.shared.instagram import (
+    DEFAULT_AGENT_IDENTITY,
+    DEFAULT_RECENT_RESULT_WINDOW,
+    DEFAULT_RECENT_SEARCH_WINDOW,
+    DEFAULT_SEARCH_RESULT_LIMIT,
+    InstagramKeywordAgentConfig,
+    InstagramMemoryStore,
+    InstagramSearchBackend,
+    build_instagram_google_query,
+)
+from harnessiq.shared.tools import RegisteredTool, ToolCall, ToolDefinition, ToolResult
+from harnessiq.tools.registry import ToolRegistry
+
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
+_MASTER_PROMPT_PATH = _PROMPTS_DIR / "master_prompt.md"
+_DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
+_SEARCH_TOOL_KEY = "instagram.search_keyword"
+
+
+class InstagramKeywordDiscoveryAgent(BaseAgent):
+    """Concrete harness for ICP-driven Instagram keyword discovery."""
+
+    def __init__(
+        self,
+        *,
+        model: AgentModel,
+        icp_descriptions: Iterable[str] = (),
+        search_backend: InstagramSearchBackend,
+        memory_path: str | Path | None = None,
+        max_tokens: int = DEFAULT_AGENT_MAX_TOKENS,
+        reset_threshold: float = DEFAULT_AGENT_RESET_THRESHOLD,
+        recent_search_window: int = DEFAULT_RECENT_SEARCH_WINDOW,
+        recent_result_window: int = DEFAULT_RECENT_RESULT_WINDOW,
+        search_result_limit: int = DEFAULT_SEARCH_RESULT_LIMIT,
+    ) -> None:
+        if search_backend is None:
+            raise ValueError("InstagramKeywordDiscoveryAgent requires a search_backend.")
+
+        candidate_memory_path = Path(memory_path) if memory_path is not None else None
+        normalized_icps = _normalize_icp_descriptions(icp_descriptions)
+
+        self._search_backend = search_backend
+        self._initial_icp_descriptions = normalized_icps
+        self._config = InstagramKeywordAgentConfig(
+            memory_path=Path("."),
+            max_tokens=max_tokens,
+            reset_threshold=reset_threshold,
+            recent_search_window=recent_search_window,
+            recent_result_window=recent_result_window,
+            search_result_limit=search_result_limit,
+        )
+
+        tool_registry = ToolRegistry(self._build_internal_tools())
+        runtime_config = AgentRuntimeConfig(
+            max_tokens=max_tokens,
+            reset_threshold=reset_threshold,
+        )
+        super().__init__(
+            name="instagram_keyword_discovery",
+            model=model,
+            tool_executor=tool_registry,
+            runtime_config=runtime_config,
+            memory_path=candidate_memory_path,
+        )
+        resolved_memory_path = self.memory_path or _DEFAULT_MEMORY_PATH
+        self._memory_store = InstagramMemoryStore(memory_path=resolved_memory_path)
+        self._config = InstagramKeywordAgentConfig(
+            memory_path=resolved_memory_path,
+            max_tokens=max_tokens,
+            reset_threshold=reset_threshold,
+            recent_search_window=recent_search_window,
+            recent_result_window=recent_result_window,
+            search_result_limit=search_result_limit,
+        )
+
+    @property
+    def config(self) -> InstagramKeywordAgentConfig:
+        return self._config
+
+    @property
+    def memory_store(self) -> InstagramMemoryStore:
+        return self._memory_store
+
+    @classmethod
+    def from_memory(
+        cls,
+        *,
+        model: AgentModel,
+        search_backend: InstagramSearchBackend,
+        memory_path: str | Path | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+    ) -> "InstagramKeywordDiscoveryAgent":
+        resolved_path = _resolve_memory_path(memory_path)
+        store = InstagramMemoryStore(memory_path=resolved_path)
+        store.prepare()
+        runtime_parameters = store.read_runtime_parameters()
+        if runtime_overrides:
+            runtime_parameters.update(runtime_overrides)
+        from harnessiq.shared.instagram import normalize_instagram_runtime_parameters
+
+        normalized = normalize_instagram_runtime_parameters(runtime_parameters)
+        return cls(
+            model=model,
+            search_backend=search_backend,
+            memory_path=resolved_path,
+            icp_descriptions=store.read_icp_profiles(),
+            **normalized,
+        )
+
+    def prepare(self) -> None:
+        self._memory_store.prepare()
+        if self._initial_icp_descriptions:
+            self._memory_store.write_icp_profiles(self._initial_icp_descriptions)
+
+    def build_system_prompt(self) -> str:
+        if not _MASTER_PROMPT_PATH.exists():
+            raise FileNotFoundError(
+                f"Instagram master prompt not found at '{_MASTER_PROMPT_PATH}'. "
+                "Ensure the prompt file exists."
+            )
+        identity = (
+            self._memory_store.read_agent_identity()
+            if self._memory_store.agent_identity_path.exists()
+            else DEFAULT_AGENT_IDENTITY
+        )
+        prompt = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+        if identity and identity != DEFAULT_AGENT_IDENTITY:
+            prompt = prompt.replace(
+                "[IDENTITY]\nYou are InstagramKeywordDiscoveryAgent.",
+                f"[IDENTITY]\n{identity}\n\n(You are InstagramKeywordDiscoveryAgent.)",
+            )
+        additional_prompt = (
+            self._memory_store.read_additional_prompt()
+            if self._memory_store.additional_prompt_path.exists()
+            else ""
+        )
+        if additional_prompt:
+            prompt = f"{prompt}\n\n[ADDITIONAL INSTRUCTIONS]\n{additional_prompt}"
+        return prompt
+
+    def load_parameter_sections(self) -> Sequence[AgentParameterSection]:
+        icp_profiles = self._memory_store.read_icp_profiles()
+        recent_searches = [
+            record.as_dict()
+            for record in self._memory_store.read_recent_searches(self._config.recent_search_window)
+        ]
+        recent_results = [
+            record.as_dict()
+            for record in self._memory_store.read_recent_leads(self._config.recent_result_window)
+        ]
+        return (
+            AgentParameterSection(title="ICP Profiles", content=_json_block(icp_profiles)),
+            AgentParameterSection(title="Recent Searches", content=_json_block(recent_searches)),
+            AgentParameterSection(title="Recent Search Results", content=_json_block(recent_results)),
+        )
+
+    def get_emails(self) -> tuple[str, ...]:
+        return tuple(self._memory_store.get_emails())
+
+    def get_leads(self):
+        return tuple(self._memory_store.get_leads())
+
+    def get_search_history(self):
+        return tuple(self._memory_store.read_search_history())
+
+    def _build_internal_tools(self) -> tuple[RegisteredTool, ...]:
+        return (
+            RegisteredTool(
+                definition=_tool_definition(
+                    key=_SEARCH_TOOL_KEY,
+                    name="search_keyword",
+                    description=(
+                        "Run a deterministic Google site:instagram.com search for one keyword, load the search page "
+                        "and opened result tabs fully, extract public emails from visited pages, and persist all "
+                        "new leads/emails to durable memory."
+                    ),
+                    properties={
+                        "keyword": {
+                            "type": "string",
+                            "description": "The concise Instagram creator niche keyword to search.",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of Instagram result URLs to open for this keyword.",
+                        },
+                    },
+                    required=("keyword",),
+                ),
+                handler=self._handle_search_keyword,
+            ),
+        )
+
+    def _handle_search_keyword(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        keyword = str(arguments["keyword"]).strip()
+        if not keyword:
+            raise ValueError("keyword must not be blank.")
+        if self._memory_store.has_searched(keyword):
+            return {
+                "keyword": keyword,
+                "message": "Keyword already exists in durable search history.",
+                "query": build_instagram_google_query(keyword),
+                "status": "already_searched",
+            }
+        max_results = int(arguments.get("max_results", self._config.search_result_limit))
+        if max_results <= 0:
+            raise ValueError("max_results must be positive.")
+
+        execution = self._search_backend.search_keyword(keyword=keyword, max_results=max_results)
+        self._memory_store.append_search(execution.search_record)
+        merge_summary = self._memory_store.merge_leads(execution.leads)
+        return {
+            "email_count": execution.search_record.email_count,
+            "keyword": execution.search_record.keyword,
+            "lead_count": execution.search_record.lead_count,
+            "merge_summary": merge_summary.as_dict(),
+            "query": execution.search_record.query,
+            "status": "searched",
+            "visited_urls": list(execution.search_record.visited_urls),
+        }
+
+    def _execute_tool(self, tool_call: ToolCall) -> ToolResult:
+        result = super()._execute_tool(tool_call)
+        if tool_call.tool_key == _SEARCH_TOOL_KEY:
+            self.refresh_parameters()
+        return result
+
+
+def _resolve_memory_path(memory_path: str | Path | None) -> Path:
+    if memory_path is None:
+        return _DEFAULT_MEMORY_PATH
+    return Path(memory_path)
+
+
+def _normalize_icp_descriptions(icp_descriptions: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for description in icp_descriptions:
+        cleaned = str(description).strip()
+        if cleaned:
+            normalized.append(cleaned)
+    return tuple(normalized)
+
+
+def _tool_definition(
+    *,
+    key: str,
+    name: str,
+    description: str,
+    properties: dict[str, Any],
+    required: Sequence[str] = (),
+) -> ToolDefinition:
+    return ToolDefinition(
+        key=key,
+        name=name,
+        description=description,
+        input_schema={
+            "type": "object",
+            "properties": properties,
+            "required": list(required),
+            "additionalProperties": False,
+        },
+    )
+
+
+def _read_optional_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _json_block(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+__all__ = [
+    "InstagramKeywordAgentConfig",
+    "InstagramKeywordDiscoveryAgent",
+    "InstagramMemoryStore",
+]

--- a/harnessiq/agents/instagram/prompts/master_prompt.md
+++ b/harnessiq/agents/instagram/prompts/master_prompt.md
@@ -1,0 +1,29 @@
+[IDENTITY]
+You are InstagramKeywordDiscoveryAgent.
+
+[GOAL]
+Turn the persisted ICP descriptions into concise search keywords, run the deterministic search tool for the best unseen keyword, and accumulate public creator leads and email addresses in durable memory.
+
+[WORKFLOW]
+- Read the ICP Profiles section first.
+- Read Recent Searches next and do not repeat a keyword that is already present there unless every materially distinct keyword idea is exhausted.
+- Read Recent Search Results after that to understand what has already been found.
+- Choose short, concrete keywords that map directly to creator niches, audiences, verticals, or offer types.
+- Use the search tool for one keyword at a time.
+- After each search, reassess the persisted search results before choosing the next keyword.
+
+[KEYWORD RULES]
+- Keep keywords concise: usually one to four words.
+- Prefer niche descriptors over generic words.
+- Avoid repeating the full ICP sentence as a keyword.
+- Favor terms that are likely to appear in Instagram bios or creator positioning.
+- If the ICP is broad, start with the most commercially specific sub-niche.
+
+[SEARCH RULES]
+- Use the deterministic search tool instead of manual browser reasoning.
+- Treat persisted memory as the source of truth for what has already been searched and found.
+- Stop when there are no materially new keywords left or when searches stop producing novel leads.
+
+[OUTPUT RULES]
+- Never claim an email was found unless it came from the deterministic search tool result.
+- Never invent creator details that are not present in persisted search results.

--- a/harnessiq/cli/instagram/__init__.py
+++ b/harnessiq/cli/instagram/__init__.py
@@ -1,0 +1,5 @@
+"""Instagram discovery CLI commands."""
+
+from .commands import register_instagram_commands
+
+__all__ = ["register_instagram_commands"]

--- a/harnessiq/cli/instagram/commands.py
+++ b/harnessiq/cli/instagram/commands.py
@@ -1,0 +1,364 @@
+"""CLI commands for the Instagram keyword discovery agent."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from harnessiq.shared.instagram import InstagramMemoryStore, normalize_instagram_runtime_parameters
+
+SUPPORTED_INSTAGRAM_RUNTIME_PARAMETERS = (
+    "max_tokens",
+    "recent_result_window",
+    "recent_search_window",
+    "reset_threshold",
+    "search_result_limit",
+)
+
+_DEFAULT_SEARCH_BACKEND_FACTORY = "harnessiq.integrations.instagram_playwright:create_search_backend"
+
+
+def register_instagram_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser("instagram", help="Manage and run the Instagram keyword discovery agent")
+    parser.set_defaults(command_handler=lambda args: _print_help(parser))
+    instagram_subparsers = parser.add_subparsers(dest="instagram_command")
+
+    prepare_parser = instagram_subparsers.add_parser(
+        "prepare",
+        help="Create or refresh an Instagram agent memory folder",
+    )
+    _add_agent_options(prepare_parser)
+    prepare_parser.set_defaults(command_handler=_handle_prepare)
+
+    configure_parser = instagram_subparsers.add_parser(
+        "configure",
+        help="Persist ICPs, identity, prompt text, and runtime parameters for the Instagram agent",
+    )
+    _add_agent_options(configure_parser)
+    configure_parser.add_argument(
+        "--icp",
+        action="append",
+        default=[],
+        help="One ICP description. Repeat the flag to provide multiple ICPs.",
+    )
+    configure_parser.add_argument(
+        "--icp-file",
+        help="Path to a JSON array or newline-delimited UTF-8 text file containing ICP descriptions.",
+    )
+    _add_text_or_file_options(configure_parser, "agent_identity", "Agent identity")
+    _add_text_or_file_options(configure_parser, "additional_prompt", "Additional prompt")
+    configure_parser.add_argument(
+        "--runtime-param",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            f"Persist a runtime parameter. Supported keys: "
+            f"{', '.join(SUPPORTED_INSTAGRAM_RUNTIME_PARAMETERS)}."
+        ),
+    )
+    configure_parser.set_defaults(command_handler=_handle_configure)
+
+    show_parser = instagram_subparsers.add_parser(
+        "show",
+        help="Render the current Instagram agent state as JSON",
+    )
+    _add_agent_options(show_parser)
+    show_parser.set_defaults(command_handler=_handle_show)
+
+    run_parser = instagram_subparsers.add_parser(
+        "run",
+        help="Run the Instagram keyword discovery agent from persisted memory",
+    )
+    _add_agent_options(run_parser)
+    run_parser.add_argument(
+        "--model-factory",
+        required=True,
+        help="Import path (module:callable) that returns an AgentModel instance.",
+    )
+    run_parser.add_argument(
+        "--search-backend-factory",
+        default=_DEFAULT_SEARCH_BACKEND_FACTORY,
+        help=(
+            "Import path (module:callable) that returns an InstagramSearchBackend instance. "
+            f"Defaults to {_DEFAULT_SEARCH_BACKEND_FACTORY}."
+        ),
+    )
+    run_parser.add_argument(
+        "--runtime-param",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a persisted runtime parameter for this run only.",
+    )
+    run_parser.add_argument("--max-cycles", type=int, help="Optional max cycle count passed to agent.run().")
+    run_parser.set_defaults(command_handler=_handle_run)
+
+    get_emails_parser = instagram_subparsers.add_parser(
+        "get-emails",
+        help="Return all persisted discovered emails for the configured Instagram agent",
+    )
+    _add_agent_options(get_emails_parser)
+    get_emails_parser.set_defaults(command_handler=_handle_get_emails)
+
+
+def _handle_prepare(args: argparse.Namespace) -> int:
+    store = _load_store(args)
+    store.prepare()
+    _emit_json(
+        {
+            "agent": args.agent,
+            "memory_path": str(store.memory_path.resolve()),
+            "status": "prepared",
+        }
+    )
+    return 0
+
+
+def _handle_configure(args: argparse.Namespace) -> int:
+    store = _load_store(args)
+    store.prepare()
+    updated: list[str] = []
+
+    icp_profiles = _resolve_icp_input(args.icp, args.icp_file)
+    if icp_profiles is not None:
+        store.write_icp_profiles(icp_profiles)
+        updated.append("icp_profiles")
+
+    agent_identity = _resolve_text_argument(
+        getattr(args, "agent_identity_text", None),
+        getattr(args, "agent_identity_file", None),
+    )
+    if agent_identity is not None:
+        store.write_agent_identity(agent_identity)
+        updated.append("agent_identity")
+
+    additional_prompt = _resolve_text_argument(
+        getattr(args, "additional_prompt_text", None),
+        getattr(args, "additional_prompt_file", None),
+    )
+    if additional_prompt is not None:
+        store.write_additional_prompt(additional_prompt)
+        updated.append("additional_prompt")
+
+    runtime_parameters = _parse_runtime_assignments(args.runtime_param)
+    if runtime_parameters:
+        current = store.read_runtime_parameters()
+        current.update(runtime_parameters)
+        store.write_runtime_parameters(current)
+        updated.append("runtime_parameters")
+
+    payload = _build_summary(store)
+    payload["status"] = "configured"
+    payload["updated"] = updated
+    _emit_json(payload)
+    return 0
+
+
+def _handle_show(args: argparse.Namespace) -> int:
+    store = _load_store(args)
+    store.prepare()
+    _emit_json(_build_summary(store))
+    return 0
+
+
+def _handle_run(args: argparse.Namespace) -> int:
+    from harnessiq.agents.instagram import InstagramKeywordDiscoveryAgent
+
+    store = _load_store(args)
+    store.prepare()
+
+    model = _load_factory(args.model_factory)()
+    if not hasattr(model, "generate_turn"):
+        raise TypeError("Model factory must return an object that implements generate_turn(request).")
+
+    browser_data_dir = store.memory_path / "browser-data"
+    if "HARNESSIQ_INSTAGRAM_SESSION_DIR" not in os.environ:
+        os.environ["HARNESSIQ_INSTAGRAM_SESSION_DIR"] = str(browser_data_dir.resolve())
+
+    search_backend = _load_factory(args.search_backend_factory)()
+    runtime_overrides = _parse_runtime_assignments(args.runtime_param)
+
+    agent = InstagramKeywordDiscoveryAgent.from_memory(
+        model=model,
+        search_backend=search_backend,
+        memory_path=store.memory_path,
+        runtime_overrides=runtime_overrides,
+    )
+    result = agent.run(max_cycles=args.max_cycles)
+    _emit_json(
+        {
+            "agent": args.agent,
+            "email_count": len(agent.get_emails()),
+            "memory_path": str(store.memory_path.resolve()),
+            "result": {
+                "cycles_completed": result.cycles_completed,
+                "pause_reason": result.pause_reason,
+                "resets": result.resets,
+                "status": result.status,
+            },
+        }
+    )
+    return 0
+
+
+def _handle_get_emails(args: argparse.Namespace) -> int:
+    store = _load_store(args)
+    store.prepare()
+    emails = store.get_emails()
+    _emit_json(
+        {
+            "agent": args.agent,
+            "count": len(emails),
+            "emails": emails,
+            "memory_path": str(store.memory_path.resolve()),
+        }
+    )
+    return 0
+
+
+def _load_store(args: argparse.Namespace) -> InstagramMemoryStore:
+    return InstagramMemoryStore(memory_path=_resolve_memory_path(args.agent, args.memory_root))
+
+
+def _resolve_memory_path(agent_name: str, memory_root: str) -> Path:
+    return Path(memory_root).expanduser() / _slugify_agent_name(agent_name)
+
+
+def _slugify_agent_name(agent_name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", agent_name.strip()).strip("-")
+    if not cleaned:
+        raise ValueError("Agent names must contain at least one alphanumeric character.")
+    return cleaned
+
+
+def _add_agent_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Logical agent name used to resolve the memory folder.",
+    )
+    parser.add_argument(
+        "--memory-root",
+        default="memory/instagram",
+        help="Root directory that holds per-agent instagram memory folders.",
+    )
+
+
+def _add_text_or_file_options(parser: argparse.ArgumentParser, field_name: str, label: str) -> None:
+    group = parser.add_mutually_exclusive_group()
+    option_name = field_name.replace("_", "-")
+    group.add_argument(f"--{option_name}-text", help=f"{label} content provided inline.")
+    group.add_argument(
+        f"--{option_name}-file",
+        help=f"Path to a UTF-8 text file containing {label.lower()} content.",
+    )
+
+
+def _resolve_text_argument(text_value: str | None, file_value: str | None) -> str | None:
+    if text_value is not None:
+        return text_value
+    if file_value is not None:
+        return Path(file_value).read_text(encoding="utf-8")
+    return None
+
+
+def _resolve_icp_input(inline_values: Sequence[str], file_value: str | None) -> list[str] | None:
+    cleaned_inline = [value.strip() for value in inline_values if value and value.strip()]
+    if file_value is None:
+        return cleaned_inline or None
+    raw = Path(file_value).read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return [line.strip() for line in raw.splitlines() if line.strip()]
+    if not isinstance(payload, list):
+        raise ValueError("ICP file must be a JSON array or newline-delimited text file.")
+    return [str(value).strip() for value in payload if str(value).strip()]
+
+
+def _parse_runtime_assignments(assignments: Sequence[str]) -> dict[str, Any]:
+    return normalize_instagram_runtime_parameters(_parse_generic_assignments(assignments))
+
+
+def _parse_generic_assignments(assignments: Sequence[str]) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for assignment in assignments:
+        key, raw_value = _split_assignment(assignment)
+        parsed[key] = _parse_scalar(raw_value)
+    return parsed
+
+
+def _split_assignment(assignment: str) -> tuple[str, str]:
+    key, separator, value = assignment.partition("=")
+    if not separator:
+        raise ValueError(f"Expected KEY=VALUE assignment, received '{assignment}'.")
+    normalized_key = key.strip()
+    if not normalized_key:
+        raise ValueError(f"Expected a non-empty key in assignment '{assignment}'.")
+    return normalized_key, value
+
+
+def _parse_scalar(value: str) -> Any:
+    trimmed = value.strip()
+    if not trimmed:
+        return ""
+    try:
+        return json.loads(trimmed)
+    except json.JSONDecodeError:
+        return value
+
+
+def _build_summary(store: InstagramMemoryStore) -> dict[str, Any]:
+    search_history = store.read_search_history()
+    lead_database = store.read_lead_database()
+    return {
+        "additional_prompt": store.read_additional_prompt(),
+        "agent_identity": store.read_agent_identity(),
+        "email_count": len(lead_database.emails),
+        "icp_profiles": store.read_icp_profiles(),
+        "lead_count": len(lead_database.leads),
+        "memory_path": str(store.memory_path.resolve()),
+        "recent_searches": [record.as_dict() for record in search_history[-5:]],
+        "runtime_parameters": store.read_runtime_parameters(),
+        "search_count": len(search_history),
+    }
+
+
+def _load_factory(spec: str):
+    module_name, separator, attribute_path = spec.partition(":")
+    if not separator or not module_name or not attribute_path:
+        raise ValueError(f"Factory import paths must use the form module:callable. Received '{spec}'.")
+    module = importlib.import_module(module_name)
+    target: Any = module
+    for attribute_name in attribute_path.split("."):
+        target = getattr(target, attribute_name)
+    if not callable(target):
+        raise TypeError(f"Imported object '{spec}' is not callable.")
+    return target
+
+
+def _emit_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _print_help(parser: argparse.ArgumentParser) -> int:
+    parser.print_help()
+    return 0
+
+
+__all__ = [
+    "SUPPORTED_INSTAGRAM_RUNTIME_PARAMETERS",
+    "normalize_instagram_runtime_parameters",
+    "register_instagram_commands",
+]

--- a/harnessiq/cli/main.py
+++ b/harnessiq/cli/main.py
@@ -13,9 +13,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     from harnessiq.cli.linkedin import register_linkedin_commands
     from harnessiq.cli.exa_outreach import register_exa_outreach_commands
+    from harnessiq.cli.instagram import register_instagram_commands
 
     register_linkedin_commands(subparsers)
     register_exa_outreach_commands(subparsers)
+    register_instagram_commands(subparsers)
     return parser
 
 

--- a/harnessiq/integrations/instagram_playwright.py
+++ b/harnessiq/integrations/instagram_playwright.py
@@ -1,0 +1,203 @@
+"""Playwright-backed deterministic search backend for the Instagram discovery agent."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
+
+from harnessiq.shared.instagram import (
+    InstagramLeadRecord,
+    InstagramSearchBackend,
+    InstagramSearchExecution,
+    InstagramSearchRecord,
+    build_instagram_google_query,
+    extract_emails,
+)
+
+_GOOGLE_SEARCH_URL = "https://www.google.com/search"
+_DEFAULT_TIMEOUT_MS = 30_000
+_NETWORK_IDLE_TIMEOUT_MS = 5_000
+
+
+class PlaywrightInstagramSearchBackend:
+    """Deterministic Google-to-Instagram search executor using Playwright."""
+
+    def __init__(
+        self,
+        *,
+        session_dir: str | Path | None = None,
+        headless: bool = True,
+        channel: str = "chrome",
+        timeout_ms: int = _DEFAULT_TIMEOUT_MS,
+        network_idle_timeout_ms: int = _NETWORK_IDLE_TIMEOUT_MS,
+    ) -> None:
+        self._session_dir = Path(session_dir) if session_dir else None
+        self._headless = headless
+        self._channel = channel
+        self._timeout_ms = timeout_ms
+        self._network_idle_timeout_ms = network_idle_timeout_ms
+
+    def search_keyword(self, *, keyword: str, max_results: int) -> InstagramSearchExecution:
+        query = build_instagram_google_query(keyword)
+        search_url = f"{_GOOGLE_SEARCH_URL}?q={quote_plus(query)}"
+
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise RuntimeError(
+                "playwright is required for instagram search.\n"
+                "Install with: pip install playwright && python -m playwright install chromium"
+            ) from exc
+
+        with sync_playwright() as playwright:
+            if self._session_dir is not None:
+                self._session_dir.mkdir(parents=True, exist_ok=True)
+                context = playwright.chromium.launch_persistent_context(
+                    str(self._session_dir),
+                    channel=self._channel,
+                    headless=self._headless,
+                    viewport={"width": 1280, "height": 900},
+                )
+                browser = None
+            else:
+                browser = playwright.chromium.launch(channel=self._channel, headless=self._headless)
+                context = browser.new_context(viewport={"width": 1280, "height": 900})
+
+            try:
+                search_page = context.pages[0] if context.pages else context.new_page()
+                search_page.goto(search_url, wait_until="domcontentloaded", timeout=self._timeout_ms)
+                self._wait_for_page_ready(search_page)
+
+                candidate_urls = self._extract_instagram_urls(search_page, max_results=max_results)
+                visited_urls: list[str] = []
+                leads: list[InstagramLeadRecord] = []
+
+                for url in candidate_urls:
+                    detail_page = context.new_page()
+                    try:
+                        detail_page.goto(url, wait_until="domcontentloaded", timeout=self._timeout_ms)
+                        self._wait_for_page_ready(detail_page)
+                        visited_urls.append(detail_page.url)
+                        text = self._read_page_text(detail_page)
+                        emails = extract_emails(text)
+                        if not emails:
+                            continue
+                        leads.append(
+                            InstagramLeadRecord(
+                                source_url=detail_page.url,
+                                source_keyword=keyword,
+                                found_at=_utcnow(),
+                                emails=tuple(emails),
+                                title=self._safe_title(detail_page),
+                                snippet=text[:500].strip(),
+                            )
+                        )
+                    finally:
+                        detail_page.close()
+
+                email_count = sum(len(lead.emails) for lead in leads)
+                search_record = InstagramSearchRecord(
+                    keyword=keyword,
+                    query=query,
+                    searched_at=_utcnow(),
+                    visited_urls=tuple(visited_urls),
+                    lead_count=len(leads),
+                    email_count=email_count,
+                )
+                return InstagramSearchExecution(search_record=search_record, leads=tuple(leads))
+            finally:
+                context.close()
+                if browser is not None:
+                    browser.close()
+
+    def _wait_for_page_ready(self, page: Any) -> None:
+        page.wait_for_load_state("domcontentloaded", timeout=self._timeout_ms)
+        page.wait_for_load_state("load", timeout=self._timeout_ms)
+        try:
+            page.wait_for_load_state("networkidle", timeout=self._network_idle_timeout_ms)
+        except Exception:
+            pass
+
+    def _extract_instagram_urls(self, page: Any, *, max_results: int) -> list[str]:
+        raw_entries = page.eval_on_selector_all(
+            "a[href]",
+            """
+            elements => elements.map(element => ({
+                href: element.getAttribute('href') || '',
+                text: (element.innerText || '').trim()
+            }))
+            """,
+        )
+        result: list[str] = []
+        for entry in raw_entries:
+            normalized = _normalize_candidate_url(str(entry.get("href", "")), base_url=page.url)
+            if normalized is None or normalized in result:
+                continue
+            result.append(normalized)
+            if len(result) >= max_results:
+                break
+        return result
+
+    def _read_page_text(self, page: Any) -> str:
+        try:
+            return str(page.inner_text("body"))
+        except Exception:
+            return str(page.content())
+
+    def _safe_title(self, page: Any) -> str:
+        try:
+            return str(page.title()).strip()
+        except Exception:
+            return ""
+
+
+def create_search_backend() -> InstagramSearchBackend:
+    """Factory for CLI usage via --search-backend-factory."""
+    session_dir_env = os.environ.get("HARNESSIQ_INSTAGRAM_SESSION_DIR", "").strip()
+    channel = os.environ.get("HARNESSIQ_INSTAGRAM_BROWSER_CHANNEL", "chrome").strip() or "chrome"
+    headless = _parse_bool(os.environ.get("HARNESSIQ_INSTAGRAM_HEADLESS"), default=True)
+    session_dir = Path(session_dir_env) if session_dir_env else None
+    return PlaywrightInstagramSearchBackend(
+        session_dir=session_dir,
+        channel=channel,
+        headless=headless,
+    )
+
+
+def _normalize_candidate_url(raw_url: str, *, base_url: str) -> str | None:
+    candidate = raw_url.strip()
+    if not candidate:
+        return None
+    if candidate.startswith("/url?"):
+        query_payload = parse_qs(urlparse(candidate).query)
+        candidate = str(query_payload.get("q", [""])[0]).strip()
+    candidate = urljoin(base_url, candidate)
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if "instagram.com" not in parsed.netloc.lower():
+        return None
+    return parsed._replace(fragment="").geturl()
+
+
+def _parse_bool(value: str | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if not normalized:
+        return default
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Unsupported boolean value '{value}'.")
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+__all__ = ["PlaywrightInstagramSearchBackend", "create_search_backend"]

--- a/harnessiq/shared/instagram.py
+++ b/harnessiq/shared/instagram.py
@@ -1,0 +1,470 @@
+"""Shared data models, memory store, and runtime helpers for Instagram discovery."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, Sequence, runtime_checkable
+
+from harnessiq.shared.agents import DEFAULT_AGENT_MAX_TOKENS, DEFAULT_AGENT_RESET_THRESHOLD
+
+ICP_PROFILES_FILENAME = "icp_profiles.json"
+SEARCH_HISTORY_FILENAME = "search_history.json"
+LEAD_DATABASE_FILENAME = "lead_database.json"
+RUNTIME_PARAMETERS_FILENAME = "runtime_parameters.json"
+AGENT_IDENTITY_FILENAME = "agent_identity.txt"
+ADDITIONAL_PROMPT_FILENAME = "additional_prompt.txt"
+
+DEFAULT_RECENT_SEARCH_WINDOW = 10
+DEFAULT_RECENT_RESULT_WINDOW = 10
+DEFAULT_SEARCH_RESULT_LIMIT = 5
+
+DEFAULT_AGENT_IDENTITY = (
+    "A deterministic Instagram creator discovery agent that turns ICP descriptions into concise "
+    "Google search keywords, runs targeted site:instagram.com searches, extracts public emails from "
+    "loaded pages, and persists every verified discovery to durable memory."
+)
+
+_EMAIL_PATTERN = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramKeywordAgentConfig:
+    """Runtime configuration for the Instagram keyword discovery agent."""
+
+    memory_path: Path
+    max_tokens: int = DEFAULT_AGENT_MAX_TOKENS
+    reset_threshold: float = DEFAULT_AGENT_RESET_THRESHOLD
+    recent_search_window: int = DEFAULT_RECENT_SEARCH_WINDOW
+    recent_result_window: int = DEFAULT_RECENT_RESULT_WINDOW
+    search_result_limit: int = DEFAULT_SEARCH_RESULT_LIMIT
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "memory_path", Path(self.memory_path))
+        if self.recent_search_window <= 0:
+            raise ValueError("recent_search_window must be positive.")
+        if self.recent_result_window <= 0:
+            raise ValueError("recent_result_window must be positive.")
+        if self.search_result_limit <= 0:
+            raise ValueError("search_result_limit must be positive.")
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramLeadRecord:
+    """Canonical persisted record for a discovered Instagram lead."""
+
+    source_url: str
+    source_keyword: str
+    found_at: str
+    emails: tuple[str, ...]
+    title: str = ""
+    snippet: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_url", self.source_url.strip())
+        object.__setattr__(self, "source_keyword", self.source_keyword.strip())
+        object.__setattr__(self, "title", self.title.strip())
+        object.__setattr__(self, "snippet", self.snippet.strip())
+        object.__setattr__(self, "emails", tuple(_dedupe_emails(self.emails)))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "emails": list(self.emails),
+            "found_at": self.found_at,
+            "snippet": self.snippet,
+            "source_keyword": self.source_keyword,
+            "source_url": self.source_url,
+            "title": self.title,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "InstagramLeadRecord":
+        return cls(
+            source_url=str(data["source_url"]),
+            source_keyword=str(data.get("source_keyword", "")),
+            found_at=str(data["found_at"]),
+            emails=tuple(str(value) for value in data.get("emails", ())),
+            title=str(data.get("title", "")),
+            snippet=str(data.get("snippet", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramSearchRecord:
+    """Summary of one deterministic keyword search execution."""
+
+    keyword: str
+    query: str
+    searched_at: str
+    visited_urls: tuple[str, ...] = ()
+    lead_count: int = 0
+    email_count: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "keyword", self.keyword.strip())
+        object.__setattr__(self, "query", self.query.strip())
+        object.__setattr__(self, "visited_urls", tuple(_dedupe_strings(self.visited_urls)))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "email_count": self.email_count,
+            "keyword": self.keyword,
+            "lead_count": self.lead_count,
+            "query": self.query,
+            "searched_at": self.searched_at,
+            "visited_urls": list(self.visited_urls),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "InstagramSearchRecord":
+        return cls(
+            keyword=str(data["keyword"]),
+            query=str(data["query"]),
+            searched_at=str(data["searched_at"]),
+            visited_urls=tuple(str(value) for value in data.get("visited_urls", ())),
+            lead_count=int(data.get("lead_count", 0)),
+            email_count=int(data.get("email_count", 0)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramLeadDatabase:
+    """Canonical persisted lead/email store."""
+
+    leads: tuple[InstagramLeadRecord, ...] = ()
+    emails: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "emails": list(self.emails),
+            "leads": [lead.as_dict() for lead in self.leads],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "InstagramLeadDatabase":
+        return cls(
+            leads=tuple(InstagramLeadRecord.from_dict(item) for item in data.get("leads", ())),
+            emails=tuple(str(value) for value in data.get("emails", ())),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LeadMergeSummary:
+    """Summary payload returned after canonical lead persistence."""
+
+    new_emails: int
+    new_leads: int
+    total_emails: int
+    total_leads: int
+    updated_leads: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "new_emails": self.new_emails,
+            "new_leads": self.new_leads,
+            "total_emails": self.total_emails,
+            "total_leads": self.total_leads,
+            "updated_leads": self.updated_leads,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramSearchExecution:
+    """Output returned by a deterministic browser-backed search backend."""
+
+    search_record: InstagramSearchRecord
+    leads: tuple[InstagramLeadRecord, ...] = ()
+
+
+@runtime_checkable
+class InstagramSearchBackend(Protocol):
+    """Deterministic backend that executes one keyword search and extracts leads."""
+
+    def search_keyword(self, *, keyword: str, max_results: int) -> InstagramSearchExecution:
+        """Execute a keyword search and return the summary payload."""
+        ...
+
+
+@dataclass(slots=True)
+class InstagramMemoryStore:
+    """Manage durable state files used by the Instagram discovery harness."""
+
+    memory_path: Path
+
+    def __post_init__(self) -> None:
+        self.memory_path = Path(self.memory_path)
+
+    @property
+    def icp_profiles_path(self) -> Path:
+        return self.memory_path / ICP_PROFILES_FILENAME
+
+    @property
+    def search_history_path(self) -> Path:
+        return self.memory_path / SEARCH_HISTORY_FILENAME
+
+    @property
+    def lead_database_path(self) -> Path:
+        return self.memory_path / LEAD_DATABASE_FILENAME
+
+    @property
+    def runtime_parameters_path(self) -> Path:
+        return self.memory_path / RUNTIME_PARAMETERS_FILENAME
+
+    @property
+    def agent_identity_path(self) -> Path:
+        return self.memory_path / AGENT_IDENTITY_FILENAME
+
+    @property
+    def additional_prompt_path(self) -> Path:
+        return self.memory_path / ADDITIONAL_PROMPT_FILENAME
+
+    def prepare(self) -> None:
+        self.memory_path.mkdir(parents=True, exist_ok=True)
+        _ensure_json_file(self.icp_profiles_path, [])
+        _ensure_json_file(self.search_history_path, [])
+        _ensure_json_file(self.lead_database_path, InstagramLeadDatabase().as_dict())
+        _ensure_json_file(self.runtime_parameters_path, {})
+        _ensure_text_file(self.agent_identity_path, DEFAULT_AGENT_IDENTITY)
+        _ensure_text_file(self.additional_prompt_path, "")
+
+    def read_icp_profiles(self) -> list[str]:
+        payload = _read_json_file(self.icp_profiles_path, expected_type=list)
+        return [str(value).strip() for value in payload if str(value).strip()]
+
+    def write_icp_profiles(self, profiles: Sequence[str]) -> None:
+        cleaned = [value.strip() for value in profiles if value and value.strip()]
+        _write_json(self.icp_profiles_path, cleaned)
+
+    def read_search_history(self) -> list[InstagramSearchRecord]:
+        payload = _read_json_file(self.search_history_path, expected_type=list)
+        return [InstagramSearchRecord.from_dict(item) for item in payload]
+
+    def read_recent_searches(self, limit: int) -> list[InstagramSearchRecord]:
+        return self.read_search_history()[-limit:]
+
+    def append_search(self, record: InstagramSearchRecord) -> None:
+        history = self.read_search_history()
+        history.append(record)
+        _write_json(self.search_history_path, [item.as_dict() for item in history])
+
+    def has_searched(self, keyword: str) -> bool:
+        normalized_keyword = keyword.strip().lower()
+        if not normalized_keyword:
+            return False
+        return any(record.keyword.lower() == normalized_keyword for record in self.read_search_history())
+
+    def read_lead_database(self) -> InstagramLeadDatabase:
+        payload = _read_json_file(self.lead_database_path, expected_type=dict)
+        return InstagramLeadDatabase.from_dict(payload)
+
+    def read_recent_leads(self, limit: int) -> list[InstagramLeadRecord]:
+        database = self.read_lead_database()
+        return list(database.leads[-limit:])
+
+    def merge_leads(self, leads: Sequence[InstagramLeadRecord]) -> LeadMergeSummary:
+        database = self.read_lead_database()
+        lead_index = {lead.source_url: lead for lead in database.leads}
+        email_set = {email.lower() for email in database.emails}
+
+        new_leads = 0
+        updated_leads = 0
+        new_emails = 0
+
+        for lead in leads:
+            existing = lead_index.get(lead.source_url)
+            if existing is None:
+                lead_index[lead.source_url] = lead
+                new_leads += 1
+            else:
+                merged_record = InstagramLeadRecord(
+                    source_url=existing.source_url,
+                    source_keyword=existing.source_keyword or lead.source_keyword,
+                    found_at=existing.found_at,
+                    emails=tuple(_dedupe_emails((*existing.emails, *lead.emails))),
+                    title=existing.title or lead.title,
+                    snippet=existing.snippet or lead.snippet,
+                )
+                if merged_record != existing:
+                    lead_index[lead.source_url] = merged_record
+                    updated_leads += 1
+
+            for email in lead.emails:
+                normalized_email = email.lower()
+                if normalized_email not in email_set:
+                    email_set.add(normalized_email)
+                    new_emails += 1
+
+        persisted_emails = tuple(sorted(email_set))
+        persisted_leads = tuple(sorted(lead_index.values(), key=lambda item: (item.found_at, item.source_url)))
+        _write_json(
+            self.lead_database_path,
+            InstagramLeadDatabase(leads=persisted_leads, emails=persisted_emails).as_dict(),
+        )
+        return LeadMergeSummary(
+            new_emails=new_emails,
+            new_leads=new_leads,
+            total_emails=len(persisted_emails),
+            total_leads=len(persisted_leads),
+            updated_leads=updated_leads,
+        )
+
+    def get_emails(self) -> list[str]:
+        return list(self.read_lead_database().emails)
+
+    def get_leads(self) -> list[InstagramLeadRecord]:
+        return list(self.read_lead_database().leads)
+
+    def read_runtime_parameters(self) -> dict[str, Any]:
+        return _read_json_file(self.runtime_parameters_path, expected_type=dict)
+
+    def write_runtime_parameters(self, parameters: dict[str, Any]) -> None:
+        _write_json(self.runtime_parameters_path, parameters)
+
+    def read_agent_identity(self) -> str:
+        return self.agent_identity_path.read_text(encoding="utf-8").strip()
+
+    def write_agent_identity(self, text: str) -> None:
+        _write_text(self.agent_identity_path, text)
+
+    def read_additional_prompt(self) -> str:
+        return self.additional_prompt_path.read_text(encoding="utf-8").strip()
+
+    def write_additional_prompt(self, text: str) -> None:
+        _write_text(self.additional_prompt_path, text)
+
+
+def build_instagram_google_query(keyword: str) -> str:
+    """Build the canonical Google search query for one keyword."""
+    cleaned_keyword = keyword.strip()
+    if not cleaned_keyword:
+        raise ValueError("keyword must not be blank.")
+    return f'site:instagram.com "@gmail.com" "{cleaned_keyword}"'
+
+
+def extract_emails(text: str) -> list[str]:
+    """Return unique normalized email addresses from a text blob."""
+    if not text:
+        return []
+    return _dedupe_emails(_EMAIL_PATTERN.findall(text))
+
+
+def normalize_instagram_runtime_parameters(parameters: dict[str, Any]) -> dict[str, Any]:
+    """Validate and type-coerce runtime parameters for the Instagram agent."""
+    normalized: dict[str, Any] = {}
+    coercers = {
+        "max_tokens": _coerce_int,
+        "recent_result_window": _coerce_int,
+        "recent_search_window": _coerce_int,
+        "reset_threshold": _coerce_float,
+        "search_result_limit": _coerce_int,
+    }
+    for key, value in parameters.items():
+        if key not in coercers:
+            supported = ", ".join(sorted(coercers))
+            raise ValueError(
+                f"Unsupported instagram runtime parameter '{key}'. Supported: {supported}."
+            )
+        normalized[key] = coercers[key](value)
+    return normalized
+
+
+def _coerce_int(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("Boolean values are not valid integer runtime parameters.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        return int(value)
+    raise ValueError("Runtime parameter must be an integer.")
+
+
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, bool):
+        raise ValueError("Boolean values are not valid float runtime parameters.")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        return float(value)
+    raise ValueError("Runtime parameter must be a float.")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    rendered = text if not text or text.endswith("\n") else f"{text}\n"
+    path.write_text(rendered, encoding="utf-8")
+
+
+def _ensure_json_file(path: Path, default_payload: Any) -> None:
+    if not path.exists():
+        _write_json(path, default_payload)
+
+
+def _ensure_text_file(path: Path, default_content: str) -> None:
+    if not path.exists():
+        _write_text(path, default_content)
+
+
+def _read_json_file(path: Path, *, expected_type: type) -> Any:
+    if not path.exists():
+        return expected_type()
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return expected_type()
+    payload = json.loads(raw)
+    if not isinstance(payload, expected_type):
+        raise ValueError(f"Expected JSON {expected_type.__name__} in '{path.name}'.")
+    return payload
+
+
+def _dedupe_emails(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = value.strip().strip(".,;:!?()[]{}<>\"'").lower()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _dedupe_strings(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+__all__ = [
+    "ADDITIONAL_PROMPT_FILENAME",
+    "AGENT_IDENTITY_FILENAME",
+    "DEFAULT_AGENT_IDENTITY",
+    "DEFAULT_RECENT_RESULT_WINDOW",
+    "DEFAULT_RECENT_SEARCH_WINDOW",
+    "DEFAULT_SEARCH_RESULT_LIMIT",
+    "ICP_PROFILES_FILENAME",
+    "InstagramKeywordAgentConfig",
+    "InstagramLeadDatabase",
+    "InstagramLeadRecord",
+    "InstagramMemoryStore",
+    "InstagramSearchBackend",
+    "InstagramSearchExecution",
+    "InstagramSearchRecord",
+    "LEAD_DATABASE_FILENAME",
+    "LeadMergeSummary",
+    "RUNTIME_PARAMETERS_FILENAME",
+    "SEARCH_HISTORY_FILENAME",
+    "build_instagram_google_query",
+    "extract_emails",
+    "normalize_instagram_runtime_parameters",
+]

--- a/memory/new-icp-keyword-agent/clarifications.md
+++ b/memory/new-icp-keyword-agent/clarifications.md
@@ -1,0 +1,9 @@
+No blocking user clarifications are required after Phase 1.
+
+Implementation assumptions chosen to keep the task additive and consistent with repo patterns:
+
+1. The new agent domain will be `instagram`, with a concrete SDK harness focused on deriving keyword searches from persisted ICP descriptions and executing deterministic Google `site:instagram.com` searches.
+2. ICP input will be persisted as a list of strings in agent memory and exposed through both SDK construction parameters and CLI configuration.
+3. Browser work will be executed through a new Playwright-backed integration with explicit load waits for the search page and each opened result tab before extraction.
+4. Canonical persistent state will include a durable JSON file for discovered leads/emails, plus JSON search-history state used to populate the context window.
+5. The SDK/CLI `get-emails` surface will return persisted discovered emails across runs; per-run filtering can be added later without changing the base storage contract.

--- a/memory/new-icp-keyword-agent/internalization.md
+++ b/memory/new-icp-keyword-agent/internalization.md
@@ -1,0 +1,143 @@
+### 1a: Structural Survey
+
+Repository shape:
+
+- `harnessiq/` is the shipped SDK package. It is organized around agent harnesses, shared runtime/data models, CLI entrypoints, provider-backed tools, integrations, and utilities.
+- `harnessiq/agents/` contains the abstract runtime (`base/agent.py`) plus concrete harnesses:
+  - `linkedin/agent.py`: the strongest example of a durable-memory browser agent with CLI-backed persisted configuration and injectable browser runtime handlers.
+  - `exa_outreach/agent.py`: the strongest example of deterministic event logging into JSON run files plus internal tool handlers that persist leads/emails regardless of model behavior.
+  - `knowt/agent.py` and `email/agent.py`: narrower examples of prompt-driven harnesses built on the same `BaseAgent`.
+- `harnessiq/shared/` contains dataclasses, config normalization, filenames, and memory-store helpers that concrete agents depend on. `shared/exa_outreach.py` and `shared/linkedin.py` are the closest patterns for this task.
+- `harnessiq/cli/` contains the root argparse entrypoint plus agent-specific command modules. Each concrete agent has its own command registration module and typically supports `prepare`, `configure`, `show`, and `run`.
+- `harnessiq/integrations/` contains runtime bridges such as the Playwright-backed LinkedIn browser session and model adapters. Browser automation is not global today; it is injected per agent through integration code.
+- `harnessiq/tools/` and `harnessiq/toolset/` provide the deterministic tool runtime layer. `ToolRegistry` is the canonical in-memory execution/validation surface for local tools.
+- `harnessiq/utils/` contains reusable persistence helpers including agent-instance resolution (`agent_instances.py`) and run-event storage (`run_storage.py`).
+- `tests/` is broad and mostly unit-style. Existing test coverage asserts SDK exports, CLI registration, agent parameter ordering, memory persistence, and tool behavior.
+- `docs/` and `README.md` describe the public runtime and CLI contracts and are expected to be kept in sync with new agent surfaces.
+- `artifacts/file_index.md` is the architectural reference for top-level layout and conventions.
+
+Technology and runtime conventions:
+
+- Language/runtime: Python 3.11+, setuptools packaging, pytest/unittest mixed test suite.
+- Agent architecture: concrete agents inherit `BaseAgent`, implement `build_system_prompt()` and `load_parameter_sections()`, optionally `prepare()`, and usually inject a `ToolRegistry`.
+- Context-window ordering is fixed by `BaseAgent`: system prompt, then parameter sections in the order returned by `load_parameter_sections()`, then transcript entries.
+- Durable memory is file-backed under a per-agent memory folder. CLI flows typically persist configuration to files and reconstruct runtime state through a memory-store abstraction.
+- Deterministic persistence is preferred when model recall would be lossy. `ExaOutreachAgent` logs events inside tool handlers; `LinkedInJobApplierAgent` persists append-only records plus recent semantic actions.
+- Browser automation is currently agent-specific. `integrations/linkedin_playwright.py` owns session lifecycle and tool handlers and uses persistent browser profiles under agent memory.
+- Packaging/public surface is curated explicitly through `harnessiq/__init__.py`, `harnessiq/agents/__init__.py`, CLI command registration, and tests like `tests/test_sdk_package.py`.
+
+Observed conventions and relevant inconsistencies:
+
+- Agent-specific shared models live in `harnessiq/shared/<domain>.py`; agent package `__init__.py` files re-export the concrete harness.
+- CLI naming is domain-based (`linkedin`, `outreach`), not class-name based.
+- Browser tooling is exposed as concrete tool definitions plus a separate integration that wires runtime handlers; there is no general reusable browser abstraction yet.
+- `BaseAgent` only refreshes parameter sections at start/reset. If a task requires parameter sections to reflect newly persisted state during an active run, the concrete agent must explicitly refresh after tool execution or use compaction.
+- The repository is currently in a dirty state with many unrelated tracked and untracked changes, so this task must avoid broad refactors or cleanup outside its own blast radius.
+
+### 1b: Task Cross-Reference
+
+User request, mapped to codebase:
+
+1. "Create a new agent ... input should be a list of descriptions of ICPs"
+- Requires a new concrete harness under `harnessiq/agents/`.
+- Requires a new shared memory/config module under `harnessiq/shared/`.
+- Requires CLI configure/show/run commands to persist and reload ICP lists.
+
+2. "come up with keywords for the search"
+- The new harness system prompt and tool surface must steer the model to derive keywords from persisted ICP descriptions.
+- For determinism, the actual search execution should be handled by code, not by free-form browser manipulation alone.
+
+3. "more deterministic"
+- Strongly points to the `ExaOutreachAgent` pattern: high-level deterministic tool handlers that perform persistence immediately.
+- Also points to a narrow browser/search integration rather than exposing a wide browser tool surface and hoping the model uses it consistently.
+
+4. "context window should be the system prompt, icp, then recent searches"
+- Requires `load_parameter_sections()` to order sections as ICPs first, recent searches second.
+- Because `BaseAgent` always appends transcript after parameter sections, the authoritative durable ordering can be satisfied, but a concrete agent may need to refresh sections after search tools run.
+
+5. "After it searches and gets results, the context window should be the same with the appended search results"
+- Requires an additional parameter section for recent/persisted search results.
+- Because `BaseAgent` does not automatically reload parameters after every tool call, the new agent likely needs a targeted override around tool execution to call `refresh_parameters()` after memory-mutating tools complete.
+
+6. "The leads/emails that it finds should be stored in its memory in a json file"
+- Requires a durable JSON memory file for canonical leads/emails, likely alongside agent config files.
+- `harnessiq/utils/run_storage.py` is relevant if per-run JSON event logs are also desirable, but the user specifically asked for persistent JSON memory, so a top-level canonical JSON file is needed.
+
+7. "Make sure that when the agent loads the browser/tabs the content is fully loaded"
+- Requires a new Playwright-backed integration under `harnessiq/integrations/`.
+- Existing reference: `integrations/linkedin_playwright.py`, especially its session lifecycle and page interaction patterns.
+- The new integration should explicitly wait for load completion for both the search results page and opened result tabs/pages.
+
+8. "functions to get emails exposed in the sdk/cli after the user runs the agent"
+- Requires SDK-level methods on the agent and/or memory store, plus public exports in `harnessiq/agents/__init__.py`.
+- Requires CLI commands, likely a new `get-emails` subcommand under the new agent domain.
+
+9. "emails gotten should persist after running the agent in its memory"
+- Requires the CLI `run` path to use the persisted memory folder and not transient in-memory state.
+- Favors a `from_memory(...)` constructor pattern similar to `LinkedInJobApplierAgent`.
+
+10. "build this agent into the sdk and cli of our repo"
+- Requires updating:
+  - `harnessiq/agents/`
+  - `harnessiq/cli/main.py`
+  - agent/domain-specific CLI package
+  - `harnessiq/__init__.py` or other public export points if needed
+  - README/docs/tests
+
+11. "replicate ... just the instagram keyword part"
+- Scope is limited to: derive keyword(s), execute Google `site:instagram.com`-style searches, extract emails from discovered pages/content, and persist them.
+- Out of scope unless later requested: email verification, sending, campaign orchestration, pricing negotiation, attribution/tracking, or ad-spend logic.
+
+Primary files/modules likely affected:
+
+- New:
+  - `harnessiq/agents/<new_agent>/__init__.py`
+  - `harnessiq/agents/<new_agent>/agent.py`
+  - `harnessiq/agents/<new_agent>/prompts/master_prompt.md`
+  - `harnessiq/shared/<new_agent>.py`
+  - `harnessiq/cli/<new_agent>/__init__.py`
+  - `harnessiq/cli/<new_agent>/commands.py`
+  - `harnessiq/integrations/<new_agent>_playwright.py`
+  - `tests/test_<new_agent>_agent.py`
+  - `tests/test_<new_agent>_cli.py`
+- Existing:
+  - `harnessiq/agents/__init__.py`
+  - `harnessiq/cli/main.py`
+  - `harnessiq/shared/tools.py` if new internal tool-key constants are added
+  - `harnessiq/__init__.py` only if top-level export policy changes
+  - `README.md`
+  - `artifacts/file_index.md`
+  - potentially `tests/test_sdk_package.py`
+
+Blast radius:
+
+- Moderate. This is a net-new agent plus CLI command and integration, but it touches core package exports and public docs.
+- The cleanest implementation path is additive and should avoid modifying unrelated existing agent behavior.
+
+### 1c: Assumption & Risk Inventory
+
+Assumptions I can likely resolve locally:
+
+- The new agent should follow existing domain-command naming conventions, so a new root CLI namespace is appropriate rather than overloading `outreach`.
+- The ICP input can be stored as a persisted list of strings in the agent memory folder.
+- The "get emails" surface should read from persisted memory, not from the last in-process run object only.
+- "Just the instagram keyword part" excludes the downstream verification/email-sending workflow.
+
+Material implementation risks:
+
+- Search backend ambiguity: the request references Google search syntax and browser tabs, but the repo has no existing generic Google-search browser harness. A new Playwright integration is required and must be designed carefully to avoid a brittle wide-open browser tool surface.
+- Context refresh gap: `BaseAgent` does not automatically reload parameter sections after tool handlers mutate memory. Without a deliberate refresh step, appended search results would not appear in parameter sections until a reset or next run.
+- Load-state correctness: Playwright `goto()` completion alone is not enough for the user requirement. The integration must explicitly wait for the document and any opened result tabs to be fully usable before extraction.
+- Output-shape ambiguity: the user asked for "leads/emails" in JSON memory. The exact schema is not predefined in the repo, so the new shared module must define one that supports dedupe, provenance, and retrieval cleanly.
+- SDK/CLI persistence contract: if the new CLI `run` path reconstructs the agent incorrectly, emails may persist in run-local files but not in the canonical memory JSON required by the user.
+- Dirty worktree risk: several core files already contain unrelated changes. Touch points like `harnessiq/agents/__init__.py`, `harnessiq/__init__.py`, and `README.md` need careful read-modify-write edits to avoid clobbering existing user work.
+- GitHub issue / PR workflow risk from the requested skill: the skill mandates `gh` issue/PR creation, but this environment has restricted network access, so those steps may be impossible to complete locally even if the code work is completed.
+
+Open design choices I may still need to lock down before implementation:
+
+- Final agent/domain naming (`instagram`, `instagram_keyword`, `instagram_leads`, etc.).
+- Whether CLI ICP input should be repeated `--icp` flags, JSON file import, or both.
+- Whether `get-emails` should default to all persisted unique emails or expose both all-time and per-run modes.
+- Whether canonical persisted state should be a single JSON file or a small set of JSON files (preferred for clarity if the schema is non-trivial).
+
+Phase 1 complete.

--- a/memory/new-icp-keyword-agent/tickets/index.md
+++ b/memory/new-icp-keyword-agent/tickets/index.md
@@ -1,0 +1,18 @@
+1. Ticket 1: Add Instagram discovery memory models and persistence
+   One-line description: define the durable on-disk schema for ICPs, recent searches, and canonical lead/email records.
+   Issue URL: blocked in local environment; `gh issue create` cannot reach GitHub from this sandbox.
+   Local status: implemented and verified locally.
+
+2. Ticket 2: Add deterministic Instagram discovery agent and Playwright search integration
+   One-line description: implement the new agent harness, high-level deterministic search tool, parameter refresh behavior, and browser load guarantees.
+   Issue URL: blocked in local environment; `gh issue create` cannot reach GitHub from this sandbox.
+   Local status: implemented and verified locally.
+
+3. Ticket 3: Add SDK/CLI/public-surface wiring, documentation, and tests
+   One-line description: expose the new agent across package exports, CLI commands, retrieval functions, and repository documentation with verification coverage.
+   Issue URL: blocked in local environment; `gh issue create` cannot reach GitHub from this sandbox.
+   Local status: implemented and verified locally.
+
+Phase 3a complete.
+
+Phase 3 complete with a GitHub issue creation blocker: `gh issue list` failed because this environment cannot open outbound connections to `api.github.com`.

--- a/memory/new-icp-keyword-agent/tickets/ticket-1-critique.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-1-critique.md
@@ -1,0 +1,10 @@
+Self-critique findings:
+
+- The most likely long-term risk was schema drift between persisted leads and the retrieval surface. I kept a single canonical `lead_database.json` contract and derived `get_emails()` from it to avoid dual-write drift.
+- Search history and canonical lead state are separated so recent-search context can stay compact without losing the all-time email list.
+- The memory-store API is intentionally narrow; adding downstream outreach or verification state later should happen in separate files rather than overloading the current lead schema.
+
+Post-critique changes made:
+
+- Kept the persisted lead/email contract centralized in `InstagramLeadDatabase`.
+- Ensured runtime parameter normalization is explicit and rejects unknown keys.

--- a/memory/new-icp-keyword-agent/tickets/ticket-1-quality.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-1-quality.md
@@ -1,0 +1,17 @@
+Stage 1 — Static Analysis:
+- No project linter is configured in this environment. Applied existing repository style manually while implementing the new shared Instagram memory module.
+
+Stage 2 — Type Checking:
+- No project type checker is configured in this environment. Added explicit annotations across the new shared dataclasses, protocol, and memory-store methods.
+
+Stage 3 — Unit Tests:
+- Verified with:
+  - `python -m unittest tests.test_instagram_agent`
+
+Stage 4 — Integration & Contract Tests:
+- Verified with:
+  - `python -m unittest tests.test_instagram_playwright`
+
+Stage 5 — Smoke & Manual Verification:
+- Confirmed the new shared memory contract produces persisted `icp_profiles.json`, `search_history.json`, `lead_database.json`, and `runtime_parameters.json` files in temporary test directories.
+- Confirmed canonical persisted emails are deduped and retrievable from the memory store.

--- a/memory/new-icp-keyword-agent/tickets/ticket-1.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-1.md
@@ -1,0 +1,44 @@
+Title: Add Instagram discovery memory models and persistence
+
+Issue URL:
+Blocked in local environment. `gh` cannot reach GitHub from this sandbox.
+
+Intent:
+Define a durable, explicit memory contract for the new Instagram keyword-discovery agent so ICP inputs, recent searches, search results, and canonical lead/email records survive across runs and can be re-injected into the context window deterministically.
+
+Scope:
+- Create a new shared module for the Instagram discovery domain.
+- Define persisted filenames, dataclasses, and memory-store helpers for ICPs, search history, and leads/emails.
+- Define canonical read/write/query helpers that the agent and CLI can share.
+- Keep persistence additive; do not refactor existing agent memory stores.
+
+Relevant Files:
+- `harnessiq/shared/instagram.py`: new shared dataclasses, filenames, runtime normalization, and memory-store implementation.
+- `harnessiq/utils/run_storage.py`: reuse only; no changes expected unless a narrow shared helper is required.
+- `tests/test_instagram_agent.py`: coverage for persistence behavior and retrieval semantics.
+
+Approach:
+Follow the established `shared/exa_outreach.py` and `shared/linkedin.py` pattern: define a small memory-store abstraction that owns the on-disk contract, keep files human-readable JSON/text, and provide canonical query helpers such as `read_icp_profiles()`, `append_search()`, `append_leads()`, and `get_emails()`. The canonical lead/email JSON file should support dedupe plus provenance fields such as source keyword and source URL.
+
+Assumptions:
+- ICP descriptions are stored as a list of strings.
+- Recent searches should be bounded in the context window even if the underlying history file stores all searches.
+- Canonical email retrieval should operate over persisted memory, not only per-run files.
+
+Acceptance Criteria:
+- [ ] A new shared Instagram memory module exists with typed dataclasses and a memory-store abstraction.
+- [ ] The memory store creates and reads default files without requiring pre-existing data.
+- [ ] ICP descriptions, search history, and leads/emails persist in JSON files under the agent memory directory.
+- [ ] Canonical helper methods return persisted emails across runs and dedupe duplicates deterministically.
+- [ ] Tests cover default initialization, append/read flows, and email retrieval behavior.
+
+Verification Steps:
+- Run the Instagram agent unit tests that cover the shared memory contract.
+- Confirm newly created memory files are written under a temporary directory during tests.
+- Manually inspect a generated leads/emails JSON payload shape in test assertions if needed.
+
+Dependencies:
+- None.
+
+Drift Guard:
+This ticket must not implement the full agent loop, CLI commands, or Playwright browser automation. Its responsibility ends at defining durable state and the read/write/query contract that later tickets consume.

--- a/memory/new-icp-keyword-agent/tickets/ticket-2-critique.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-2-critique.md
@@ -1,0 +1,10 @@
+Self-critique findings:
+
+- The biggest functional risk was relying on transcript-only tool results instead of refreshing durable parameter sections. The agent now refreshes parameters after the deterministic search tool executes.
+- A wide-open browser tool surface would have made the agent less deterministic. The implementation keeps browser behavior behind one high-level search backend and one high-level tool.
+- Browser lifecycle complexity was reduced by making each search execution self-contained inside the Playwright backend instead of depending on long-lived session teardown hooks in `BaseAgent`.
+
+Post-critique changes made:
+
+- Kept the browser API narrow and deterministic.
+- Added unit coverage for the load-wait helper and Google redirect normalization.

--- a/memory/new-icp-keyword-agent/tickets/ticket-2-quality.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-2-quality.md
@@ -1,0 +1,19 @@
+Stage 1 — Static Analysis:
+- No configured linter in this environment. Reviewed the new agent and Playwright backend for consistency with existing agent/integration patterns.
+
+Stage 2 — Type Checking:
+- No configured type checker in this environment. Added annotations on the new agent constructor, `from_memory`, tool handler, and Playwright backend helpers.
+
+Stage 3 — Unit Tests:
+- Verified with:
+  - `python -m unittest tests.test_instagram_agent`
+
+Stage 4 — Integration & Contract Tests:
+- Verified with:
+  - `python -m unittest tests.test_instagram_playwright`
+  - `python -m compileall harnessiq\\shared\\instagram.py harnessiq\\agents\\instagram harnessiq\\cli\\instagram harnessiq\\integrations\\instagram_playwright.py`
+
+Stage 5 — Smoke & Manual Verification:
+- Confirmed the agent injects parameter sections in the requested order: ICP Profiles, Recent Searches, Recent Search Results.
+- Confirmed search-state mutations refresh parameter sections before the next model turn.
+- Confirmed the Playwright backend explicitly waits for `domcontentloaded`, `load`, and then `networkidle` with fallback tolerance.

--- a/memory/new-icp-keyword-agent/tickets/ticket-2.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-2.md
@@ -1,0 +1,49 @@
+Title: Add deterministic Instagram discovery agent and Playwright search integration
+
+Issue URL:
+Blocked in local environment. `gh` cannot reach GitHub from this sandbox.
+
+Intent:
+Implement the new agent harness so it derives keyword searches from persisted ICPs, executes deterministic Google-to-Instagram search extraction through a Playwright-backed integration, refreshes context parameters after new search results are persisted, and exposes SDK-level retrieval helpers.
+
+Scope:
+- Add the new concrete agent package and prompt.
+- Add a Playwright-backed search integration with explicit page/tab load waits.
+- Add the deterministic internal search tool and any supporting tool-key constants.
+- Add SDK-level accessors for persisted leads/emails.
+- Avoid adding unrelated generic browser frameworks.
+
+Relevant Files:
+- `harnessiq/agents/instagram/__init__.py`: new agent package export.
+- `harnessiq/agents/instagram/agent.py`: new concrete harness implementation.
+- `harnessiq/agents/instagram/prompts/master_prompt.md`: system prompt contract.
+- `harnessiq/integrations/instagram_playwright.py`: deterministic Google/Instagram search executor with load guarantees.
+- `harnessiq/shared/tools.py`: new tool-key constants if needed.
+- `tests/test_instagram_agent.py`: agent behavior, parameter ordering, refresh behavior, and integration seams.
+
+Approach:
+Model the harness after `ExaOutreachAgent` for deterministic tool-driven persistence and after `LinkedInJobApplierAgent` for memory-backed parameter sections and browser/runtime injection. Keep browser interaction high-level and deterministic: one search tool should own query construction, search-page loading, result opening, email extraction, persistence, and dedupe. Override or extend runtime behavior only as needed to refresh parameter sections after search-state mutations so the next cycle sees appended results.
+
+Assumptions:
+- A high-level deterministic search tool is preferable to exposing a wide manual browser tool surface.
+- The agent should own only the Instagram/Google-discovery loop, not downstream verification or email sending.
+- Explicit page/tab load waiting can be enforced inside the Playwright integration without changing `BaseAgent`.
+
+Acceptance Criteria:
+- [ ] A new concrete Instagram discovery agent exists and is runnable from SDK code.
+- [ ] Parameter sections are ordered so ICPs appear before recent searches, and recent search results are available after search-state updates.
+- [ ] The Playwright search integration explicitly waits for fully loaded search pages and opened result tabs before extraction.
+- [ ] Discovered leads/emails are persisted deterministically during tool execution.
+- [ ] The agent exposes SDK-level methods to retrieve persisted emails after runs.
+- [ ] Tests cover parameter ordering, deterministic persistence, and load-wait integration behavior at the unit seam.
+
+Verification Steps:
+- Run targeted Instagram agent tests.
+- Run any integration-mock tests for the Playwright session helpers.
+- Inspect request/parameter ordering in unit tests to confirm the context contract.
+
+Dependencies:
+- Ticket 1.
+
+Drift Guard:
+This ticket must not add CLI commands, top-level command registration, or documentation-only changes beyond what is strictly required for the agent module itself. It also must not broaden into generic web crawling abstractions for the whole repo.

--- a/memory/new-icp-keyword-agent/tickets/ticket-3-critique.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-3-critique.md
@@ -1,0 +1,10 @@
+Self-critique findings:
+
+- The highest-risk export changes were `harnessiq/agents/__init__.py` and `harnessiq/cli/main.py` because the repo already had unrelated edits there. I kept those patches minimal and additive.
+- CLI ergonomics matter here because the user explicitly asked for a post-run email retrieval function. The dedicated `get-emails` subcommand keeps that surface deterministic and memory-backed.
+- README updates were kept focused on the new agent rather than broad documentation churn to avoid conflicting with unrelated in-progress doc edits in the worktree.
+
+Post-critique changes made:
+
+- Added focused CLI coverage for `prepare`, `configure`, `show`, `run`, and `get-emails`.
+- Added package smoke assertions so the new agent is part of the shipped SDK surface.

--- a/memory/new-icp-keyword-agent/tickets/ticket-3-quality.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-3-quality.md
@@ -1,0 +1,19 @@
+Stage 1 — Static Analysis:
+- No configured linter in this environment. Reviewed CLI wiring, README changes, and package exports manually.
+
+Stage 2 — Type Checking:
+- No configured type checker in this environment. Added annotations to the new CLI command module and retained existing parser/factory patterns.
+
+Stage 3 — Unit Tests:
+- Verified with:
+  - `python -m unittest tests.test_instagram_cli`
+  - `python -m unittest tests.test_sdk_package`
+
+Stage 4 — Integration & Contract Tests:
+- Verified with:
+  - `python -m unittest tests.test_agents_base tests.test_linkedin_agent tests.test_linkedin_cli tests.test_sdk_package`
+
+Stage 5 — Smoke & Manual Verification:
+- Confirmed the root CLI now exposes `instagram` and `instagram get-emails`.
+- Confirmed package smoke tests still pass with the new agent exported through `harnessiq.agents`.
+- Confirmed README and `artifacts/file_index.md` describe the new agent/integration surface.

--- a/memory/new-icp-keyword-agent/tickets/ticket-3.md
+++ b/memory/new-icp-keyword-agent/tickets/ticket-3.md
@@ -1,0 +1,52 @@
+Title: Add SDK/CLI/public-surface wiring, documentation, and tests
+
+Issue URL:
+Blocked in local environment. `gh` cannot reach GitHub from this sandbox.
+
+Intent:
+Make the new Instagram discovery agent usable through the shipped package and command line, and document the contract so users can configure the agent, run it, and retrieve persisted emails through supported surfaces.
+
+Scope:
+- Register new CLI commands under the root parser.
+- Expose the new agent and memory store through package exports.
+- Add CLI retrieval commands such as `get-emails`.
+- Update README and architectural artifact references.
+- Extend package/CLI tests.
+
+Relevant Files:
+- `harnessiq/cli/instagram/__init__.py`: new CLI package export.
+- `harnessiq/cli/instagram/commands.py`: new CLI commands.
+- `harnessiq/cli/main.py`: root command registration.
+- `harnessiq/agents/__init__.py`: public SDK export.
+- `harnessiq/__init__.py`: top-level package export if required by existing policy.
+- `README.md`: public usage documentation.
+- `artifacts/file_index.md`: architecture reference update.
+- `tests/test_instagram_cli.py`: CLI coverage.
+- `tests/test_sdk_package.py`: packaging smoke coverage for the new public surface if needed.
+
+Approach:
+Mirror the existing `linkedin` and `outreach` CLI patterns: `prepare`, `configure`, `show`, `run`, plus a new retrieval command for persisted emails. Keep stdout JSON-first for automation. Wire the new agent into exports and documentation additively, then extend tests to lock down the public surface.
+
+Assumptions:
+- The CLI namespace should be `instagram`.
+- `get-emails` should read persisted memory and not require a live agent process.
+- The local environment may block GitHub issue/PR creation, but local code/documentation/test work remains in scope.
+
+Acceptance Criteria:
+- [ ] The root CLI registers the new Instagram command group.
+- [ ] Users can prepare/configure/show/run the agent and retrieve persisted emails through CLI commands.
+- [ ] The SDK public exports include the new agent and memory-store surface.
+- [ ] README and architecture docs mention the new agent accurately.
+- [ ] Tests cover CLI parser registration, run wiring, and persisted email retrieval.
+
+Verification Steps:
+- Run targeted Instagram CLI tests.
+- Run package smoke tests if changes touch package exports.
+- Manually inspect CLI help output and JSON payload shapes in tests where relevant.
+
+Dependencies:
+- Ticket 1.
+- Ticket 2.
+
+Drift Guard:
+This ticket must not redesign existing CLI conventions or rework unrelated package exports. It should wire the new domain into the existing patterns with the minimum necessary surface area.

--- a/tests/test_instagram_agent.py
+++ b/tests/test_instagram_agent.py
@@ -1,0 +1,162 @@
+"""Tests for the Instagram keyword discovery agent."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from harnessiq.agents import (
+    AgentModelRequest,
+    AgentModelResponse,
+    InstagramKeywordDiscoveryAgent,
+    InstagramMemoryStore,
+)
+from harnessiq.shared.instagram import InstagramLeadRecord, InstagramSearchExecution, InstagramSearchRecord
+from harnessiq.shared.tools import ToolCall
+
+
+class _FakeModel:
+    def __init__(self, responses: list[AgentModelResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[AgentModelRequest] = []
+
+    def generate_turn(self, request: AgentModelRequest) -> AgentModelResponse:
+        self.requests.append(request)
+        return self._responses[len(self.requests) - 1]
+
+
+class _FakeSearchBackend:
+    def __init__(self, execution: InstagramSearchExecution) -> None:
+        self.execution = execution
+        self.calls: list[tuple[str, int]] = []
+
+    def search_keyword(self, *, keyword: str, max_results: int) -> InstagramSearchExecution:
+        self.calls.append((keyword, max_results))
+        return self.execution
+
+
+def _build_execution(keyword: str = "fitness coach") -> InstagramSearchExecution:
+    lead = InstagramLeadRecord(
+        source_url="https://www.instagram.com/creator-a/",
+        source_keyword=keyword,
+        found_at="2026-03-19T00:00:00Z",
+        emails=("creator@example.com",),
+        title="Creator A",
+        snippet="creator@example.com fitness coach",
+    )
+    search_record = InstagramSearchRecord(
+        keyword=keyword,
+        query='site:instagram.com "@gmail.com" "fitness coach"',
+        searched_at="2026-03-19T00:00:00Z",
+        visited_urls=("https://www.instagram.com/creator-a/",),
+        lead_count=1,
+        email_count=1,
+    )
+    return InstagramSearchExecution(search_record=search_record, leads=(lead,))
+
+
+class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
+    def test_run_bootstraps_memory_files_and_parameter_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+            agent = InstagramKeywordDiscoveryAgent(
+                model=model,
+                search_backend=_FakeSearchBackend(_build_execution()),
+                memory_path=temp_dir,
+                icp_descriptions=("fitness creators", "ugc skincare creators"),
+            )
+
+            result = agent.run(max_cycles=1)
+
+            self.assertEqual(result.status, "completed")
+            self.assertTrue(Path(temp_dir, "icp_profiles.json").exists())
+            self.assertTrue(Path(temp_dir, "search_history.json").exists())
+            self.assertTrue(Path(temp_dir, "lead_database.json").exists())
+            self.assertTrue(Path(temp_dir, "runtime_parameters.json").exists())
+            self.assertEqual(
+                [section.title for section in model.requests[0].parameter_sections],
+                ["ICP Profiles", "Recent Searches", "Recent Search Results"],
+            )
+            self.assertIn("fitness creators", model.requests[0].parameter_sections[0].content)
+
+    def test_search_tool_persists_results_and_refreshes_parameter_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel(
+                [
+                    AgentModelResponse(
+                        assistant_message="Search fitness coach.",
+                        tool_calls=(ToolCall(tool_key="instagram.search_keyword", arguments={"keyword": "fitness coach"}),),
+                        should_continue=True,
+                    ),
+                    AgentModelResponse(assistant_message="done", should_continue=False),
+                ]
+            )
+            backend = _FakeSearchBackend(_build_execution())
+            agent = InstagramKeywordDiscoveryAgent(
+                model=model,
+                search_backend=backend,
+                memory_path=temp_dir,
+                icp_descriptions=("fitness creators",),
+            )
+
+            result = agent.run(max_cycles=2)
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(backend.calls, [("fitness coach", 5)])
+            self.assertEqual(len(model.requests), 2)
+            self.assertIn("fitness coach", model.requests[1].parameter_sections[1].content)
+            self.assertIn("creator@example.com", model.requests[1].parameter_sections[2].content)
+            database = json.loads(Path(temp_dir, "lead_database.json").read_text(encoding="utf-8"))
+            self.assertEqual(database["emails"], ["creator@example.com"])
+
+    def test_get_emails_returns_unique_persisted_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+            agent = InstagramKeywordDiscoveryAgent(
+                model=model,
+                search_backend=_FakeSearchBackend(_build_execution()),
+                memory_path=temp_dir,
+                icp_descriptions=("fitness creators",),
+            )
+            agent.prepare()
+
+            agent.tool_executor.execute("instagram.search_keyword", {"keyword": "fitness coach"})
+            agent.tool_executor.execute("instagram.search_keyword", {"keyword": "fitness coach"})
+
+            self.assertEqual(agent.get_emails(), ("creator@example.com",))
+
+    def test_from_memory_loads_runtime_parameters(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = InstagramMemoryStore(memory_path=temp_dir)
+            store.prepare()
+            store.write_icp_profiles(["ugc skincare creators"])
+            store.write_runtime_parameters(
+                {
+                    "recent_result_window": 3,
+                    "recent_search_window": 4,
+                    "search_result_limit": 2,
+                }
+            )
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+
+            agent = InstagramKeywordDiscoveryAgent.from_memory(
+                model=model,
+                search_backend=_FakeSearchBackend(_build_execution("skincare")),
+                memory_path=temp_dir,
+            )
+
+            self.assertEqual(agent.config.recent_search_window, 4)
+            self.assertEqual(agent.config.recent_result_window, 3)
+            self.assertEqual(agent.config.search_result_limit, 2)
+            self.assertIn("ugc skincare creators", agent.load_parameter_sections()[0].content)
+
+    def test_agent_is_importable_from_harnessiq_agents(self) -> None:
+        from harnessiq.agents import InstagramKeywordDiscoveryAgent as Imported
+
+        self.assertIs(Imported, InstagramKeywordDiscoveryAgent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instagram_cli.py
+++ b/tests/test_instagram_cli.py
@@ -1,0 +1,152 @@
+"""Tests for the Instagram CLI commands."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from harnessiq.cli.main import build_parser, main
+from harnessiq.shared.instagram import InstagramLeadRecord, InstagramMemoryStore
+
+
+def _run(argv: list[str]) -> int:
+    return main(argv)
+
+
+class InstagramCliTests(unittest.TestCase):
+    def test_instagram_subcommand_registered(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as exc_info:
+            parser.parse_args(["instagram", "--help"])
+        self.assertEqual(exc_info.exception.code, 0)
+
+    def test_get_emails_subcommand_registered(self) -> None:
+        parser = build_parser()
+        args, _ = parser.parse_known_args(["instagram", "get-emails", "--agent", "test"])
+        self.assertEqual(args.instagram_command, "get-emails")
+
+    def test_prepare_creates_memory_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("sys.stdout.write") as mock_write:
+                result = _run(["instagram", "prepare", "--agent", "my-agent", "--memory-root", temp_dir])
+            self.assertEqual(result, 0)
+            self.assertTrue((Path(temp_dir) / "my-agent").is_dir())
+            rendered = "".join(call.args[0] for call in mock_write.call_args_list)
+            payload = json.loads(rendered)
+            self.assertEqual(payload["status"], "prepared")
+
+    def test_configure_sets_icps_and_runtime_parameters(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _run(["instagram", "prepare", "--agent", "a", "--memory-root", temp_dir])
+            with patch("sys.stdout.write") as mock_write:
+                result = _run(
+                    [
+                        "instagram",
+                        "configure",
+                        "--agent",
+                        "a",
+                        "--memory-root",
+                        temp_dir,
+                        "--icp",
+                        "fitness creators",
+                        "--icp",
+                        "ugc skincare creators",
+                        "--runtime-param",
+                        "search_result_limit=3",
+                    ]
+                )
+            self.assertEqual(result, 0)
+            payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
+            self.assertEqual(payload["icp_profiles"], ["fitness creators", "ugc skincare creators"])
+            self.assertEqual(payload["runtime_parameters"]["search_result_limit"], 3)
+
+    def test_show_returns_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _run(["instagram", "prepare", "--agent", "a", "--memory-root", temp_dir])
+            with patch("sys.stdout.write") as mock_write:
+                _run(["instagram", "show", "--agent", "a", "--memory-root", temp_dir])
+            payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
+            self.assertEqual(payload["search_count"], 0)
+            self.assertEqual(payload["email_count"], 0)
+
+    def test_get_emails_reads_persisted_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = InstagramMemoryStore(memory_path=Path(temp_dir) / "a")
+            store.prepare()
+            store.merge_leads(
+                [
+                    InstagramLeadRecord(
+                        source_url="https://www.instagram.com/creator-a/",
+                        source_keyword="fitness coach",
+                        found_at="2026-03-19T00:00:00Z",
+                        emails=("creator@example.com",),
+                    )
+                ]
+            )
+            with patch("sys.stdout.write") as mock_write:
+                result = _run(["instagram", "get-emails", "--agent", "a", "--memory-root", temp_dir])
+            self.assertEqual(result, 0)
+            payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
+            self.assertEqual(payload["emails"], ["creator@example.com"])
+            self.assertEqual(payload["count"], 1)
+
+    def test_run_invokes_agent_from_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _run(["instagram", "prepare", "--agent", "a", "--memory-root", temp_dir])
+            _run(
+                [
+                    "instagram",
+                    "configure",
+                    "--agent",
+                    "a",
+                    "--memory-root",
+                    temp_dir,
+                    "--icp",
+                    "fitness creators",
+                ]
+            )
+
+            mock_agent = MagicMock()
+            mock_result = MagicMock()
+            mock_result.cycles_completed = 2
+            mock_result.pause_reason = None
+            mock_result.resets = 0
+            mock_result.status = "completed"
+            mock_agent.run.return_value = mock_result
+            mock_agent.get_emails.return_value = ("creator@example.com",)
+
+            with (
+                patch(
+                    "harnessiq.cli.instagram.commands._load_factory",
+                    side_effect=[lambda: MagicMock(), lambda: object()],
+                ),
+                patch(
+                    "harnessiq.agents.instagram.InstagramKeywordDiscoveryAgent.from_memory",
+                    return_value=mock_agent,
+                ),
+                patch("sys.stdout.write") as mock_write,
+            ):
+                result = _run(
+                    [
+                        "instagram",
+                        "run",
+                        "--agent",
+                        "a",
+                        "--memory-root",
+                        temp_dir,
+                        "--model-factory",
+                        "mod:model",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
+            self.assertEqual(payload["email_count"], 1)
+            self.assertEqual(payload["result"]["cycles_completed"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instagram_playwright.py
+++ b/tests/test_instagram_playwright.py
@@ -1,0 +1,48 @@
+"""Tests for the Instagram Playwright integration helpers."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, call
+
+from harnessiq.integrations.instagram_playwright import (
+    PlaywrightInstagramSearchBackend,
+    _normalize_candidate_url,
+)
+
+
+class InstagramPlaywrightTests(unittest.TestCase):
+    def test_wait_for_page_ready_waits_for_dom_load_and_network_idle(self) -> None:
+        page = MagicMock()
+        backend = PlaywrightInstagramSearchBackend(timeout_ms=1234, network_idle_timeout_ms=567)
+
+        backend._wait_for_page_ready(page)
+
+        self.assertEqual(
+            page.wait_for_load_state.call_args_list,
+            [
+                call("domcontentloaded", timeout=1234),
+                call("load", timeout=1234),
+                call("networkidle", timeout=567),
+            ],
+        )
+
+    def test_normalize_candidate_url_unwraps_google_redirects(self) -> None:
+        normalized = _normalize_candidate_url(
+            "/url?q=https://www.instagram.com/creator-a/&sa=U&ved=2ah",
+            base_url="https://www.google.com/search?q=ugc",
+        )
+
+        self.assertEqual(normalized, "https://www.instagram.com/creator-a/")
+
+    def test_normalize_candidate_url_filters_non_instagram_targets(self) -> None:
+        normalized = _normalize_candidate_url(
+            "https://www.example.com/profile",
+            base_url="https://www.google.com/search?q=ugc",
+        )
+
+        self.assertIsNone(normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_package.py
+++ b/tests/test_sdk_package.py
@@ -55,6 +55,7 @@ class HarnessiqPackageTests(unittest.TestCase):
                         "from harnessiq.cli.main import main as cli_main; "
                         "assert harnessiq.__version__ == '0.1.0'; "
                         "assert hasattr(harnessiq.agents, 'LinkedInJobApplierAgent'); "
+                        "assert hasattr(harnessiq.agents, 'InstagramKeywordDiscoveryAgent'); "
                         "assert callable(cli_main); "
                         "assert hasattr(harnessiq.config, 'CredentialsConfigStore'); "
                         "assert hasattr(harnessiq.tools, 'create_builtin_registry')"
@@ -80,6 +81,7 @@ class HarnessiqPackageTests(unittest.TestCase):
         )
 
         self.assertIn("linkedin", help_run.stdout)
+        self.assertIn("instagram", help_run.stdout)
         self.assertEqual(help_run.returncode, 0)
 
 


### PR DESCRIPTION
## Summary
- add a new Instagram keyword discovery agent with durable ICP/search/lead memory
- add a Playwright-backed deterministic Google-to-Instagram search backend and CLI commands, including get-emails
- add targeted tests and workflow artifacts for the new agent

## Verification
- python -m unittest tests.test_instagram_agent tests.test_instagram_cli tests.test_instagram_playwright tests.test_sdk_package