### PR TITLE
Fix Instagram snippet extraction and agent wiring

### DIFF
--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -70,7 +70,6 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             search_result_limit=search_result_limit,
         )
 
-        tool_registry = ToolRegistry(self._build_internal_tools())
         bound_search_tool = create_instagram_tools(
             memory_store=self._memory_store,
             search_backend=self._search_backend,
@@ -85,7 +84,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
                 ),
             )
         )
-        runtime_config = AgentRuntimeConfig(
+        base_runtime_config = AgentRuntimeConfig(
             max_tokens=max_tokens,
             reset_threshold=reset_threshold,
         )
@@ -94,7 +93,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             model=model,
             tool_executor=tool_registry,
             runtime_config=merge_agent_runtime_config(
-                runtime_config,
+                runtime_config or base_runtime_config,
                 max_tokens=max_tokens,
                 reset_threshold=reset_threshold,
             ),

--- a/harnessiq/agents/instagram/prompts/master_prompt.md
+++ b/harnessiq/agents/instagram/prompts/master_prompt.md
@@ -21,6 +21,7 @@ Turn the persisted ICP descriptions into concise search keywords, run the determ
 
 [SEARCH RULES]
 - Use the deterministic search tool instead of manual browser reasoning.
+- The deterministic search tool uses the Google pattern `site:instagram .com "@gmail .com" <keyword>` and extracts emails from Google result snippets, not by opening Instagram profiles.
 - Treat persisted memory as the source of truth for what has already been searched and found.
 - Stop when there are no materially new keywords left or when searches stop producing novel leads.
 

--- a/harnessiq/integrations/instagram_playwright.py
+++ b/harnessiq/integrations/instagram_playwright.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -13,12 +14,14 @@ from harnessiq.providers.playwright import (
     PlaywrightBrowserSession,
     goto_page,
     read_page_text,
-    safe_page_title,
     wait_for_page_ready,
 )
 from harnessiq.shared.instagram import (
     DEFAULT_INSTAGRAM_BROWSER_CHANNEL,
+    DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,
+    DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS,
     DEFAULT_INSTAGRAM_BROWSER_VIEWPORT,
+    DEFAULT_INSTAGRAM_HEADLESS,
     DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS,
     DEFAULT_INSTAGRAM_TIMEOUT_MS,
     INSTAGRAM_GOOGLE_SEARCH_URL,
@@ -26,6 +29,7 @@ from harnessiq.shared.instagram import (
     InstagramSearchBackend,
     InstagramSearchExecution,
     InstagramSearchRecord,
+    build_instagram_google_fallback_query,
     build_instagram_google_query,
     extract_emails,
 )
@@ -44,11 +48,13 @@ class PlaywrightInstagramSearchBackend:
         self,
         *,
         session_dir: str | Path | None = None,
-        headless: bool = True,
+        headless: bool = DEFAULT_INSTAGRAM_HEADLESS,
         channel: str = DEFAULT_INSTAGRAM_BROWSER_CHANNEL,
         timeout_ms: int = DEFAULT_INSTAGRAM_TIMEOUT_MS,
         network_idle_timeout_ms: int = DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS,
         search_interval_seconds: float = _DEFAULT_SEARCH_INTERVAL_SECONDS,
+        launch_args: Sequence[str] | None = None,
+        init_scripts: Sequence[str] | None = None,
     ) -> None:
         self._session_dir = Path(session_dir) if session_dir else None
         self._headless = headless
@@ -56,60 +62,54 @@ class PlaywrightInstagramSearchBackend:
         self._timeout_ms = timeout_ms
         self._network_idle_timeout_ms = network_idle_timeout_ms
         self._search_interval_seconds = max(0.0, float(search_interval_seconds))
+        self._launch_args = (
+            tuple(str(value) for value in launch_args)
+            if launch_args is not None
+            else DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS
+        )
+        self._init_scripts = (
+            tuple(str(value) for value in init_scripts if str(value).strip())
+            if init_scripts is not None
+            else (DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,)
+        )
         self._session: PlaywrightBrowserSession | None = None
         self._search_page: Any = None
         self._last_search_started_at: float | None = None
 
     def search_keyword(self, *, keyword: str, max_results: int) -> InstagramSearchExecution:
         query = build_instagram_google_query(keyword)
-        search_url = f"{INSTAGRAM_GOOGLE_SEARCH_URL}?q={quote_plus(query)}"
         self._wait_for_next_search_slot()
         self._last_search_started_at = time.monotonic()
 
         search_page = self._get_search_page()
-        goto_page(search_page, url=search_url, timeout_ms=self._timeout_ms)
-        wait_for_page_ready(
-            search_page,
-            timeout_ms=self._timeout_ms,
-            network_idle_timeout_ms=self._network_idle_timeout_ms,
-        )
-        self._raise_if_google_blocked(search_page, keyword=keyword)
+        executed_query = self._load_query(search_page, keyword=keyword, query=query)
 
-        candidate_urls = self._extract_instagram_urls(search_page, max_results=max_results)
-        visited_urls: list[str] = []
+        result_entries = self._extract_google_result_entries(search_page, max_results=max_results)
+        visited_urls = [entry["source_url"] for entry in result_entries]
         leads: list[InstagramLeadRecord] = []
 
-        for url in candidate_urls:
-            detail_page = self._get_session().new_page()
-            try:
-                goto_page(detail_page, url=url, timeout_ms=self._timeout_ms)
-                wait_for_page_ready(
-                    detail_page,
-                    timeout_ms=self._timeout_ms,
-                    network_idle_timeout_ms=self._network_idle_timeout_ms,
+        for entry in result_entries:
+            text = "\n".join(
+                part for part in (entry["title"], entry["snippet"], entry["text"]) if part
+            ).strip()
+            emails = extract_emails(text)
+            if not emails:
+                continue
+            leads.append(
+                InstagramLeadRecord(
+                    source_url=entry["source_url"],
+                    source_keyword=keyword,
+                    found_at=_utcnow(),
+                    emails=tuple(emails),
+                    title=entry["title"],
+                    snippet=(entry["snippet"] or entry["text"])[:500].strip(),
                 )
-                visited_urls.append(detail_page.url)
-                text = read_page_text(detail_page)
-                emails = extract_emails(text)
-                if not emails:
-                    continue
-                leads.append(
-                    InstagramLeadRecord(
-                        source_url=detail_page.url,
-                        source_keyword=keyword,
-                        found_at=_utcnow(),
-                        emails=tuple(emails),
-                        title=safe_page_title(detail_page),
-                        snippet=text[:500].strip(),
-                    )
-                )
-            finally:
-                detail_page.close()
+            )
 
         email_count = sum(len(lead.emails) for lead in leads)
         search_record = InstagramSearchRecord(
             keyword=keyword,
-            query=query,
+            query=executed_query,
             searched_at=_utcnow(),
             visited_urls=tuple(visited_urls),
             lead_count=len(leads),
@@ -133,6 +133,8 @@ class PlaywrightInstagramSearchBackend:
                 headless=self._headless,
                 viewport=DEFAULT_INSTAGRAM_BROWSER_VIEWPORT,
                 import_error_message=_DEFAULT_IMPORT_ERROR_MESSAGE,
+                launch_args=self._launch_args,
+                init_scripts=self._init_scripts,
             )
             session.start()
             self._session = session
@@ -165,22 +167,67 @@ class PlaywrightInstagramSearchBackend:
                 "anti-bot interstitial."
             )
 
-    def _extract_instagram_urls(self, page: Any, *, max_results: int) -> list[str]:
+    def _load_query(self, page: Any, *, keyword: str, query: str) -> str:
+        self._navigate_to_query(page, query=query)
+        self._raise_if_google_blocked(page, keyword=keyword)
+        if self._has_no_search_results(page):
+            fallback_query = build_instagram_google_fallback_query(keyword)
+            if fallback_query != query:
+                self._navigate_to_query(page, query=fallback_query)
+                self._raise_if_google_blocked(page, keyword=keyword)
+                return fallback_query
+        return query
+
+    def _navigate_to_query(self, page: Any, *, query: str) -> None:
+        search_url = f"{INSTAGRAM_GOOGLE_SEARCH_URL}?q={quote_plus(query)}"
+        goto_page(page, url=search_url, timeout_ms=self._timeout_ms)
+        wait_for_page_ready(
+            page,
+            timeout_ms=self._timeout_ms,
+            network_idle_timeout_ms=self._network_idle_timeout_ms,
+        )
+
+    def _has_no_search_results(self, page: Any) -> bool:
+        body_text = read_page_text(page).lower()
+        return "no results found for" in body_text or "your search did not match any documents" in body_text
+
+    def _extract_google_result_entries(self, page: Any, *, max_results: int) -> list[dict[str, str]]:
         raw_entries = page.eval_on_selector_all(
             "a[href]",
             """
             elements => elements.map(element => ({
                 href: element.getAttribute('href') || '',
-                text: (element.innerText || '').trim()
+                title: (
+                    element.closest('div[data-ved], div.g, div.Gx5Zad, div.tF2Cxc')?.querySelector('h3')?.innerText
+                    || ''
+                ).trim(),
+                snippet: (
+                    element.closest('div[data-ved], div.g, div.Gx5Zad, div.tF2Cxc')
+                        ?.querySelector('.VwiC3b, .yXK7lf, .MUxGbd, [data-sncf="1"]')
+                        ?.innerText
+                    || ''
+                ).trim(),
+                text: (
+                    element.closest('div[data-ved], div.g, div.Gx5Zad, div.tF2Cxc')?.innerText
+                    || element.innerText
+                    || ''
+                ).trim()
             }))
             """,
         )
-        result: list[str] = []
+        result: list[dict[str, str]] = []
         for entry in raw_entries:
             normalized = _normalize_candidate_url(str(entry.get("href", "")), base_url=page.url)
-            if normalized is None or normalized in result:
+            if normalized is None or any(item["source_url"] == normalized for item in result):
                 continue
-            result.append(normalized)
+            result.append(
+                {
+                    "source_url": normalized,
+                    "title": str(entry.get("title", "")).strip(),
+                    "snippet": str(entry.get("snippet", "")).strip(),
+                    "text": str(entry.get("text", "")).strip(),
+                }
+            )
             if len(result) >= max_results:
                 break
         return result
@@ -193,7 +240,11 @@ def create_search_backend() -> InstagramSearchBackend:
         os.environ.get("HARNESSIQ_INSTAGRAM_BROWSER_CHANNEL", DEFAULT_INSTAGRAM_BROWSER_CHANNEL).strip()
         or DEFAULT_INSTAGRAM_BROWSER_CHANNEL
     )
-    headless = _parse_bool(os.environ.get("HARNESSIQ_INSTAGRAM_HEADLESS"), default=True)
+    headless = _parse_bool(os.environ.get("HARNESSIQ_INSTAGRAM_HEADLESS"), default=DEFAULT_INSTAGRAM_HEADLESS)
+    hardening_disabled = _parse_bool(
+        os.environ.get("HARNESSIQ_INSTAGRAM_DISABLE_BROWSER_HARDENING"),
+        default=False,
+    )
     session_dir = Path(session_dir_env) if session_dir_env else None
     return PlaywrightInstagramSearchBackend(
         session_dir=session_dir,
@@ -203,6 +254,8 @@ def create_search_backend() -> InstagramSearchBackend:
             os.environ.get("HARNESSIQ_INSTAGRAM_SEARCH_INTERVAL_SECONDS"),
             default=_DEFAULT_SEARCH_INTERVAL_SECONDS,
         ),
+        launch_args=() if hardening_disabled else None,
+        init_scripts=() if hardening_disabled else None,
     )
 
 
@@ -217,9 +270,13 @@ def _normalize_candidate_url(raw_url: str, *, base_url: str) -> str | None:
     parsed = urlparse(candidate)
     if parsed.scheme not in {"http", "https"}:
         return None
-    if "instagram.com" not in parsed.netloc.lower():
+    normalized_netloc = parsed.netloc.lower()
+    if "instagram.com" not in normalized_netloc:
         return None
-    return parsed._replace(fragment="").geturl()
+    if normalized_netloc.endswith("instagram.com"):
+        normalized_netloc = "www.instagram.com"
+    normalized_path = parsed.path or "/"
+    return parsed._replace(netloc=normalized_netloc, path=normalized_path, query="", fragment="").geturl()
 
 
 def _parse_bool(value: str | None, *, default: bool) -> bool:

--- a/harnessiq/providers/playwright/browser.py
+++ b/harnessiq/providers/playwright/browser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -19,12 +19,16 @@ class PlaywrightBrowserSession:
         headless: bool,
         viewport: Mapping[str, int],
         import_error_message: str,
+        launch_args: Sequence[str] = (),
+        init_scripts: Sequence[str] = (),
     ) -> None:
         self._session_dir = Path(session_dir) if session_dir is not None else None
         self._channel = channel
         self._headless = headless
         self._viewport = dict(viewport)
         self._import_error_message = import_error_message
+        self._launch_args = tuple(str(value) for value in launch_args)
+        self._init_scripts = tuple(str(value) for value in init_scripts if str(value).strip())
         self._playwright: Any = None
         self._browser: Any = None
         self._context: Any = None
@@ -52,14 +56,18 @@ class PlaywrightBrowserSession:
                 channel=self._channel,
                 headless=self._headless,
                 viewport=dict(self._viewport),
+                args=list(self._launch_args),
             )
             self._browser = None
+            self._apply_init_scripts()
             return
         self._browser = self._playwright.chromium.launch(
             channel=self._channel,
             headless=self._headless,
+            args=list(self._launch_args),
         )
         self._context = self._browser.new_context(viewport=dict(self._viewport))
+        self._apply_init_scripts()
 
     def get_or_create_page(self) -> Any:
         """Return the first existing page in the live context or create one."""
@@ -84,6 +92,12 @@ class PlaywrightBrowserSession:
         self._playwright = None
         self._browser = None
         self._context = None
+
+    def _apply_init_scripts(self) -> None:
+        if self._context is None:
+            return
+        for script in self._init_scripts:
+            self._context.add_init_script(script)
 
 
 @contextmanager

--- a/harnessiq/shared/instagram.py
+++ b/harnessiq/shared/instagram.py
@@ -18,9 +18,18 @@ AGENT_IDENTITY_FILENAME = "agent_identity.txt"
 ADDITIONAL_PROMPT_FILENAME = "additional_prompt.txt"
 INSTAGRAM_GOOGLE_SEARCH_URL = "https://www.google.com/search"
 DEFAULT_INSTAGRAM_BROWSER_CHANNEL = "chrome"
+DEFAULT_INSTAGRAM_HEADLESS = False
 DEFAULT_INSTAGRAM_TIMEOUT_MS = 30_000
 DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS = 5_000
 DEFAULT_INSTAGRAM_BROWSER_VIEWPORT = {"width": 1280, "height": 900}
+DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS = ("--disable-blink-features=AutomationControlled",)
+DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT = """
+Object.defineProperty(navigator, 'webdriver', {get: () => undefined});
+Object.defineProperty(navigator, 'languages', {get: () => ['en-US', 'en']});
+Object.defineProperty(navigator, 'platform', {get: () => 'Win32'});
+Object.defineProperty(navigator, 'plugins', {get: () => [1, 2, 3, 4, 5]});
+window.chrome = window.chrome || { runtime: {} };
+"""
 
 DEFAULT_RECENT_SEARCH_WINDOW = 10
 DEFAULT_RECENT_RESULT_WINDOW = 10
@@ -28,11 +37,14 @@ DEFAULT_SEARCH_RESULT_LIMIT = 5
 
 DEFAULT_AGENT_IDENTITY = (
     "A deterministic Instagram creator discovery agent that turns ICP descriptions into concise "
-    "Google search keywords, runs targeted site:instagram.com searches, extracts public emails from "
-    "loaded pages, and persists every verified discovery to durable memory."
+    "Google search keywords, runs targeted spaced site:instagram Google searches, extracts public "
+    "emails from Google result snippets, and persists every verified discovery to durable memory."
 )
 
-_EMAIL_PATTERN = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
+_EMAIL_PATTERN = re.compile(
+    r"[A-Z0-9._%+-]+\s*@\s*(?:[A-Z0-9-]+\s*\.(?!\s))+[A-Z]{2,63}\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -345,14 +357,22 @@ def build_instagram_google_query(keyword: str) -> str:
     cleaned_keyword = keyword.strip()
     if not cleaned_keyword:
         raise ValueError("keyword must not be blank.")
-    return f'site:instagram.com "@gmail.com" "{cleaned_keyword}"'
+    return f'site:instagram .com "@gmail .com" {cleaned_keyword}'
+
+
+def build_instagram_google_fallback_query(keyword: str) -> str:
+    """Build the Google fallback query when the spaced query yields no results."""
+    cleaned_keyword = keyword.strip()
+    if not cleaned_keyword:
+        raise ValueError("keyword must not be blank.")
+    return f'site:instagram.com "@gmail.com" {cleaned_keyword}'
 
 
 def extract_emails(text: str) -> list[str]:
     """Return unique normalized email addresses from a text blob."""
     if not text:
         return []
-    return _dedupe_emails(_EMAIL_PATTERN.findall(text))
+    return _dedupe_emails(_normalize_email_match(match.group(0)) for match in _EMAIL_PATTERN.finditer(text))
 
 
 def normalize_instagram_runtime_parameters(parameters: dict[str, Any]) -> dict[str, Any]:
@@ -450,12 +470,19 @@ def _dedupe_strings(values: Sequence[str]) -> list[str]:
     return result
 
 
+def _normalize_email_match(value: str) -> str:
+    return re.sub(r"\s+", "", value.strip()).lower()
+
+
 __all__ = [
     "ADDITIONAL_PROMPT_FILENAME",
     "AGENT_IDENTITY_FILENAME",
     "DEFAULT_AGENT_IDENTITY",
     "DEFAULT_INSTAGRAM_BROWSER_CHANNEL",
+    "DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT",
+    "DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS",
     "DEFAULT_INSTAGRAM_BROWSER_VIEWPORT",
+    "DEFAULT_INSTAGRAM_HEADLESS",
     "DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS",
     "DEFAULT_INSTAGRAM_TIMEOUT_MS",
     "DEFAULT_RECENT_RESULT_WINDOW",
@@ -474,6 +501,7 @@ __all__ = [
     "LeadMergeSummary",
     "RUNTIME_PARAMETERS_FILENAME",
     "SEARCH_HISTORY_FILENAME",
+    "build_instagram_google_fallback_query",
     "build_instagram_google_query",
     "extract_emails",
     "normalize_instagram_runtime_parameters",

--- a/harnessiq/tools/instagram.py
+++ b/harnessiq/tools/instagram.py
@@ -41,9 +41,9 @@ def _search_keyword_definition() -> ToolDefinition:
         key=INSTAGRAM_SEARCH_KEYWORD,
         name="search_keyword",
         description=(
-            "Run a deterministic Google site:instagram.com search for one keyword, load the search page "
-            "and opened result tabs fully, extract public emails from visited pages, and persist all "
-            "new leads/emails to durable memory."
+            "Run a deterministic Google site:instagram search for one keyword, inspect the Google "
+            "results page using the spaced query pattern, extract public emails from result snippets "
+            "without opening Instagram pages, and persist all new leads/emails to durable memory."
         ),
         input_schema={
             "type": "object",
@@ -54,7 +54,7 @@ def _search_keyword_definition() -> ToolDefinition:
                 },
                 "max_results": {
                     "type": "integer",
-                    "description": "Maximum number of Instagram result URLs to open for this keyword.",
+                    "description": "Maximum number of Google result rows to inspect for this keyword.",
                 },
             },
             "required": ["keyword"],

--- a/tests/test_instagram_agent.py
+++ b/tests/test_instagram_agent.py
@@ -64,7 +64,7 @@ def _build_execution(keyword: str = "fitness coach") -> InstagramSearchExecution
     )
     search_record = InstagramSearchRecord(
         keyword=keyword,
-        query='site:instagram.com "@gmail.com" "fitness coach"',
+        query='site:instagram .com "@gmail .com" fitness coach',
         searched_at="2026-03-19T00:00:00Z",
         visited_urls=("https://www.instagram.com/creator-a/",),
         lead_count=1,

--- a/tests/test_instagram_playwright.py
+++ b/tests/test_instagram_playwright.py
@@ -9,6 +9,14 @@ from harnessiq.integrations.instagram_playwright import (
     PlaywrightInstagramSearchBackend,
     _normalize_candidate_url,
 )
+from harnessiq.shared.instagram import (
+    DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,
+    DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS,
+    DEFAULT_INSTAGRAM_HEADLESS,
+    build_instagram_google_fallback_query,
+    build_instagram_google_query,
+    extract_emails,
+)
 
 
 class _FakePage:
@@ -19,17 +27,25 @@ class _FakePage:
         body_text: str = "",
         title_text: str = "",
         entries: list[dict[str, str]] | None = None,
+        states: dict[str, dict[str, object]] | None = None,
     ) -> None:
         self.url = url
         self._body_text = body_text
         self._title_text = title_text
         self._entries = list(entries or [])
+        self._states = dict(states or {})
         self.goto_calls: list[str] = []
         self.closed = False
 
     def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
         self.goto_calls.append(url)
         self.url = url
+        for pattern, state in self._states.items():
+            if pattern in url:
+                self._body_text = str(state.get("body_text", self._body_text))
+                self._title_text = str(state.get("title_text", self._title_text))
+                self._entries = list(state.get("entries", self._entries))
+                break
 
     def wait_for_load_state(self, state: str, *, timeout: int) -> None:
         return None
@@ -75,6 +91,30 @@ class _FakeSession:
 
 
 class InstagramPlaywrightTests(unittest.TestCase):
+    def test_build_instagram_google_query_uses_spaced_email_pattern(self) -> None:
+        self.assertEqual(
+            build_instagram_google_query("ai educator"),
+            'site:instagram .com "@gmail .com" ai educator',
+        )
+
+    def test_extract_emails_normalizes_spaced_google_snippet_addresses(self) -> None:
+        self.assertEqual(
+            extract_emails("Reach me at Creator@Gmail .com or creator@gmail.com"),
+            ["creator@gmail.com"],
+        )
+
+    def test_extract_emails_ignores_sentence_text_after_email(self) -> None:
+        self.assertEqual(
+            extract_emails("Collab: iamchonchol94@gmail.com. Sharing the latest updates."),
+            ["iamchonchol94@gmail.com"],
+        )
+
+    def test_build_instagram_google_fallback_query_uses_google_operator_form(self) -> None:
+        self.assertEqual(
+            build_instagram_google_fallback_query("ai educator"),
+            'site:instagram.com "@gmail.com" ai educator',
+        )
+
     def test_normalize_candidate_url_unwraps_google_redirects(self) -> None:
         normalized = _normalize_candidate_url(
             "/url?q=https://www.instagram.com/creator-a/&sa=U&ved=2ah",
@@ -91,25 +131,26 @@ class InstagramPlaywrightTests(unittest.TestCase):
 
         self.assertIsNone(normalized)
 
+    def test_normalize_candidate_url_canonicalizes_instagram_fallback_domain(self) -> None:
+        normalized = _normalize_candidate_url(
+            "https://www-fallback.instagram.com/creator-a/?hl=en",
+            base_url="https://www.google.com/search?q=ugc",
+        )
+
+        self.assertEqual(normalized, "https://www.instagram.com/creator-a/")
+
     def test_backend_reuses_one_session_and_search_page_across_searches(self) -> None:
         search_page = _FakePage(
             entries=[
-                {"href": "/url?q=https://www.instagram.com/creator-a/&sa=U", "text": "Creator A"},
+                {
+                    "href": "/url?q=https://www.instagram.com/creator-a/&sa=U",
+                    "title": "Creator A",
+                    "snippet": "creator@gmail .com ai educator",
+                    "text": "Creator A creator@gmail .com ai educator",
+                },
             ]
         )
-        detail_pages = [
-            _FakePage(
-                url="https://www.instagram.com/creator-a/",
-                body_text="creator@example.com ai educator",
-                title_text="Creator A",
-            ),
-            _FakePage(
-                url="https://www.instagram.com/creator-a/",
-                body_text="creator@example.com ai educator",
-                title_text="Creator A",
-            ),
-        ]
-        fake_session = _FakeSession(search_page=search_page, detail_pages=detail_pages)
+        fake_session = _FakeSession(search_page=search_page, detail_pages=[])
 
         with patch(
             "harnessiq.integrations.instagram_playwright.PlaywrightBrowserSession",
@@ -121,10 +162,52 @@ class InstagramPlaywrightTests(unittest.TestCase):
 
         self.assertEqual(fake_session.start_calls, 1)
         self.assertEqual(fake_session.get_or_create_page_calls, 1)
-        self.assertEqual(fake_session.new_page_calls, 2)
+        self.assertEqual(fake_session.new_page_calls, 0)
         self.assertEqual(len(search_page.goto_calls), 2)
         self.assertEqual(first.search_record.lead_count, 1)
         self.assertEqual(second.search_record.lead_count, 1)
+        self.assertEqual(first.search_record.visited_urls, ("https://www.instagram.com/creator-a/",))
+        self.assertEqual(first.leads[0].emails, ("creator@gmail.com",))
+        self.assertEqual(first.leads[0].source_url, "https://www.instagram.com/creator-a/")
+
+    def test_backend_falls_back_when_spaced_query_returns_no_results(self) -> None:
+        search_page = _FakePage(
+            states={
+                'site%3Ainstagram+.com+%22%40gmail+.com%22+ai+educator': {
+                    "body_text": (
+                        "No results found for site:instagram .com \"@gmail .com\" ai educator. "
+                        "Your search did not match any documents."
+                    ),
+                    "entries": [],
+                },
+                'site%3Ainstagram.com+%22%40gmail.com%22+ai+educator': {
+                    "body_text": "Search Results Creator A creator@gmail.com",
+                    "entries": [
+                        {
+                            "href": "/url?q=https://www.instagram.com/creator-a/&sa=U",
+                            "title": "Creator A",
+                            "snippet": "creator@gmail.com ai educator",
+                            "text": "Creator A creator@gmail.com ai educator",
+                        }
+                    ],
+                },
+            }
+        )
+        fake_session = _FakeSession(search_page=search_page, detail_pages=[])
+
+        with patch(
+            "harnessiq.integrations.instagram_playwright.PlaywrightBrowserSession",
+            return_value=fake_session,
+        ):
+            backend = PlaywrightInstagramSearchBackend(search_interval_seconds=0)
+            result = backend.search_keyword(keyword="ai educator", max_results=1)
+
+        self.assertEqual(len(search_page.goto_calls), 2)
+        self.assertEqual(
+            result.search_record.query,
+            'site:instagram.com "@gmail.com" ai educator',
+        )
+        self.assertEqual(result.search_record.lead_count, 1)
 
     def test_backend_raises_explicit_error_for_google_sorry_page(self) -> None:
         search_page = _FakePage(
@@ -157,6 +240,44 @@ class InstagramPlaywrightTests(unittest.TestCase):
         self.assertEqual(fake_session.close_calls, 1)
         self.assertIsNone(backend._session)
         self.assertIsNone(backend._search_page)
+
+    def test_backend_creates_hardened_headed_session(self) -> None:
+        search_page = _FakePage(entries=[])
+        fake_session = _FakeSession(search_page=search_page, detail_pages=[])
+
+        with patch(
+            "harnessiq.integrations.instagram_playwright.PlaywrightBrowserSession",
+            return_value=fake_session,
+        ) as session_ctor:
+            backend = PlaywrightInstagramSearchBackend(search_interval_seconds=0)
+            backend._get_session()
+
+        session_ctor.assert_called_once()
+        kwargs = session_ctor.call_args.kwargs
+        self.assertEqual(kwargs["headless"], DEFAULT_INSTAGRAM_HEADLESS)
+        self.assertEqual(kwargs["launch_args"], DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS)
+        self.assertEqual(kwargs["init_scripts"], (DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,))
+
+    def test_backend_allows_explicit_session_hardening_overrides(self) -> None:
+        search_page = _FakePage(entries=[])
+        fake_session = _FakeSession(search_page=search_page, detail_pages=[])
+
+        with patch(
+            "harnessiq.integrations.instagram_playwright.PlaywrightBrowserSession",
+            return_value=fake_session,
+        ) as session_ctor:
+            backend = PlaywrightInstagramSearchBackend(
+                search_interval_seconds=0,
+                headless=True,
+                launch_args=("--custom-arg",),
+                init_scripts=("window.__custom = true;",),
+            )
+            backend._get_session()
+
+        kwargs = session_ctor.call_args.kwargs
+        self.assertTrue(kwargs["headless"])
+        self.assertEqual(kwargs["launch_args"], ("--custom-arg",))
+        self.assertEqual(kwargs["init_scripts"], ("window.__custom = true;",))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix the Instagram agent constructor regression on main so the harness can run again
- switch Instagram discovery to extract emails from Google result snippets instead of opening Instagram pages
- harden the Playwright browser session, add no-results fallback from the spaced query to the operator form, and canonicalize Instagram URLs for dedupe

## Verification
- `python -m unittest tests.test_instagram_playwright tests.test_instagram_agent tests.test_instagram_cli`
- `python -m compileall harnessiq/providers/playwright/browser.py harnessiq/shared/instagram.py harnessiq/integrations/instagram_playwright.py harnessiq/tools/instagram.py harnessiq/agents/instagram/agent.py tests/test_instagram_playwright.py tests/test_instagram_agent.py`
- live backend smoke on this branch: `search_keyword("ai educator", max_results=5)` returned snippet-derived leads/emails without opening Instagram pages
- live agent smoke on this branch with a deterministic local stub model and the real Playwright backend: 5 cycles completed for the AI education niche and persisted 18 emails / 15 leads under `memory/instagram/ai-education-main-check-stub`

## Notes
- current xAI calls in this shell returned `403 Forbidden`, so the end-to-end live agent verification used a local deterministic model stub to drive the real browser-backed Instagram search path
