### PR TITLE
fix(prospecting): restore Google Maps browser tool binding

### DIFF
--- a/harnessiq/integrations/google_maps_playwright.py
+++ b/harnessiq/integrations/google_maps_playwright.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from harnessiq.tools.browser import create_browser_tools
+from harnessiq.shared.tools import RegisteredTool
+from harnessiq.tools.browser import create_browser_tools as create_registered_browser_tools
 
 _DEFAULT_TIMEOUT_MS = 30_000
 _NETWORK_IDLE_TIMEOUT_MS = 5_000
@@ -101,8 +102,8 @@ class PlaywrightGoogleMapsSession:
         except Exception:
             pass
 
-    def build_tools(self):
-        return create_browser_tools(
+    def build_tools(self) -> tuple[RegisteredTool, ...]:
+        return create_registered_browser_tools(
             handlers={
                 "navigate": self._handle_navigate,
                 "click": self._handle_click,
@@ -333,7 +334,7 @@ class PlaywrightGoogleMapsSession:
             return 0
 
 
-def create_browser_tools():
+def create_browser_tools() -> tuple[RegisteredTool, ...]:
     session_dir_env = os.environ.get("HARNESSIQ_PROSPECTING_SESSION_DIR", "").strip()
     channel = os.environ.get("HARNESSIQ_PROSPECTING_BROWSER_CHANNEL", "chrome").strip() or "chrome"
     headless = _parse_bool(os.environ.get("HARNESSIQ_PROSPECTING_HEADLESS"), default=True)

--- a/memory/fix-prospecting-browser-tools-factory/clarifications.md
+++ b/memory/fix-prospecting-browser-tools-factory/clarifications.md
@@ -1,0 +1,4 @@
+No blocking ambiguities remained after Phase 1.
+
+- The traceback identified a concrete, source-level defect with a single correct fix direction.
+- The user’s success criterion is explicit: use the same command, remove the startup failure, and confirm the agent runs.

--- a/memory/fix-prospecting-browser-tools-factory/internalization.md
+++ b/memory/fix-prospecting-browser-tools-factory/internalization.md
@@ -1,0 +1,40 @@
+### 1a: Structural Survey
+
+- `harnessiq/` is the live runtime source tree; generated build residue exists under `build/` and `src/` but is not authoritative.
+- The repo is a Python 3.11+ SDK with argparse-based CLIs under `harnessiq/cli/`, harness implementations under `harnessiq/agents/`, shared manifests/state models under `harnessiq/shared/`, deterministic tool factories under `harnessiq/tools/`, and concrete external runtime adapters under `harnessiq/integrations/`.
+- The prospecting path is split cleanly:
+  - `harnessiq/cli/prospecting/commands.py` parses persisted memory/config, loads a model factory and browser-tools factory, and starts `GoogleMapsProspectingAgent.from_memory(...)`.
+  - `harnessiq/agents/prospecting/agent.py` composes canonical browser tool definitions with runtime handlers, prospecting-specific public/internal tools, and durable memory/state updates.
+  - `harnessiq/shared/prospecting.py` owns the manifest, defaults, typed custom/runtime parameter coercion, and durable files under `memory/prospecting/<agent>/`.
+  - `harnessiq/integrations/google_maps_playwright.py` provides the Playwright-backed browser handlers and the CLI browser-tools factory used by `--browser-tools-factory`.
+- Shared browser-tool definitions are centralized in `harnessiq/tools/browser.py`. That module expects integrations to bind the canonical definitions to concrete handlers via `create_browser_tools(handlers=...)`.
+- Test coverage follows the same boundaries: CLI tests in `tests/test_prospecting_cli.py`, shared browser tool tests in `tests/test_prospecting_tools.py`, and Google Maps Playwright integration tests in `tests/test_google_maps_playwright.py`.
+- Conventions observed in the relevant code:
+  - Durable runtime state lives under `memory/`.
+  - CLI factory hooks use `module:callable` strings and validate type/shape eagerly.
+  - Shared abstractions are preferred over duplicating tool schemas in integrations.
+
+### 1b: Task Cross-Reference
+
+- User task: run the existing Google Maps prospecting agent command successfully and fix the traceback preventing startup.
+- Failing path:
+  - `harnessiq/cli/prospecting/commands.py::_handle_run` imports and calls the `--browser-tools-factory`.
+  - The configured factory resolves to `harnessiq.integrations.google_maps_playwright:create_browser_tools`.
+  - Inside `PlaywrightGoogleMapsSession.build_tools()` the module currently calls `create_browser_tools(handlers=...)`.
+  - That module also defines its own zero-argument `create_browser_tools()` factory later in the file, so the global name resolves to the local factory at runtime instead of the imported shared binder, producing `TypeError: create_browser_tools() got an unexpected keyword argument 'handlers'`.
+- Files directly touched by this fix:
+  - `harnessiq/integrations/google_maps_playwright.py`: remove the name collision by calling the shared browser-tool binder through an unambiguous alias.
+  - `tests/test_google_maps_playwright.py`: add regression coverage that executes `session.build_tools()` so this collision fails in tests instead of only at runtime.
+- Existing behavior that must be preserved:
+  - The public CLI factory name `harnessiq.integrations.google_maps_playwright:create_browser_tools` must remain unchanged because the user command already depends on it.
+  - Shared browser tool definitions and handler names must stay aligned with `harnessiq/tools/browser.py`.
+  - Prospecting CLI behavior, memory layout, and runtime parameter semantics should not change.
+
+### 1c: Assumption & Risk Inventory
+
+- Assumption: the immediate blocker is the namespace collision, and once fixed the command should at least start the browser-tool layer successfully. This is strongly supported by the traceback and current source.
+- Assumption: keeping the exported CLI factory name unchanged is required because the user explicitly wants the same terminal command to work.
+- Risk: after the collision fix, later runtime issues may still appear (Playwright install, browser profile corruption, Google Maps page changes, API/model configuration). The success check therefore needs a real rerun of the user’s command, not tests alone.
+- Risk: the repo already has untracked runtime state under `memory/prospecting/`; implementation should avoid mutating or deleting that data except through the user’s requested run.
+
+Phase 1 complete.

--- a/memory/fix-prospecting-browser-tools-factory/tickets/index.md
+++ b/memory/fix-prospecting-browser-tools-factory/tickets/index.md
@@ -1,0 +1,1 @@
+1. Ticket 1: Fix the Google Maps browser-tool factory name collision and verify the prospecting command starts successfully.

--- a/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-critique.md
+++ b/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-critique.md
@@ -1,0 +1,14 @@
+## Self-Critique
+
+- The core fix is intentionally minimal: alias the shared browser-tool binder so the module-level CLI factory can keep its public name without shadowing the imported helper.
+- The highest-value missing guardrail after the first patch was explicit API coverage for `PlaywrightGoogleMapsSession.build_tools()`. That regression test was added because the earlier test surface exercised extraction handlers but not the browser-tool binding path that actually failed in production.
+- A small maintainability gap remained after the functional fix: the Google Maps integration factory methods did not advertise their concrete return type. I tightened that with `tuple[RegisteredTool, ...]` annotations so the module now matches the surrounding integration style more closely.
+
+## Improvements Applied
+
+- Added a regression test that binds the full shared browser-tool set through `session.build_tools()`.
+- Added explicit return annotations for `build_tools()` and the exported `create_browser_tools()` factory.
+
+## Remaining Risk
+
+- The command now clears the original browser-tool factory failure, but useful prospecting still depends on the persisted company description and browser/session state under `memory/prospecting/nj-dentists/`. In this verification run the agent completed after one cycle with the default placeholder company description, so runtime usefulness beyond startup remains a data/config concern rather than a code-path failure in this ticket.

--- a/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-quality.md
+++ b/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-quality.md
@@ -1,0 +1,60 @@
+## Stage 1 - Static Analysis
+
+- No dedicated linter configuration was found in `pyproject.toml` or adjacent repo tooling for this scoped path.
+- Applied the repo’s existing style conventions manually and reviewed the changed files with `git diff`.
+
+## Stage 2 - Type Checking
+
+- No configured project type-checker entrypoint was found for this repository.
+- Added explicit `tuple[RegisteredTool, ...]` return annotations to the Google Maps integration factory methods to keep the change self-describing and aligned with adjacent integrations.
+
+## Stage 3 - Unit Tests
+
+- Command run:
+
+```bash
+python -m pytest tests/test_google_maps_playwright.py tests/test_prospecting_tools.py tests/test_prospecting_cli.py -q
+```
+
+- Result: `14 passed in 0.43s`
+- Coverage relevant to this ticket:
+  - `tests/test_google_maps_playwright.py` now executes `PlaywrightGoogleMapsSession.build_tools()`.
+  - `tests/test_prospecting_tools.py` still validates the shared browser-tool factory contract.
+  - `tests/test_prospecting_cli.py` still validates the CLI run path and factory loading behavior.
+
+## Stage 4 - Integration & Contract Tests
+
+- No separate contract-test harness exists for this integration path.
+- The targeted CLI test suite above covers the CLI-to-factory loading boundary for the prospecting run path.
+
+## Stage 5 - Smoke & Manual Verification
+
+- Ran the user’s exact command:
+
+```bash
+python -m harnessiq.cli prospecting run `
+    --agent nj-dentists `
+    --memory-root memory/prospecting `
+    --model-factory harnessiq.integrations.grok_model:create_grok_model `
+    --browser-tools-factory harnessiq.integrations.google_maps_playwright:create_browser_tools `
+    --runtime-param max_tokens=4096 `
+    --runtime-param reset_threshold=0.8 `
+    --custom-param qualification_threshold=10 `
+    --custom-param summarize_at_x=5 `
+    --custom-param max_searches_per_run=12 `
+    --custom-param max_listings_per_search=8 `
+    --custom-param website_inspect_enabled=false `
+    --custom-param sink_record_type=prospecting_lead `
+    --max-cycles 25
+```
+
+- Result:
+  - Exit code `0`
+  - No `TypeError`
+  - Model initialized successfully (`grok-4-1-fast-reasoning`)
+  - Prospecting run returned JSON output with `status: "completed"` and `cycles_completed: 1`
+- Acceptance criteria status:
+  - `PlaywrightGoogleMapsSession.build_tools()` no longer raises the prior `TypeError`
+  - Regression coverage added and passing
+  - Targeted verification passing
+  - Exact user command now runs successfully past the prior startup failure

--- a/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1.md
+++ b/memory/fix-prospecting-browser-tools-factory/tickets/ticket-1.md
@@ -1,0 +1,36 @@
+Title: Fix the Google Maps browser-tool factory name collision
+
+Intent: Restore the `prospecting run` startup path by ensuring the Google Maps Playwright integration binds the shared browser tool definitions instead of recursively resolving its own CLI factory name.
+
+Scope:
+- Update the Google Maps Playwright integration so `PlaywrightGoogleMapsSession.build_tools()` calls the shared browser-tool binder through an unambiguous symbol.
+- Add regression coverage that executes `session.build_tools()`.
+- Verify the user’s existing `python -m harnessiq.cli prospecting run ...` command starts without the reported `TypeError`.
+- Do not change the public factory import path, prospecting agent prompts, or durable-memory semantics.
+
+Relevant Files:
+- `harnessiq/integrations/google_maps_playwright.py`: alias the shared browser factory import and use that alias inside `build_tools()`.
+- `tests/test_google_maps_playwright.py`: add a regression test for `session.build_tools()`.
+- `memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-quality.md`: record verification results.
+- `memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-critique.md`: record post-implementation critique and improvements.
+
+Approach: Keep the exported module-level `create_browser_tools()` function intact for CLI compatibility, but disambiguate the imported shared binder with an alias so `build_tools()` cannot accidentally resolve the module’s own zero-argument factory. Cover the failure mode by constructing a session with a fake page and asserting that all canonical browser tools bind successfully.
+
+Assumptions:
+- `harnessiq.tools.browser.create_browser_tools(handlers=...)` remains the canonical binding helper.
+- The existing traceback is caused by Python global name resolution in `harnessiq.integrations.google_maps_playwright`.
+- The user’s command should continue to reference `harnessiq.integrations.google_maps_playwright:create_browser_tools`.
+
+Acceptance Criteria:
+- [ ] `PlaywrightGoogleMapsSession.build_tools()` returns the shared browser tool set without raising `TypeError`.
+- [ ] The Google Maps Playwright tests cover the regression.
+- [ ] Relevant targeted tests pass.
+- [ ] The user’s exact prospecting command no longer fails with `create_browser_tools() got an unexpected keyword argument 'handlers'`.
+
+Verification Steps:
+- Run `python -m pytest tests/test_google_maps_playwright.py tests/test_prospecting_tools.py tests/test_prospecting_cli.py -q`.
+- Run the user’s exact `python -m harnessiq.cli prospecting run ...` command and confirm startup proceeds beyond the prior traceback.
+
+Dependencies: None.
+
+Drift Guard: This ticket must not redesign the browser tool abstraction, rename the CLI factory import path, or broaden into unrelated Playwright/prospecting behavior changes unless a new runtime failure discovered during verification makes that strictly necessary to satisfy the user’s command.

--- a/tests/test_google_maps_playwright.py
+++ b/tests/test_google_maps_playwright.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unittest
 
 from harnessiq.integrations.google_maps_playwright import PlaywrightGoogleMapsSession
+from harnessiq.tools.browser import build_browser_tool_definitions
 
 
 class _FakeKeyboard:
@@ -106,6 +107,16 @@ class _FakePage:
 
 
 class GoogleMapsPlaywrightTests(unittest.TestCase):
+    def test_build_tools_binds_all_shared_browser_handlers(self) -> None:
+        session = PlaywrightGoogleMapsSession()
+        session._page = _FakePage()  # type: ignore[attr-defined]
+
+        tools = session.build_tools()
+
+        self.assertEqual(len(tools), len(build_browser_tool_definitions()))
+        registry = {tool.definition.name: tool for tool in tools}
+        self.assertEqual(registry["get_current_url"].execute({}).output["url"], session.page.url)
+
     def test_extract_modes_return_structured_content(self) -> None:
         session = PlaywrightGoogleMapsSession()
         session._page = _FakePage()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fix the Google Maps prospecting Playwright integration so the browser tool binding path no longer crashes during `prospecting run`.

## What Changed

- Aliased the shared browser tool factory import in `google_maps_playwright.py` so `PlaywrightGoogleMapsSession.build_tools()` binds handlers to the canonical shared browser tool definitions instead of accidentally resolving the module's own zero-argument CLI factory.
- Added explicit `tuple[RegisteredTool, ...]` return annotations for the Google Maps browser-tool factory methods.
- Added regression coverage that executes `PlaywrightGoogleMapsSession.build_tools()` directly.
- Recorded the internalization, verification, and critique artifacts for the fix under `memory/fix-prospecting-browser-tools-factory/`.

## Files of Interest

- `harnessiq/integrations/google_maps_playwright.py`
- `tests/test_google_maps_playwright.py`
- `memory/fix-prospecting-browser-tools-factory/tickets/ticket-1-quality.md`

## How To Test

1. Run `python -m pytest tests/test_google_maps_playwright.py tests/test_prospecting_tools.py tests/test_prospecting_cli.py -q`
2. Run:

```powershell
python -m harnessiq.cli prospecting run `
    --agent nj-dentists `
    --memory-root memory/prospecting `
    --model-factory harnessiq.integrations.grok_model:create_grok_model `
    --browser-tools-factory harnessiq.integrations.google_maps_playwright:create_browser_tools `
    --runtime-param max_tokens=4096 `
    --runtime-param reset_threshold=0.8 `
    --custom-param qualification_threshold=10 `
    --custom-param summarize_at_x=5 `
    --custom-param max_searches_per_run=12 `
    --custom-param max_listings_per_search=8 `
    --custom-param website_inspect_enabled=false `
    --custom-param sink_record_type=prospecting_lead `
    --max-cycles 25
```

3. Confirm the command exits successfully and no longer raises `TypeError: create_browser_tools() got an unexpected keyword argument 'handlers'`

## Risks

- This PR fixes the startup regression in the browser-tool factory path. Prospecting quality still depends on the persisted company description and browser/session state in the target memory folder.
