### PR TITLE
Add Paperclip provider and tool integration

### DIFF
--- a/harnessiq/providers/__init__.py
+++ b/harnessiq/providers/__init__.py
@@ -19,6 +19,7 @@ from .output_sinks import (
     SupabaseClient,
     WebhookDeliveryClient,
     extract_model_metadata,
+)
 from .playwright import (
     chromium_context,
     get_or_create_page,

--- a/harnessiq/providers/paperclip/__init__.py
+++ b/harnessiq/providers/paperclip/__init__.py
@@ -1,0 +1,22 @@
+"""Paperclip control-plane API provider support."""
+
+from .api import DEFAULT_BASE_URL, build_headers, url
+from .client import PaperclipClient, PaperclipCredentials
+from .operations import (
+    PaperclipOperation,
+    PaperclipPreparedRequest,
+    build_paperclip_operation_catalog,
+    get_paperclip_operation,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "PaperclipClient",
+    "PaperclipCredentials",
+    "PaperclipOperation",
+    "PaperclipPreparedRequest",
+    "build_headers",
+    "build_paperclip_operation_catalog",
+    "get_paperclip_operation",
+    "url",
+]

--- a/harnessiq/providers/paperclip/api.py
+++ b/harnessiq/providers/paperclip/api.py
@@ -1,0 +1,38 @@
+"""Paperclip API endpoint and authentication helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from harnessiq.providers.http import join_url
+
+DEFAULT_BASE_URL = "http://localhost:3100/api"
+
+
+def build_headers(
+    api_key: str,
+    *,
+    run_id: str | None = None,
+    extra_headers: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the headers required for Paperclip API requests."""
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {api_key}",
+    }
+    if run_id is not None:
+        headers["X-Paperclip-Run-Id"] = run_id
+    if extra_headers:
+        headers.update(extra_headers)
+    return headers
+
+
+def url(base_url: str, path: str) -> str:
+    """Return a fully qualified Paperclip API URL."""
+    return join_url(base_url, path)
+
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "build_headers",
+    "url",
+]

--- a/harnessiq/providers/paperclip/client.py
+++ b/harnessiq/providers/paperclip/client.py
@@ -1,0 +1,101 @@
+"""Paperclip credentials and HTTP client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from harnessiq.providers.http import RequestExecutor, request_json
+from harnessiq.providers.paperclip.api import DEFAULT_BASE_URL
+
+
+@dataclass(frozen=True, slots=True)
+class PaperclipCredentials:
+    """Runtime credentials for the Paperclip control-plane API."""
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    timeout_seconds: float = 60.0
+
+    def __post_init__(self) -> None:
+        if not self.api_key.strip():
+            raise ValueError("Paperclip api_key must not be blank.")
+        if not self.base_url.strip():
+            raise ValueError("Paperclip base_url must not be blank.")
+        if self.timeout_seconds <= 0:
+            raise ValueError("Paperclip timeout_seconds must be greater than zero.")
+
+    def masked_api_key(self) -> str:
+        """Return a redacted version of the configured API key."""
+        key = self.api_key
+        if len(key) <= 4:
+            return "*" * len(key)
+        return f"{key[:3]}{'*' * max(1, len(key) - 7)}{key[-4:]}"
+
+    def as_redacted_dict(self) -> dict[str, object]:
+        """Return a safe-to-log credential summary."""
+        return {
+            "api_key_masked": self.masked_api_key(),
+            "base_url": self.base_url,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PaperclipClient:
+    """Minimal Paperclip HTTP client suitable for tool execution and tests."""
+
+    credentials: PaperclipCredentials
+    request_executor: RequestExecutor = request_json
+
+    def prepare_request(
+        self,
+        operation_name: str,
+        *,
+        path_params: Mapping[str, object] | None = None,
+        query: Mapping[str, object] | None = None,
+        payload: Any | None = None,
+        run_id: str | None = None,
+    ) -> Any:
+        """Validate inputs and build an executable request."""
+        from harnessiq.providers.paperclip.operations import _build_prepared_request
+
+        return _build_prepared_request(
+            operation_name=operation_name,
+            credentials=self.credentials,
+            path_params=path_params,
+            query=query,
+            payload=payload,
+            run_id=run_id,
+        )
+
+    def execute_operation(
+        self,
+        operation_name: str,
+        *,
+        path_params: Mapping[str, object] | None = None,
+        query: Mapping[str, object] | None = None,
+        payload: Any | None = None,
+        run_id: str | None = None,
+    ) -> Any:
+        """Execute one validated Paperclip operation and return the decoded response."""
+        prepared = self.prepare_request(
+            operation_name,
+            path_params=path_params,
+            query=query,
+            payload=payload,
+            run_id=run_id,
+        )
+        return self.request_executor(
+            prepared.method,
+            prepared.url,
+            headers=prepared.headers,
+            json_body=prepared.json_body,
+            timeout_seconds=self.credentials.timeout_seconds,
+        )
+
+
+__all__ = [
+    "PaperclipClient",
+    "PaperclipCredentials",
+]

--- a/harnessiq/providers/paperclip/operations.py
+++ b/harnessiq/providers/paperclip/operations.py
@@ -1,0 +1,248 @@
+"""Paperclip operation catalog and prepared-request helpers."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
+from urllib.parse import quote
+
+from harnessiq.providers.http import join_url
+
+if TYPE_CHECKING:
+    from harnessiq.providers.paperclip.client import PaperclipCredentials
+
+PayloadKind = Literal["none", "object"]
+
+
+@dataclass(frozen=True, slots=True)
+class PaperclipOperation:
+    """Declarative metadata for one Paperclip API operation."""
+
+    name: str
+    category: str
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+    path_hint: str
+    required_path_params: tuple[str, ...] = ()
+    payload_kind: PayloadKind = "none"
+    payload_required: bool = False
+    allow_query: bool = False
+    supports_run_id: bool = False
+
+    def summary(self) -> str:
+        return f"{self.name} ({self.method} {self.path_hint})"
+
+
+@dataclass(frozen=True, slots=True)
+class PaperclipPreparedRequest:
+    """A validated Paperclip request ready for execution."""
+
+    operation: PaperclipOperation
+    method: str
+    path: str
+    url: str
+    headers: dict[str, str]
+    json_body: Any | None
+
+
+def _op(
+    name: str,
+    category: str,
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+    path_hint: str,
+    *,
+    required_path_params: Sequence[str] = (),
+    payload_kind: PayloadKind = "none",
+    payload_required: bool = False,
+    allow_query: bool = False,
+    supports_run_id: bool = False,
+) -> tuple[str, PaperclipOperation]:
+    return (
+        name,
+        PaperclipOperation(
+            name=name,
+            category=category,
+            method=method,
+            path_hint=path_hint,
+            required_path_params=tuple(required_path_params),
+            payload_kind=payload_kind,
+            payload_required=payload_required,
+            allow_query=allow_query,
+            supports_run_id=supports_run_id,
+        ),
+    )
+
+
+_PAPERCLIP_CATALOG: OrderedDict[str, PaperclipOperation] = OrderedDict(
+    (
+        _op("list_companies", "Companies", "GET", "/companies"),
+        _op("get_company", "Companies", "GET", "/companies/{company_id}", required_path_params=("company_id",)),
+        _op("create_company", "Companies", "POST", "/companies", payload_kind="object", payload_required=True),
+        _op("update_company", "Companies", "PATCH", "/companies/{company_id}", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("archive_company", "Companies", "POST", "/companies/{company_id}/archive", required_path_params=("company_id",), supports_run_id=True),
+        _op("list_agents", "Agents", "GET", "/companies/{company_id}/agents", required_path_params=("company_id",)),
+        _op("get_agent", "Agents", "GET", "/agents/{agent_id}", required_path_params=("agent_id",)),
+        _op("get_current_agent", "Agents", "GET", "/agents/me"),
+        _op("create_agent", "Agents", "POST", "/companies/{company_id}/agents", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("update_agent", "Agents", "PATCH", "/agents/{agent_id}", required_path_params=("agent_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("pause_agent", "Agents", "POST", "/agents/{agent_id}/pause", required_path_params=("agent_id",), supports_run_id=True),
+        _op("resume_agent", "Agents", "POST", "/agents/{agent_id}/resume", required_path_params=("agent_id",), supports_run_id=True),
+        _op("terminate_agent", "Agents", "POST", "/agents/{agent_id}/terminate", required_path_params=("agent_id",), supports_run_id=True),
+        _op("create_agent_api_key", "Agents", "POST", "/agents/{agent_id}/keys", required_path_params=("agent_id",), supports_run_id=True),
+        _op("invoke_agent_heartbeat", "Agents", "POST", "/agents/{agent_id}/heartbeat/invoke", required_path_params=("agent_id",), supports_run_id=True),
+        _op("get_org_chart", "Agents", "GET", "/companies/{company_id}/org", required_path_params=("company_id",)),
+        _op("list_adapter_models", "Agents", "GET", "/companies/{company_id}/adapters/{adapter_type}/models", required_path_params=("company_id", "adapter_type")),
+        _op("list_agent_config_revisions", "Agents", "GET", "/agents/{agent_id}/config-revisions", required_path_params=("agent_id",)),
+        _op("rollback_agent_config_revision", "Agents", "POST", "/agents/{agent_id}/config-revisions/{revision_id}/rollback", required_path_params=("agent_id", "revision_id"), supports_run_id=True),
+        _op("list_issues", "Issues", "GET", "/companies/{company_id}/issues", required_path_params=("company_id",), allow_query=True),
+        _op("get_issue", "Issues", "GET", "/issues/{issue_id}", required_path_params=("issue_id",)),
+        _op("create_issue", "Issues", "POST", "/companies/{company_id}/issues", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("update_issue", "Issues", "PATCH", "/issues/{issue_id}", required_path_params=("issue_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("checkout_issue", "Issues", "POST", "/issues/{issue_id}/checkout", required_path_params=("issue_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("release_issue", "Issues", "POST", "/issues/{issue_id}/release", required_path_params=("issue_id",), supports_run_id=True),
+        _op("list_issue_comments", "Issues", "GET", "/issues/{issue_id}/comments", required_path_params=("issue_id",)),
+        _op("add_issue_comment", "Issues", "POST", "/issues/{issue_id}/comments", required_path_params=("issue_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("list_issue_documents", "Issues", "GET", "/issues/{issue_id}/documents", required_path_params=("issue_id",)),
+        _op("get_issue_document", "Issues", "GET", "/issues/{issue_id}/documents/{key}", required_path_params=("issue_id", "key")),
+        _op("upsert_issue_document", "Issues", "PUT", "/issues/{issue_id}/documents/{key}", required_path_params=("issue_id", "key"), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("list_issue_document_revisions", "Issues", "GET", "/issues/{issue_id}/documents/{key}/revisions", required_path_params=("issue_id", "key")),
+        _op("delete_issue_document", "Issues", "DELETE", "/issues/{issue_id}/documents/{key}", required_path_params=("issue_id", "key"), supports_run_id=True),
+        _op("list_approvals", "Approvals", "GET", "/companies/{company_id}/approvals", required_path_params=("company_id",), allow_query=True),
+        _op("get_approval", "Approvals", "GET", "/approvals/{approval_id}", required_path_params=("approval_id",)),
+        _op("create_approval_request", "Approvals", "POST", "/companies/{company_id}/approvals", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("create_agent_hire_request", "Approvals", "POST", "/companies/{company_id}/agent-hires", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("approve_approval", "Approvals", "POST", "/approvals/{approval_id}/approve", required_path_params=("approval_id",), payload_kind="object", supports_run_id=True),
+        _op("reject_approval", "Approvals", "POST", "/approvals/{approval_id}/reject", required_path_params=("approval_id",), payload_kind="object", supports_run_id=True),
+        _op("request_approval_revision", "Approvals", "POST", "/approvals/{approval_id}/request-revision", required_path_params=("approval_id",), payload_kind="object", supports_run_id=True),
+        _op("resubmit_approval", "Approvals", "POST", "/approvals/{approval_id}/resubmit", required_path_params=("approval_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("list_approval_issues", "Approvals", "GET", "/approvals/{approval_id}/issues", required_path_params=("approval_id",)),
+        _op("list_approval_comments", "Approvals", "GET", "/approvals/{approval_id}/comments", required_path_params=("approval_id",)),
+        _op("add_approval_comment", "Approvals", "POST", "/approvals/{approval_id}/comments", required_path_params=("approval_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("list_activity", "Activity", "GET", "/companies/{company_id}/activity", required_path_params=("company_id",), allow_query=True),
+        _op("report_cost_event", "Costs", "POST", "/companies/{company_id}/cost-events", required_path_params=("company_id",), payload_kind="object", payload_required=True, supports_run_id=True),
+        _op("get_company_cost_summary", "Costs", "GET", "/companies/{company_id}/costs/summary", required_path_params=("company_id",)),
+        _op("get_costs_by_agent", "Costs", "GET", "/companies/{company_id}/costs/by-agent", required_path_params=("company_id",)),
+        _op("get_costs_by_project", "Costs", "GET", "/companies/{company_id}/costs/by-project", required_path_params=("company_id",)),
+    )
+)
+
+
+def build_paperclip_operation_catalog() -> tuple[PaperclipOperation, ...]:
+    """Return the supported Paperclip operation catalog in stable order."""
+    return tuple(_PAPERCLIP_CATALOG.values())
+
+
+def get_paperclip_operation(operation_name: str) -> PaperclipOperation:
+    """Return a supported Paperclip operation or raise a clear error."""
+    operation = _PAPERCLIP_CATALOG.get(operation_name)
+    if operation is None:
+        available = ", ".join(_PAPERCLIP_CATALOG)
+        raise ValueError(f"Unsupported Paperclip operation '{operation_name}'. Available: {available}.")
+    return operation
+
+
+def _build_prepared_request(
+    *,
+    operation_name: str,
+    credentials: "PaperclipCredentials",
+    path_params: Mapping[str, object] | None,
+    query: Mapping[str, object] | None,
+    payload: Any | None,
+    run_id: str | None,
+) -> PaperclipPreparedRequest:
+    from harnessiq.providers.paperclip.api import build_headers
+
+    operation = get_paperclip_operation(operation_name)
+    normalized_path_params = _normalize_path_params(path_params)
+    _validate_path_params(operation, normalized_path_params)
+    normalized_query = _normalize_query(query)
+    _validate_query(operation, normalized_query)
+    normalized_payload = _normalize_payload(payload)
+    _validate_payload(operation, normalized_payload)
+
+    path = operation.path_hint
+    for parameter_name, value in normalized_path_params.items():
+        path = path.replace(f"{{{parameter_name}}}", quote(value, safe=""))
+
+    full_url = join_url(credentials.base_url, path, query=normalized_query)  # type: ignore[arg-type]
+    headers = build_headers(credentials.api_key, run_id=run_id if operation.supports_run_id else None)
+
+    return PaperclipPreparedRequest(
+        operation=operation,
+        method=operation.method,
+        path=path,
+        url=full_url,
+        headers=headers,
+        json_body=deepcopy(normalized_payload) if normalized_payload is not None else None,
+    )
+
+
+def _normalize_path_params(path_params: Mapping[str, object] | None) -> dict[str, str]:
+    if path_params is None:
+        return {}
+    normalized: dict[str, str] = {}
+    for key, value in path_params.items():
+        if not isinstance(key, str):
+            raise ValueError("All keys in 'path_params' must be strings.")
+        normalized[key] = str(value)
+    return normalized
+
+
+def _normalize_query(query: Mapping[str, object] | None) -> dict[str, str | int | float | bool] | None:
+    if query is None:
+        return None
+    normalized: dict[str, str | int | float | bool] = {}
+    for key, value in query.items():
+        if not isinstance(key, str):
+            raise ValueError("All keys in 'query' must be strings.")
+        if not isinstance(value, (str, int, float, bool)):
+            raise ValueError(f"Query parameter '{key}' must be a string, number, or boolean.")
+        normalized[key] = value
+    return normalized
+
+
+def _normalize_payload(payload: Any | None) -> Mapping[str, object] | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, Mapping):
+        raise ValueError("The 'payload' argument must be an object when provided.")
+    normalized: dict[str, object] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise ValueError("All keys in 'payload' must be strings.")
+        normalized[key] = deepcopy(value)
+    return normalized
+
+
+def _validate_path_params(operation: PaperclipOperation, path_params: Mapping[str, str]) -> None:
+    allowed = set(operation.required_path_params)
+    unexpected = sorted(set(path_params) - allowed)
+    if unexpected:
+        raise ValueError(f"Operation '{operation.name}' received unexpected path parameters: {', '.join(unexpected)}.")
+    missing = [key for key in operation.required_path_params if not path_params.get(key)]
+    if missing:
+        raise ValueError(f"Operation '{operation.name}' requires path parameters: {', '.join(missing)}.")
+
+
+def _validate_query(operation: PaperclipOperation, query: Mapping[str, str | int | float | bool] | None) -> None:
+    if query is not None and not operation.allow_query:
+        raise ValueError(f"Operation '{operation.name}' does not accept query parameters.")
+
+
+def _validate_payload(operation: PaperclipOperation, payload: Mapping[str, object] | None) -> None:
+    if operation.payload_kind == "none":
+        if payload is not None:
+            raise ValueError(f"Operation '{operation.name}' does not accept a payload.")
+        return
+    if payload is None and operation.payload_required:
+        raise ValueError(f"Operation '{operation.name}' requires a payload.")
+
+
+__all__ = [
+    "PaperclipOperation",
+    "PaperclipPreparedRequest",
+    "_build_prepared_request",
+    "build_paperclip_operation_catalog",
+    "get_paperclip_operation",
+]

--- a/harnessiq/shared/tools.py
+++ b/harnessiq/shared/tools.py
@@ -141,6 +141,7 @@ ZEROBOUNCE_REQUEST = "zerobounce.request"
 EXPANDI_REQUEST = "expandi.request"
 SMARTLEAD_REQUEST = "smartlead.request"
 LUSHA_REQUEST = "lusha.request"
+PAPERCLIP_REQUEST = "paperclip.request"
 INSTAGRAM_SEARCH_KEYWORD = "instagram.search_keyword"
 
 
@@ -322,6 +323,7 @@ __all__ = [
     "LEMLIST_REQUEST",
     "LOG_COMPACTION",
     "OUTREACH_REQUEST",
+    "PAPERCLIP_REQUEST",
     "PEOPLEDATALABS_REQUEST",
     "PHANTOMBUSTER_REQUEST",
     "PROMPT_CREATE_SYSTEM_PROMPT",

--- a/harnessiq/tools/__init__.py
+++ b/harnessiq/tools/__init__.py
@@ -15,6 +15,7 @@ from harnessiq.shared.tools import (
     HEAVY_COMPACTION,
     JsonObject,
     LOG_COMPACTION,
+    PAPERCLIP_REQUEST,
     PROMPT_CREATE_SYSTEM_PROMPT,
     REASON_BRAINSTORM,
     REASON_CHAIN_OF_THOUGHT,
@@ -125,6 +126,10 @@ from .general_purpose import (
     unique_records,
 )
 from .instagram import create_instagram_tools
+from .paperclip import (
+    build_paperclip_request_tool_definition,
+    create_paperclip_tools,
+)
 from .prompting import create_prompt_tools, create_system_prompt
 from .reasoning import (
     brainstorm,
@@ -170,6 +175,7 @@ __all__ = [
     "HEAVY_COMPACTION",
     "JsonObject",
     "LOG_COMPACTION",
+    "PAPERCLIP_REQUEST",
     "PROMPT_CREATE_SYSTEM_PROMPT",
     "REASON_BRAINSTORM",
     "REASON_CHAIN_OF_THOUGHT",
@@ -250,6 +256,7 @@ __all__ = [
     "TruncatePosition",
     "append_text_file",
     "apply_log_compaction",
+    "build_paperclip_request_tool_definition",
     "build_resend_operation_catalog",
     "build_resend_request_tool_definition",
     "copy_path",
@@ -259,6 +266,7 @@ __all__ = [
     "create_filesystem_tools",
     "create_general_purpose_tools",
     "create_instagram_tools",
+    "create_paperclip_tools",
     "brainstorm",
     "chain_of_thought",
     "create_injectable_reasoning_tools",

--- a/harnessiq/tools/paperclip/__init__.py
+++ b/harnessiq/tools/paperclip/__init__.py
@@ -1,0 +1,11 @@
+"""Paperclip tool registration for the Harnessiq tool layer."""
+
+from harnessiq.tools.paperclip.operations import (
+    build_paperclip_request_tool_definition,
+    create_paperclip_tools,
+)
+
+__all__ = [
+    "build_paperclip_request_tool_definition",
+    "create_paperclip_tools",
+]

--- a/harnessiq/tools/paperclip/operations.py
+++ b/harnessiq/tools/paperclip/operations.py
@@ -1,0 +1,186 @@
+"""Paperclip MCP-style tool factory for the Harnessiq tool layer."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from harnessiq.providers.paperclip.operations import (
+    PaperclipOperation,
+    build_paperclip_operation_catalog,
+    get_paperclip_operation,
+)
+from harnessiq.shared.tools import PAPERCLIP_REQUEST, RegisteredTool, ToolArguments, ToolDefinition
+
+if TYPE_CHECKING:
+    from harnessiq.providers.paperclip.client import PaperclipClient, PaperclipCredentials
+
+
+def build_paperclip_request_tool_definition(
+    *,
+    allowed_operations: Sequence[str] | None = None,
+) -> ToolDefinition:
+    """Return the canonical tool definition for the Paperclip request surface."""
+    operations = _select_operations(allowed_operations)
+    operation_names = [operation.name for operation in operations]
+    return ToolDefinition(
+        key=PAPERCLIP_REQUEST,
+        name="paperclip_request",
+        description=_build_tool_description(operations),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": operation_names,
+                    "description": (
+                        "The Paperclip control-plane operation to execute. Use issue and approval "
+                        "operations for day-to-day agent workflow, agent operations for identity and "
+                        "management, and cost/activity operations for observability."
+                    ),
+                },
+                "path_params": {
+                    "type": "object",
+                    "description": "Path parameters required by the selected operation, such as company_id, issue_id, or approval_id.",
+                    "additionalProperties": True,
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Optional query parameters for list/filter operations.",
+                    "additionalProperties": True,
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Optional JSON request body for create, update, checkout, comment, approval, and cost-reporting operations.",
+                },
+                "run_id": {
+                    "type": "string",
+                    "description": "Optional Paperclip run identifier sent as X-Paperclip-Run-Id on supported mutating operations.",
+                },
+            },
+            "required": ["operation"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def create_paperclip_tools(
+    *,
+    credentials: "PaperclipCredentials | None" = None,
+    client: "PaperclipClient | None" = None,
+    allowed_operations: Sequence[str] | None = None,
+) -> tuple[RegisteredTool, ...]:
+    """Return the MCP-style Paperclip request tool backed by the provided client."""
+    paperclip_client = _coerce_client(credentials=credentials, client=client)
+    selected = _select_operations(allowed_operations)
+    allowed_names = frozenset(operation.name for operation in selected)
+    definition = build_paperclip_request_tool_definition(
+        allowed_operations=tuple(operation.name for operation in selected)
+    )
+
+    def handler(arguments: ToolArguments) -> dict[str, Any]:
+        operation_name = _require_operation_name(arguments, allowed_names)
+        prepared = paperclip_client.prepare_request(
+            operation_name,
+            path_params=_optional_mapping(arguments, "path_params"),
+            query=_optional_mapping(arguments, "query"),
+            payload=_optional_mapping(arguments, "payload"),
+            run_id=_optional_string(arguments, "run_id"),
+        )
+        response = paperclip_client.request_executor(
+            prepared.method,
+            prepared.url,
+            headers=prepared.headers,
+            json_body=prepared.json_body,
+            timeout_seconds=paperclip_client.credentials.timeout_seconds,
+        )
+        return {
+            "operation": prepared.operation.name,
+            "method": prepared.method,
+            "path": prepared.path,
+            "response": response,
+        }
+
+    return (RegisteredTool(definition=definition, handler=handler),)
+
+
+def _build_tool_description(operations: Sequence[PaperclipOperation]) -> str:
+    grouped: OrderedDict[str, list[str]] = OrderedDict()
+    for operation in operations:
+        grouped.setdefault(operation.category, []).append(operation.summary())
+
+    lines = [
+        "Execute authenticated Paperclip control-plane API operations.",
+        "",
+        "Paperclip is an orchestration layer for agent companies. Use it to inspect companies and agents, "
+        "manage issue workflows, interact with approvals, query activity, and report or inspect costs.",
+        "",
+        "This integration is JSON-first and intentionally excludes multipart upload endpoints such as "
+        "attachments and company-logo uploads.",
+        "",
+        "Available operations by category:",
+    ]
+    for category, summaries in grouped.items():
+        lines.append(f"  {category}: {', '.join(summaries)}")
+    lines.append(
+        "\nParameter guidance: use 'path_params' for ids, 'query' for list filters, 'payload' for JSON "
+        "bodies, and 'run_id' when you want Paperclip to trace a mutating call to the current heartbeat."
+    )
+    return "\n".join(lines)
+
+
+def _select_operations(allowed: Sequence[str] | None) -> tuple[PaperclipOperation, ...]:
+    if allowed is None:
+        return build_paperclip_operation_catalog()
+    seen: set[str] = set()
+    selected: list[PaperclipOperation] = []
+    for name in allowed:
+        operation = get_paperclip_operation(name)
+        if operation.name not in seen:
+            seen.add(operation.name)
+            selected.append(operation)
+    return tuple(selected)
+
+
+def _coerce_client(*, credentials: Any, client: Any) -> Any:
+    if client is not None:
+        return client
+    if credentials is None:
+        raise ValueError("Either Paperclip credentials or a Paperclip client must be provided.")
+    from harnessiq.providers.paperclip.client import PaperclipClient
+
+    return PaperclipClient(credentials=credentials)
+
+
+def _require_operation_name(arguments: Mapping[str, object], allowed: frozenset[str]) -> str:
+    value = arguments["operation"]
+    if not isinstance(value, str):
+        raise ValueError("The 'operation' argument must be a string.")
+    if value not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        raise ValueError(f"Unsupported Paperclip operation '{value}'. Allowed: {allowed_str}.")
+    return value
+
+
+def _optional_mapping(arguments: Mapping[str, object], key: str) -> Mapping[str, object] | None:
+    value = arguments.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(f"The '{key}' argument must be an object when provided.")
+    return value
+
+
+def _optional_string(arguments: Mapping[str, object], key: str) -> str | None:
+    value = arguments.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"The '{key}' argument must be a string when provided.")
+    return value
+
+
+__all__ = [
+    "build_paperclip_request_tool_definition",
+    "create_paperclip_tools",
+]

--- a/harnessiq/toolset/catalog.py
+++ b/harnessiq/toolset/catalog.py
@@ -196,6 +196,13 @@ PROVIDER_ENTRIES: tuple[ToolEntry, ...] = (
         requires_credentials=True,
     ),
     ToolEntry(
+        key="paperclip.request",
+        name="paperclip_request",
+        description="Execute authenticated Paperclip control-plane API operations for companies, agents, issues, approvals, activity, and costs.",
+        family="paperclip",
+        requires_credentials=True,
+    ),
+    ToolEntry(
         key="peopledatalabs.request",
         name="peopledatalabs_request",
         description="Execute authenticated People Data Labs data enrichment API operations.",
@@ -286,6 +293,7 @@ PROVIDER_FACTORY_MAP: dict[str, tuple[str, str]] = {
     "lusha": ("harnessiq.tools.lusha", "create_lusha_tools"),
     "lemlist": ("harnessiq.tools.lemlist", "create_lemlist_tools"),
     "outreach": ("harnessiq.tools.outreach", "create_outreach_tools"),
+    "paperclip": ("harnessiq.tools.paperclip", "create_paperclip_tools"),
     "peopledatalabs": ("harnessiq.tools.peopledatalabs", "create_peopledatalabs_tools"),
     "phantombuster": ("harnessiq.tools.phantombuster", "create_phantombuster_tools"),
     "proxycurl": ("harnessiq.tools.proxycurl", "create_proxycurl_tools"),

--- a/tests/test_paperclip_provider.py
+++ b/tests/test_paperclip_provider.py
@@ -1,0 +1,190 @@
+"""Tests for harnessiq.providers.paperclip."""
+
+from __future__ import annotations
+
+import unittest
+
+from harnessiq.providers.paperclip import (
+    DEFAULT_BASE_URL,
+    PaperclipClient,
+    PaperclipCredentials,
+    build_headers,
+    build_paperclip_operation_catalog,
+    get_paperclip_operation,
+)
+from harnessiq.shared.tools import PAPERCLIP_REQUEST
+from harnessiq.tools.paperclip import create_paperclip_tools
+from harnessiq.tools.registry import ToolRegistry
+
+
+class PaperclipCredentialsTests(unittest.TestCase):
+    def test_valid_credentials_accepted(self) -> None:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        self.assertEqual(credentials.api_key, "pc_test_token")
+
+    def test_blank_api_key_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            PaperclipCredentials(api_key="")
+
+    def test_blank_api_key_whitespace_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            PaperclipCredentials(api_key="   ")
+
+    def test_zero_timeout_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            PaperclipCredentials(api_key="pc_test_token", timeout_seconds=0)
+
+    def test_default_base_url_set(self) -> None:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        self.assertEqual(credentials.base_url, DEFAULT_BASE_URL)
+
+    def test_as_redacted_dict_excludes_raw_key(self) -> None:
+        summary = PaperclipCredentials(api_key="pc_super_secret").as_redacted_dict()
+        self.assertNotIn("pc_super_secret", str(summary))
+        self.assertIn("api_key_masked", summary)
+
+
+class PaperclipApiTests(unittest.TestCase):
+    def test_build_headers_produces_bearer_auth_header(self) -> None:
+        headers = build_headers("pc_test_token")
+        self.assertEqual(headers["Authorization"], "Bearer pc_test_token")
+        self.assertNotIn("X-Paperclip-Run-Id", headers)
+
+    def test_build_headers_includes_run_id_when_provided(self) -> None:
+        headers = build_headers("pc_test_token", run_id="run-123")
+        self.assertEqual(headers["X-Paperclip-Run-Id"], "run-123")
+
+
+class PaperclipOperationCatalogTests(unittest.TestCase):
+    def test_catalog_is_non_empty(self) -> None:
+        catalog = build_paperclip_operation_catalog()
+        self.assertGreater(len(catalog), 0)
+
+    def test_catalog_covers_expected_categories(self) -> None:
+        categories = {operation.category for operation in build_paperclip_operation_catalog()}
+        self.assertEqual(categories, {"Companies", "Agents", "Issues", "Approvals", "Activity", "Costs"})
+
+    def test_representative_issue_operation_requires_payload(self) -> None:
+        operation = get_paperclip_operation("checkout_issue")
+        self.assertTrue(operation.payload_required)
+        self.assertTrue(operation.supports_run_id)
+
+    def test_list_issues_allows_query(self) -> None:
+        operation = get_paperclip_operation("list_issues")
+        self.assertTrue(operation.allow_query)
+
+    def test_get_operation_raises_for_unknown(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            get_paperclip_operation("nonexistent_op")
+        self.assertIn("nonexistent_op", str(ctx.exception))
+
+
+class PaperclipClientTests(unittest.TestCase):
+    def _client(self, request_executor=None) -> PaperclipClient:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        return PaperclipClient(credentials=credentials, request_executor=request_executor or (lambda method, url, **kwargs: {"ok": True}))
+
+    def test_prepare_request_renders_issue_list_url_and_query(self) -> None:
+        prepared = self._client().prepare_request(
+            "list_issues",
+            path_params={"company_id": "company-1"},
+            query={"status": "todo,in_progress", "assigneeAgentId": "agent-42"},
+        )
+        self.assertEqual(prepared.method, "GET")
+        self.assertIn("/companies/company-1/issues", prepared.url)
+        self.assertIn("status=todo%2Cin_progress", prepared.url)
+        self.assertIn("assigneeAgentId=agent-42", prepared.url)
+
+    def test_prepare_request_sets_run_id_header_on_mutation(self) -> None:
+        prepared = self._client().prepare_request(
+            "update_issue",
+            path_params={"issue_id": "issue-1"},
+            payload={"status": "done", "comment": "Finished."},
+            run_id="run-123",
+        )
+        self.assertEqual(prepared.headers["Authorization"], "Bearer pc_test_token")
+        self.assertEqual(prepared.headers["X-Paperclip-Run-Id"], "run-123")
+        self.assertEqual(prepared.json_body["status"], "done")
+
+    def test_prepare_request_ignores_run_id_for_read_operation(self) -> None:
+        prepared = self._client().prepare_request("get_issue", path_params={"issue_id": "issue-1"}, run_id="run-123")
+        self.assertNotIn("X-Paperclip-Run-Id", prepared.headers)
+
+    def test_prepare_request_raises_on_missing_path_param(self) -> None:
+        with self.assertRaises(ValueError):
+            self._client().prepare_request("get_company")
+
+    def test_prepare_request_raises_on_query_for_non_query_operation(self) -> None:
+        with self.assertRaises(ValueError):
+            self._client().prepare_request("get_issue", path_params={"issue_id": "issue-1"}, query={"status": "todo"})
+
+    def test_prepare_request_raises_on_missing_required_payload(self) -> None:
+        with self.assertRaises(ValueError):
+            self._client().prepare_request("create_issue", path_params={"company_id": "company-1"})
+
+    def test_prepare_request_rejects_payload_for_payloadless_operation(self) -> None:
+        with self.assertRaises(ValueError):
+            self._client().prepare_request("list_companies", payload={"unexpected": True})
+
+    def test_execute_operation_delegates_to_request_executor(self) -> None:
+        captured: list[dict[str, object]] = []
+
+        def fake_request(method: str, url: str, **kwargs: object) -> dict[str, object]:
+            captured.append({"method": method, "url": url, **kwargs})
+            return {"id": "company-1"}
+
+        result = self._client(request_executor=fake_request).execute_operation("list_companies")
+        self.assertEqual(result["id"], "company-1")
+        self.assertEqual(captured[0]["method"], "GET")
+        self.assertIn("/companies", captured[0]["url"])
+
+
+class PaperclipToolsTests(unittest.TestCase):
+    def test_create_paperclip_tools_returns_registerable_tuple(self) -> None:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        tools = create_paperclip_tools(credentials=credentials)
+        self.assertEqual(len(tools), 1)
+        ToolRegistry(tools)
+
+    def test_tool_definition_key_is_paperclip_request(self) -> None:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        tools = create_paperclip_tools(credentials=credentials)
+        self.assertEqual(tools[0].definition.key, PAPERCLIP_REQUEST)
+
+    def test_tool_handler_executes_operation(self) -> None:
+        captured: list[dict[str, object]] = []
+
+        def fake_request(method: str, url: str, **kwargs: object) -> dict[str, object]:
+            captured.append({"method": method, "url": url, **kwargs})
+            return {"id": "issue-1", "status": "done"}
+
+        client = PaperclipClient(credentials=PaperclipCredentials(api_key="pc_test_token"), request_executor=fake_request)
+        registry = ToolRegistry(create_paperclip_tools(client=client))
+
+        result = registry.execute(
+            PAPERCLIP_REQUEST,
+            {
+                "operation": "update_issue",
+                "path_params": {"issue_id": "issue-1"},
+                "payload": {"status": "done", "comment": "Finished."},
+                "run_id": "run-123",
+            },
+        )
+
+        self.assertEqual(result.output["operation"], "update_issue")
+        self.assertEqual(captured[0]["headers"]["X-Paperclip-Run-Id"], "run-123")
+        self.assertEqual(captured[0]["json_body"]["status"], "done")
+
+    def test_create_paperclip_tools_raises_without_credentials_or_client(self) -> None:
+        with self.assertRaises(ValueError):
+            create_paperclip_tools()
+
+    def test_allowed_operations_subset(self) -> None:
+        credentials = PaperclipCredentials(api_key="pc_test_token")
+        tools = create_paperclip_tools(credentials=credentials, allowed_operations=["get_current_agent", "list_issues"])
+        enum_values = tools[0].definition.input_schema["properties"]["operation"]["enum"]
+        self.assertEqual(set(enum_values), {"get_current_agent", "list_issues"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `paperclip` provider package with a declarative control-plane operation catalog and authenticated JSON request client
- register `paperclip.request` in the shared tool constants, tool exports, and toolset catalog
- add Paperclip tooling coverage for provider preparation and tool execution paths
- include the required one-line syntax fix in `harnessiq/providers/__init__.py` so provider imports succeed on `origin/main`

## Verification
- `Scripts\\pytest.exe .worktrees\\issue-166-paperclip\\tests\\test_paperclip_provider.py -q`
- Paperclip registration smoke check via direct import from the clean worktree

## Notes
- `Scripts\\pytest.exe .worktrees\\issue-166-paperclip\\tests\\test_toolset_registry.py -q` still reports two existing `arxiv.request` expectation failures already present on `origin/main`; this PR does not change that behavior

Closes #166
Closes #167
