### PR TITLE
Add Instagram CLI custom parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ print(result.output)
 | Service provider packages | 26 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 8 |
-| Test modules | 79 |
+| Test modules | 80 |
 
 ## Agent Matrix
 
 | Harness | CLI | Import | Memory Root | Runtime Params | Custom Params | Providers |
 | --- | --- | --- | --- | --- | --- | --- |
 | Exa Outreach | `outreach` | `harnessiq.agents.exa_outreach:ExaOutreachAgent` | `memory/outreach` | max_tokens, reset_threshold | - | exa, resend |
-| Instagram Keyword Discovery | `instagram` | `harnessiq.agents.instagram:InstagramKeywordDiscoveryAgent` | `memory/instagram` | max_tokens, recent_result_window, recent_search_window, reset_threshold, search_result_limit | - | playwright |
+| Instagram Keyword Discovery | `instagram` | `harnessiq.agents.instagram:InstagramKeywordDiscoveryAgent` | `memory/instagram` | max_tokens, recent_result_window, recent_search_window, reset_threshold, search_result_limit | open-ended | playwright |
 | Knowt Content Creator | - | `harnessiq.agents.knowt:KnowtAgent` | `memory/knowt` | max_tokens, reset_threshold | - | creatify |
 | Leads Agent | `leads` | `harnessiq.agents.leads:LeadsAgent` | `memory/leads` | max_tokens, reset_threshold, prune_search_interval, prune_token_limit, search_summary_every, search_tail_size, max_leads_per_icp | - | apollo, arcads, arxiv, attio, browser_use, coresignal, creatify, exa, expandi, inboxapp, instantly, leadiq, lemlist, lusha, outreach, paperclip, peopledatalabs, phantombuster, proxycurl, resend, salesforge, serper, smartlead, snovio, zerobounce, zoominfo |
-| LinkedIn Job Applier | `linkedin` | `harnessiq.agents.linkedin:LinkedInJobApplierAgent` | `memory/linkedin` | max_tokens, reset_threshold, action_log_window, linkedin_start_url, notify_on_pause, pause_webhook | - | playwright |
+| LinkedIn Job Applier | `linkedin` | `harnessiq.agents.linkedin:LinkedInJobApplierAgent` | `memory/linkedin` | max_tokens, reset_threshold, action_log_window, linkedin_start_url, notify_on_pause, pause_webhook | open-ended | playwright |
 | Google Maps Prospecting | `prospecting` | `harnessiq.agents.prospecting:GoogleMapsProspectingAgent` | `memory/prospecting` | max_tokens, reset_threshold | qualification_threshold, summarize_at_x, max_searches_per_run, max_listings_per_search, website_inspect_enabled, sink_record_type, eval_system_prompt | playwright |
 
 ## Provider Surface

--- a/artifacts/file_index.md
+++ b/artifacts/file_index.md
@@ -15,7 +15,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Service provider packages | 26 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 8 |
-| Test modules | 79 |
+| Test modules | 80 |
 
 ## Codebase Standards
 
@@ -33,15 +33,11 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | --- | --- | --- |
 | `.harnessiq/` | generated/cache | Fallback local HarnessIQ home used by the ledger/output-sink runtime when the preferred home path is not writable. |
 | `.pytest_cache/` | generated/cache | Test runner cache; generated, not part of the source of truth. |
-| `.worktrees/` | other | Repository directory not yet classified in the generated file index. |
 | `artifacts/` | repo docs | Generated and curated repository reference artifacts. |
-| `build/` | generated/cache | Setuptools build output; generated, not part of the live source tree. |
 | `docs/` | repo docs | Focused usage and architecture notes for the package. |
 | `harnessiq/` | source | Live SDK package source. |
-| `harnessiq.egg-info/` | generated/cache | Packaging metadata emitted by local builds. |
 | `memory/` | local state | Task artifacts plus durable agent runtime state; not part of the shipped package. |
 | `scripts/` | repo tooling | Repository maintenance and generation scripts. |
-| `src/` | generated/cache | Legacy or generated residue in this checkout; not the authoritative package source. |
 | `tests/` | source | unittest coverage for runtime, CLI, providers, and tools. |
 
 ## Package Layout
@@ -87,10 +83,10 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Manifest | Display Name | Import | Memory Root | Runtime Params | Custom Params | Memory Entries | Providers | Output Fields |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | exa_outreach | Exa Outreach | `harnessiq.agents.exa_outreach:ExaOutreachAgent` | `memory/outreach` | max_tokens, reset_threshold | - | query_config.json, agent_identity.txt, additional_prompt.txt, runs | exa, resend | emails_sent, leads_found, search_query |
-| instagram | Instagram Keyword Discovery | `harnessiq.agents.instagram:InstagramKeywordDiscoveryAgent` | `memory/instagram` | max_tokens, recent_result_window, recent_search_window, reset_threshold, search_result_limit | - | icp_profiles.json, search_history.json, lead_database.json, runtime_parameters.json, agent_identity.txt, additional_prompt.txt | playwright | emails, leads, search_history |
+| instagram | Instagram Keyword Discovery | `harnessiq.agents.instagram:InstagramKeywordDiscoveryAgent` | `memory/instagram` | max_tokens, recent_result_window, recent_search_window, reset_threshold, search_result_limit | open-ended | icp_profiles.json, search_history.json, lead_database.json, runtime_parameters.json, custom_parameters.json, agent_identity.txt, additional_prompt.txt | playwright | emails, leads, search_history |
 | knowt | Knowt Content Creator | `harnessiq.agents.knowt:KnowtAgent` | `memory/knowt` | max_tokens, reset_threshold | - | current_script.md, current_avatar_description.md, creation_log.jsonl | creatify | avatar_description, creation_log, script |
 | leads | Leads Agent | `harnessiq.agents.leads:LeadsAgent` | `memory/leads` | max_tokens, reset_threshold, prune_search_interval, prune_token_limit, search_summary_every, search_tail_size, max_leads_per_icp | - | run_config.json, run_state.json, runtime_parameters.json, icps/*.json, lead_storage, lead_storage/saved_leads.json | apollo, arcads, arxiv, attio, browser_use, coresignal, creatify, exa, expandi, inboxapp, instantly, leadiq, lemlist, lusha, outreach, paperclip, peopledatalabs, phantombuster, proxycurl, resend, salesforge, serper, smartlead, snovio, zerobounce, zoominfo | icp_states, run_config, run_state, saved_leads |
-| linkedin | LinkedIn Job Applier | `harnessiq.agents.linkedin:LinkedInJobApplierAgent` | `memory/linkedin` | max_tokens, reset_threshold, action_log_window, linkedin_start_url, notify_on_pause, pause_webhook | - | job_preferences.md, user_profile.md, agent_identity.md, runtime_parameters.json, custom_parameters.json, additional_prompt.md, applied_jobs.jsonl, action_log.jsonl, managed_files.json, managed_files, screenshots | playwright | jobs_applied, managed_files, recent_actions |
+| linkedin | LinkedIn Job Applier | `harnessiq.agents.linkedin:LinkedInJobApplierAgent` | `memory/linkedin` | max_tokens, reset_threshold, action_log_window, linkedin_start_url, notify_on_pause, pause_webhook | open-ended | job_preferences.md, user_profile.md, agent_identity.md, runtime_parameters.json, custom_parameters.json, additional_prompt.md, applied_jobs.jsonl, action_log.jsonl, managed_files.json, managed_files, screenshots | playwright | jobs_applied, managed_files, recent_actions |
 | prospecting | Google Maps Prospecting | `harnessiq.agents.prospecting:GoogleMapsProspectingAgent` | `memory/prospecting` | max_tokens, reset_threshold | qualification_threshold, summarize_at_x, max_searches_per_run, max_listings_per_search, website_inspect_enabled, sink_record_type, eval_system_prompt | company_description.md, agent_identity.md, additional_prompt.md, runtime_parameters.json, custom_parameters.json, prospecting_state.json, qualified_leads.jsonl, browser-data | playwright | company_description, counts, qualified_leads, searches_completed, summary |
 
 ## CLI Architecture
@@ -177,7 +173,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 
 ## Test Surface
 
-`tests/` currently contains 79 test modules. The table below groups them by dominant responsibility.
+`tests/` currently contains 80 test modules. The table below groups them by dominant responsibility.
 
 | Area | Count | Examples |
 | --- | --- | --- |
@@ -185,5 +181,5 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | cli | 8 | `tests/test_exa_outreach_cli.py`, `tests/test_instagram_cli.py`, `tests/test_leads_cli.py` |
 | ledger | 1 | `tests/test_output_sinks.py` |
 | providers | 31 | `tests/test_anthropic_provider.py`, `tests/test_apollo_provider.py`, `tests/test_arcads_provider.py` |
-| support | 12 | `tests/test_cli_common.py`, `tests/test_config_loader.py`, `tests/test_credentials_config.py` |
+| support | 13 | `tests/test_cli_common.py`, `tests/test_cli_environment.py`, `tests/test_config_loader.py` |
 | tools | 12 | `tests/test_context_compaction_tools.py`, `tests/test_context_window_tools.py`, `tests/test_general_tools.py` |

--- a/artifacts/live_inventory.json
+++ b/artifacts/live_inventory.json
@@ -2011,7 +2011,7 @@
     "model_providers": 4,
     "service_provider_packages": 26,
     "sink_types": 8,
-    "test_modules": 79,
+    "test_modules": 80,
     "tool_only_external_surfaces": 1,
     "top_level_commands": 16
   },
@@ -2040,6 +2040,7 @@
       "cli_adapter_path": "harnessiq.cli.adapters.exa_outreach:ExaOutreachHarnessCliAdapter",
       "cli_command": "outreach",
       "custom_parameters": [],
+      "custom_parameters_open_ended": false,
       "default_memory_root": "memory/outreach",
       "display_name": "Exa Outreach",
       "manifest_id": "exa_outreach",
@@ -2098,6 +2099,7 @@
           "value_type": "number"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/exa_outreach.py"
     },
     {
@@ -2106,6 +2108,7 @@
       "cli_adapter_path": "harnessiq.cli.adapters.instagram:InstagramHarnessCliAdapter",
       "cli_command": "instagram",
       "custom_parameters": [],
+      "custom_parameters_open_ended": true,
       "default_memory_root": "memory/instagram",
       "display_name": "Instagram Keyword Discovery",
       "manifest_id": "instagram",
@@ -2137,6 +2140,13 @@
           "key": "runtime_parameters",
           "kind": "file",
           "relative_path": "runtime_parameters.json"
+        },
+        {
+          "description": "Open-ended user custom parameter payload.",
+          "format": "json",
+          "key": "custom_parameters",
+          "kind": "file",
+          "relative_path": "custom_parameters.json"
         },
         {
           "description": "Override for the Instagram system identity.",
@@ -2195,6 +2205,7 @@
           "value_type": "integer"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/instagram.py"
     },
     {
@@ -2203,6 +2214,7 @@
       "cli_adapter_path": "harnessiq.cli.adapters.knowt:KnowtHarnessCliAdapter",
       "cli_command": null,
       "custom_parameters": [],
+      "custom_parameters_open_ended": false,
       "default_memory_root": "memory/knowt",
       "display_name": "Knowt Content Creator",
       "manifest_id": "knowt",
@@ -2253,6 +2265,7 @@
           "value_type": "number"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/knowt.py"
     },
     {
@@ -2261,6 +2274,7 @@
       "cli_adapter_path": "harnessiq.cli.adapters.leads:LeadsHarnessCliAdapter",
       "cli_command": "leads",
       "custom_parameters": [],
+      "custom_parameters_open_ended": false,
       "default_memory_root": "memory/leads",
       "display_name": "Leads Agent",
       "manifest_id": "leads",
@@ -2388,6 +2402,7 @@
           "value_type": "integer"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/leads.py"
     },
     {
@@ -2396,6 +2411,7 @@
       "cli_adapter_path": "harnessiq.cli.adapters.linkedin:LinkedInHarnessCliAdapter",
       "cli_command": "linkedin",
       "custom_parameters": [],
+      "custom_parameters_open_ended": true,
       "default_memory_root": "memory/linkedin",
       "display_name": "LinkedIn Job Applier",
       "manifest_id": "linkedin",
@@ -2526,6 +2542,7 @@
           "value_type": "string"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/linkedin.py"
     },
     {
@@ -2577,6 +2594,7 @@
           "value_type": "string"
         }
       ],
+      "custom_parameters_open_ended": false,
       "default_memory_root": "memory/prospecting",
       "display_name": "Google Maps Prospecting",
       "manifest_id": "prospecting",
@@ -2664,6 +2682,7 @@
           "value_type": "number"
         }
       ],
+      "runtime_parameters_open_ended": false,
       "source_file": "harnessiq/shared/prospecting.py"
     }
   ],
@@ -3076,7 +3095,7 @@
     ]
   },
   "tests": {
-    "count": 79,
+    "count": 80,
     "groups": [
       {
         "count": 15,
@@ -3113,11 +3132,11 @@
         "name": "providers"
       },
       {
-        "count": 12,
+        "count": 13,
         "examples": [
           "test_cli_common.py",
-          "test_config_loader.py",
-          "test_credentials_config.py"
+          "test_cli_environment.py",
+          "test_config_loader.py"
         ],
         "name": "support"
       },
@@ -3146,22 +3165,10 @@
       "path": ".pytest_cache/"
     },
     {
-      "description": "Repository directory not yet classified in the generated file index.",
-      "kind": "other",
-      "name": ".worktrees",
-      "path": ".worktrees/"
-    },
-    {
       "description": "Generated and curated repository reference artifacts.",
       "kind": "repo docs",
       "name": "artifacts",
       "path": "artifacts/"
-    },
-    {
-      "description": "Setuptools build output; generated, not part of the live source tree.",
-      "kind": "generated/cache",
-      "name": "build",
-      "path": "build/"
     },
     {
       "description": "Focused usage and architecture notes for the package.",
@@ -3176,12 +3183,6 @@
       "path": "harnessiq/"
     },
     {
-      "description": "Packaging metadata emitted by local builds.",
-      "kind": "generated/cache",
-      "name": "harnessiq.egg-info",
-      "path": "harnessiq.egg-info/"
-    },
-    {
       "description": "Task artifacts plus durable agent runtime state; not part of the shipped package.",
       "kind": "local state",
       "name": "memory",
@@ -3192,12 +3193,6 @@
       "kind": "repo tooling",
       "name": "scripts",
       "path": "scripts/"
-    },
-    {
-      "description": "Legacy or generated residue in this checkout; not the authoritative package source.",
-      "kind": "generated/cache",
-      "name": "src",
-      "path": "src/"
     },
     {
       "description": "unittest coverage for runtime, CLI, providers, and tools.",

--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -24,6 +24,8 @@ from harnessiq.shared.instagram import (
     InstagramKeywordAgentConfig,
     InstagramMemoryStore,
     InstagramSearchBackend,
+    normalize_instagram_custom_parameters,
+    resolve_instagram_icp_profiles,
 )
 from harnessiq.shared.tools import INSTAGRAM_SEARCH_KEYWORD, RegisteredTool, ToolCall, ToolResult
 from harnessiq.toolset import get_tool
@@ -50,6 +52,8 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         recent_search_window: int = DEFAULT_RECENT_SEARCH_WINDOW,
         recent_result_window: int = DEFAULT_RECENT_RESULT_WINDOW,
         search_result_limit: int = DEFAULT_SEARCH_RESULT_LIMIT,
+        custom_parameters: Mapping[str, Any] | None = None,
+        persist_icp_descriptions: bool = True,
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
     ) -> None:
@@ -61,6 +65,8 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         normalized_icps = _normalize_icp_descriptions(icp_descriptions)
         self._search_backend = search_backend
         self._initial_icp_descriptions = normalized_icps
+        self._custom_parameters = dict(custom_parameters or {})
+        self._persist_icp_descriptions = persist_icp_descriptions
         self._payload_max_tokens = max_tokens
         self._payload_reset_threshold = reset_threshold
         self._payload_recent_search_window = recent_search_window
@@ -127,6 +133,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         search_backend: InstagramSearchBackend,
         memory_path: str | Path | None = None,
         runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
     ) -> "InstagramKeywordDiscoveryAgent":
@@ -136,14 +143,20 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         runtime_parameters = store.read_runtime_parameters()
         if runtime_overrides:
             runtime_parameters.update(runtime_overrides)
+        custom_parameters = store.read_custom_parameters()
+        if custom_overrides:
+            custom_parameters.update(custom_overrides)
         from harnessiq.shared.instagram import normalize_instagram_runtime_parameters
 
         normalized = normalize_instagram_runtime_parameters(runtime_parameters)
+        normalized_custom = normalize_instagram_custom_parameters(custom_parameters)
         return cls(
             model=model,
             search_backend=search_backend,
             memory_path=resolved_path,
-            icp_descriptions=store.read_icp_profiles(),
+            icp_descriptions=resolve_instagram_icp_profiles(store.read_icp_profiles(), normalized_custom),
+            custom_parameters=normalized_custom,
+            persist_icp_descriptions=False,
             tools=tools,
             runtime_config=runtime_config,
             **normalized,
@@ -151,7 +164,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
 
     def prepare(self) -> None:
         self._memory_store.prepare()
-        if self._initial_icp_descriptions:
+        if self._persist_icp_descriptions and self._initial_icp_descriptions:
             self._memory_store.write_icp_profiles(self._initial_icp_descriptions)
 
     def run(self, *, max_cycles: int | None = None):
@@ -187,16 +200,22 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         return prompt
 
     def load_parameter_sections(self) -> Sequence[AgentParameterSection]:
-        icp_profiles = self._memory_store.read_icp_profiles()
+        icp_profiles = list(self._initial_icp_descriptions)
         recent_searches = ", ".join(
             record.keyword
             for record in self._memory_store.read_recent_searches(self._config.recent_search_window)
             if record.keyword
         )
-        return (
+        sections: list[AgentParameterSection] = [
             json_parameter_section("ICP Profiles", icp_profiles),
             AgentParameterSection(title="Recent Searches", content=recent_searches),
-        )
+        ]
+        prompt_custom_parameters = {
+            key: value for key, value in self._custom_parameters.items() if key != "icp_profiles"
+        }
+        if prompt_custom_parameters:
+            sections.append(json_parameter_section("Custom Parameters", prompt_custom_parameters))
+        return tuple(sections)
 
     def build_instance_payload(self) -> dict[str, Any]:
         return _build_instagram_instance_payload(
@@ -207,6 +226,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             recent_search_window=self._payload_recent_search_window,
             recent_result_window=self._payload_recent_result_window,
             search_result_limit=self._payload_search_result_limit,
+            custom_parameters=self._custom_parameters,
         )
 
     def get_emails(self) -> tuple[str, ...]:
@@ -254,6 +274,7 @@ def _build_instagram_instance_payload(
     recent_search_window: int,
     recent_result_window: int,
     search_result_limit: int,
+    custom_parameters: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "icp_descriptions": list(icp_descriptions),
@@ -265,15 +286,25 @@ def _build_instagram_instance_payload(
             "search_result_limit": search_result_limit,
         },
     }
+    if custom_parameters:
+        payload["custom_parameters"] = dict(custom_parameters)
     if memory_path is not None:
         payload["memory_path"] = str(memory_path)
     if memory_path is None or not memory_path.exists():
         return payload
 
     store = InstagramMemoryStore(memory_path=memory_path)
-    payload["icp_descriptions"] = store.read_icp_profiles()
+    resolved_custom_parameters = (
+        dict(custom_parameters) if custom_parameters is not None else store.read_custom_parameters()
+    )
+    payload["icp_descriptions"] = resolve_instagram_icp_profiles(
+        store.read_icp_profiles(),
+        resolved_custom_parameters,
+    )
     payload["agent_identity"] = _read_optional_text(store.agent_identity_path)
     payload["additional_prompt"] = _read_optional_text(store.additional_prompt_path)
+    if resolved_custom_parameters:
+        payload["custom_parameters"] = resolved_custom_parameters
     return payload
 
 

--- a/harnessiq/cli/adapters/instagram.py
+++ b/harnessiq/cli/adapters/instagram.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import json
+from pathlib import Path
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, InstagramKeywordDiscoveryAgent
 from harnessiq.cli.common import load_factory
-from harnessiq.shared.instagram import InstagramMemoryStore
+from harnessiq.shared.instagram import InstagramMemoryStore, resolve_instagram_icp_profiles
 
 from .base import StoreBackedHarnessCliAdapter
 from .context import HarnessAdapterContext
@@ -29,6 +31,16 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
                 f"Defaults to {_DEFAULT_INSTAGRAM_SEARCH_BACKEND_FACTORY}."
             ),
         )
+        parser.add_argument(
+            "--icp",
+            action="append",
+            default=[],
+            help="One ICP description to use for this run. Repeat the flag to provide multiple ICPs.",
+        )
+        parser.add_argument(
+            "--icp-file",
+            help="Path to a JSON array or newline-delimited UTF-8 text file containing ICP descriptions for this run.",
+        )
 
     def read_native_runtime_parameters(
         self,
@@ -38,18 +50,31 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
         del context
         return store.read_runtime_parameters()
 
+    def read_native_custom_parameters(
+        self,
+        store: InstagramMemoryStore,
+        context: HarnessAdapterContext,
+    ) -> dict[str, object]:
+        del context
+        return store.read_custom_parameters()
+
     def write_runtime_parameters(self, store: InstagramMemoryStore, context: HarnessAdapterContext) -> None:
         store.write_runtime_parameters(dict(context.profile.runtime_parameters))
+
+    def write_custom_parameters(self, store: InstagramMemoryStore, context: HarnessAdapterContext) -> None:
+        store.write_custom_parameters(dict(context.profile.custom_parameters))
 
     def show(self, context: HarnessAdapterContext) -> dict[str, object]:
         store = self.load_store(context)
         search_history = store.read_search_history()
         lead_database = store.read_lead_database()
+        custom_parameters = store.read_custom_parameters()
         return {
             "additional_prompt": store.read_additional_prompt(),
             "agent_identity": store.read_agent_identity(),
+            "custom_parameters": custom_parameters,
             "email_count": len(lead_database.emails),
-            "icp_profiles": store.read_icp_profiles(),
+            "icp_profiles": resolve_instagram_icp_profiles(store.read_icp_profiles(), custom_parameters),
             "lead_count": len(lead_database.leads),
             "recent_searches": [record.as_dict() for record in search_history[-5:]],
             "runtime_parameters": store.read_runtime_parameters(),
@@ -67,11 +92,16 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
         store = self.load_store(context)
         set_env_path_if_missing("HARNESSIQ_INSTAGRAM_SESSION_DIR", store.memory_path / "browser-data")
         search_backend = load_factory(args.search_backend_factory)()
+        custom_overrides = dict(context.custom_parameters)
+        icp_profiles = _resolve_icp_input(args.icp, args.icp_file)
+        if icp_profiles is not None:
+            custom_overrides["icp_profiles"] = icp_profiles
         agent = InstagramKeywordDiscoveryAgent.from_memory(
             model=model,
             search_backend=search_backend,
             memory_path=context.memory_path,
             runtime_overrides=context.runtime_parameters,
+            custom_overrides=custom_overrides,
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
@@ -79,6 +109,22 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
             "email_count": len(agent.get_emails()),
             "result": result_payload(result),
         }
+
+
+def _resolve_icp_input(inline_values: list[str], file_value: str | None) -> list[str] | None:
+    cleaned_inline = [value.strip() for value in inline_values if value and value.strip()]
+    if file_value is None:
+        return cleaned_inline or None
+    raw = Path(file_value).read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return [line.strip() for line in raw.splitlines() if line.strip()]
+    if not isinstance(payload, list):
+        raise ValueError("ICP file must be a JSON array or newline-delimited text file.")
+    return [str(value).strip() for value in payload if str(value).strip()]
 
 
 __all__ = ["InstagramHarnessCliAdapter"]

--- a/harnessiq/cli/instagram/commands.py
+++ b/harnessiq/cli/instagram/commands.py
@@ -23,10 +23,13 @@ from harnessiq.cli.common import (
 from harnessiq.shared.instagram import (
     INSTAGRAM_HARNESS_MANIFEST,
     InstagramMemoryStore,
+    normalize_instagram_custom_parameters,
     normalize_instagram_runtime_parameters,
+    resolve_instagram_icp_profiles,
 )
 
 SUPPORTED_INSTAGRAM_RUNTIME_PARAMETERS = INSTAGRAM_HARNESS_MANIFEST.runtime_parameter_names
+SUPPORTED_INSTAGRAM_CUSTOM_PARAMETERS = INSTAGRAM_HARNESS_MANIFEST.custom_parameter_names
 
 _DEFAULT_SEARCH_BACKEND_FACTORY = "harnessiq.integrations.instagram_playwright:create_search_backend"
 
@@ -82,6 +85,13 @@ def register_instagram_commands(
             f"{format_manifest_parameter_keys(INSTAGRAM_HARNESS_MANIFEST, scope='runtime')}."
         ),
     )
+    configure_parser.add_argument(
+        "--custom-param",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Persist an Instagram custom parameter as KEY=VALUE. Values are parsed as JSON when possible.",
+    )
     configure_parser.set_defaults(command_handler=_handle_configure)
 
     show_parser = instagram_subparsers.add_parser(
@@ -125,6 +135,23 @@ def register_instagram_commands(
         default=[],
         metavar="KEY=VALUE",
         help="Override a persisted runtime parameter for this run only.",
+    )
+    run_parser.add_argument(
+        "--custom-param",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a persisted custom parameter for this run only.",
+    )
+    run_parser.add_argument(
+        "--icp",
+        action="append",
+        default=[],
+        help="One ICP description to use for this run. Repeat the flag to provide multiple ICPs.",
+    )
+    run_parser.add_argument(
+        "--icp-file",
+        help="Path to a JSON array or newline-delimited UTF-8 text file containing ICP descriptions for this run.",
     )
     run_parser.add_argument("--max-cycles", type=int, help="Optional max cycle count passed to agent.run().")
     run_parser.set_defaults(command_handler=_handle_run)
@@ -188,6 +215,13 @@ def _handle_configure(args: argparse.Namespace) -> int:
         store.write_runtime_parameters(current)
         updated.append("runtime_parameters")
 
+    custom_parameters = _parse_custom_assignments(args.custom_param)
+    if custom_parameters:
+        current_custom = store.read_custom_parameters()
+        current_custom.update(custom_parameters)
+        store.write_custom_parameters(current_custom)
+        updated.append("custom_parameters")
+
     payload = _build_summary(store)
     payload["status"] = "configured"
     payload["updated"] = updated
@@ -219,12 +253,17 @@ def _handle_run(args: argparse.Namespace) -> int:
 
     search_backend = _load_factory(args.search_backend_factory)()
     runtime_overrides = _parse_runtime_assignments(args.runtime_param)
+    custom_overrides = _parse_custom_assignments(args.custom_param)
+    icp_profiles = _resolve_icp_input(args.icp, args.icp_file)
+    if icp_profiles is not None:
+        custom_overrides["icp_profiles"] = icp_profiles
 
     agent = InstagramKeywordDiscoveryAgent.from_memory(
         model=model,
         search_backend=search_backend,
         memory_path=store.memory_path,
         runtime_overrides=runtime_overrides,
+        custom_overrides=custom_overrides,
     )
     result = agent.run(max_cycles=args.max_cycles)
     emit_json(
@@ -286,14 +325,24 @@ def _parse_runtime_assignments(assignments: Sequence[str]) -> dict[str, Any]:
     )
 
 
+def _parse_custom_assignments(assignments: Sequence[str]) -> dict[str, Any]:
+    return parse_manifest_parameter_assignments(
+        assignments,
+        manifest=INSTAGRAM_HARNESS_MANIFEST,
+        scope="custom",
+    )
+
+
 def _build_summary(store: InstagramMemoryStore) -> dict[str, Any]:
     search_history = store.read_search_history()
     lead_database = store.read_lead_database()
+    custom_parameters = store.read_custom_parameters()
     return {
         "additional_prompt": store.read_additional_prompt(),
         "agent_identity": store.read_agent_identity(),
+        "custom_parameters": custom_parameters,
         "email_count": len(lead_database.emails),
-        "icp_profiles": store.read_icp_profiles(),
+        "icp_profiles": resolve_instagram_icp_profiles(store.read_icp_profiles(), custom_parameters),
         "lead_count": len(lead_database.leads),
         "memory_path": str(store.memory_path.resolve()),
         "recent_searches": [record.as_dict() for record in search_history[-5:]],
@@ -321,7 +370,9 @@ def _print_help(parser: argparse.ArgumentParser) -> int:
 
 
 __all__ = [
+    "SUPPORTED_INSTAGRAM_CUSTOM_PARAMETERS",
     "SUPPORTED_INSTAGRAM_RUNTIME_PARAMETERS",
+    "normalize_instagram_custom_parameters",
     "normalize_instagram_runtime_parameters",
     "register_instagram_commands",
 ]

--- a/harnessiq/shared/instagram.py
+++ b/harnessiq/shared/instagram.py
@@ -6,7 +6,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, Sequence, runtime_checkable
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
 
 from harnessiq.shared.agents import DEFAULT_AGENT_MAX_TOKENS, DEFAULT_AGENT_RESET_THRESHOLD
 from harnessiq.shared.harness_manifest import HarnessManifest, HarnessMemoryFileSpec, HarnessParameterSpec
@@ -15,6 +15,7 @@ ICP_PROFILES_FILENAME = "icp_profiles.json"
 SEARCH_HISTORY_FILENAME = "search_history.json"
 LEAD_DATABASE_FILENAME = "lead_database.json"
 RUNTIME_PARAMETERS_FILENAME = "runtime_parameters.json"
+CUSTOM_PARAMETERS_FILENAME = "custom_parameters.json"
 AGENT_IDENTITY_FILENAME = "agent_identity.txt"
 ADDITIONAL_PROMPT_FILENAME = "additional_prompt.txt"
 INSTAGRAM_GOOGLE_SEARCH_URL = "https://www.google.com/search"
@@ -231,6 +232,10 @@ class InstagramMemoryStore:
         return self.memory_path / RUNTIME_PARAMETERS_FILENAME
 
     @property
+    def custom_parameters_path(self) -> Path:
+        return self.memory_path / CUSTOM_PARAMETERS_FILENAME
+
+    @property
     def agent_identity_path(self) -> Path:
         return self.memory_path / AGENT_IDENTITY_FILENAME
 
@@ -244,6 +249,7 @@ class InstagramMemoryStore:
         _ensure_json_file(self.search_history_path, [])
         _ensure_json_file(self.lead_database_path, InstagramLeadDatabase().as_dict())
         _ensure_json_file(self.runtime_parameters_path, {})
+        _ensure_json_file(self.custom_parameters_path, {})
         _ensure_text_file(self.agent_identity_path, DEFAULT_AGENT_IDENTITY)
         _ensure_text_file(self.additional_prompt_path, "")
 
@@ -340,6 +346,12 @@ class InstagramMemoryStore:
     def write_runtime_parameters(self, parameters: dict[str, Any]) -> None:
         _write_json(self.runtime_parameters_path, parameters)
 
+    def read_custom_parameters(self) -> dict[str, Any]:
+        return _read_json_file(self.custom_parameters_path, expected_type=dict)
+
+    def write_custom_parameters(self, parameters: Mapping[str, Any]) -> None:
+        _write_json(self.custom_parameters_path, dict(parameters))
+
     def read_agent_identity(self) -> str:
         return self.agent_identity_path.read_text(encoding="utf-8").strip()
 
@@ -381,6 +393,21 @@ def normalize_instagram_runtime_parameters(parameters: dict[str, Any]) -> dict[s
     return INSTAGRAM_HARNESS_MANIFEST.coerce_runtime_parameters(parameters)
 
 
+def normalize_instagram_custom_parameters(parameters: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize open-ended custom parameters for the Instagram agent."""
+    return INSTAGRAM_HARNESS_MANIFEST.coerce_custom_parameters(parameters)
+
+
+def resolve_instagram_icp_profiles(
+    stored_profiles: Sequence[str],
+    custom_parameters: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """Resolve the effective ICP list, allowing custom parameters to override stored profiles."""
+    if custom_parameters and "icp_profiles" in custom_parameters:
+        return _coerce_icp_profiles_value(custom_parameters["icp_profiles"])
+    return _coerce_icp_profiles_value(stored_profiles)
+
+
 INSTAGRAM_HARNESS_MANIFEST = HarnessManifest(
     manifest_id="instagram",
     agent_name="instagram_keyword_discovery",
@@ -398,11 +425,13 @@ INSTAGRAM_HARNESS_MANIFEST = HarnessManifest(
         HarnessParameterSpec("reset_threshold", "number", "Fraction of max_tokens that triggers a reset.", default=DEFAULT_AGENT_RESET_THRESHOLD),
         HarnessParameterSpec("search_result_limit", "integer", "Maximum results requested from the search backend.", default=DEFAULT_SEARCH_RESULT_LIMIT),
     ),
+    custom_parameters_open_ended=True,
     memory_files=(
         HarnessMemoryFileSpec("icp_profiles", ICP_PROFILES_FILENAME, "Persisted ICP descriptions.", format="json"),
         HarnessMemoryFileSpec("search_history", SEARCH_HISTORY_FILENAME, "Durable Instagram search history.", format="json"),
         HarnessMemoryFileSpec("lead_database", LEAD_DATABASE_FILENAME, "Persisted deduplicated leads and emails.", format="json"),
         HarnessMemoryFileSpec("runtime_parameters", RUNTIME_PARAMETERS_FILENAME, "Persisted typed runtime overrides.", format="json"),
+        HarnessMemoryFileSpec("custom_parameters", CUSTOM_PARAMETERS_FILENAME, "Open-ended user custom parameter payload.", format="json"),
         HarnessMemoryFileSpec("agent_identity", AGENT_IDENTITY_FILENAME, "Override for the Instagram system identity.", format="text"),
         HarnessMemoryFileSpec("additional_prompt", ADDITIONAL_PROMPT_FILENAME, "Additional free-form prompt data.", format="text"),
     ),
@@ -470,6 +499,22 @@ def _read_json_file(path: Path, *, expected_type: type) -> Any:
     return payload
 
 
+def _coerce_icp_profiles_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        cleaned_values: list[str] = []
+        for item in value:
+            cleaned_item = str(item).strip()
+            if cleaned_item:
+                cleaned_values.append(cleaned_item)
+        return cleaned_values
+    raise ValueError("Instagram ICP profiles must be a string, null, or a JSON array of strings.")
+
+
 def _dedupe_emails(values: Sequence[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
@@ -512,6 +557,7 @@ __all__ = [
     "DEFAULT_RECENT_RESULT_WINDOW",
     "DEFAULT_RECENT_SEARCH_WINDOW",
     "DEFAULT_SEARCH_RESULT_LIMIT",
+    "CUSTOM_PARAMETERS_FILENAME",
     "ICP_PROFILES_FILENAME",
     "INSTAGRAM_HARNESS_MANIFEST",
     "INSTAGRAM_GOOGLE_SEARCH_URL",
@@ -529,5 +575,7 @@ __all__ = [
     "build_instagram_google_fallback_query",
     "build_instagram_google_query",
     "extract_emails",
+    "normalize_instagram_custom_parameters",
     "normalize_instagram_runtime_parameters",
+    "resolve_instagram_icp_profiles",
 ]

--- a/scripts/sync_repo_docs.py
+++ b/scripts/sync_repo_docs.py
@@ -475,6 +475,12 @@ def parse_harness_manifest(manifest_name: str, source_path: Path) -> dict[str, A
         ),
         "runtime_parameters": parse_parameter_specs(keyword_map.get("runtime_parameters"), constants),
         "custom_parameters": parse_parameter_specs(keyword_map.get("custom_parameters"), constants),
+        "runtime_parameters_open_ended": bool(
+            eval_simple(keyword_map["runtime_parameters_open_ended"], constants)
+        ) if "runtime_parameters_open_ended" in keyword_map else False,
+        "custom_parameters_open_ended": bool(
+            eval_simple(keyword_map["custom_parameters_open_ended"], constants)
+        ) if "custom_parameters_open_ended" in keyword_map else False,
         "memory_files": parse_memory_specs(keyword_map.get("memory_files"), constants),
         "provider_families": [str(value) for value in provider_families],
         "output_fields": parse_output_fields(keyword_map.get("output_schema"), constants),
@@ -924,8 +930,14 @@ def render_readme(inventory: dict[str, Any]) -> str:
                 f"`{harness['cli_command']}`" if harness["cli_command"] else "-",
                 f"`{harness['module_path']}:{harness['class_name']}`",
                 f"`{harness['default_memory_root']}`",
-                [item["key"] for item in harness["runtime_parameters"]],
-                [item["key"] for item in harness["custom_parameters"]],
+                format_parameter_surface(
+                    harness["runtime_parameters"],
+                    open_ended=harness.get("runtime_parameters_open_ended", False),
+                ),
+                format_parameter_surface(
+                    harness["custom_parameters"],
+                    open_ended=harness.get("custom_parameters_open_ended", False),
+                ),
                 harness["provider_families"],
             ]
         )
@@ -1105,8 +1117,14 @@ def render_file_index(inventory: dict[str, Any]) -> str:
                 harness["display_name"],
                 f"`{harness['module_path']}:{harness['class_name']}`",
                 f"`{harness['default_memory_root']}`",
-                [item["key"] for item in harness["runtime_parameters"]],
-                [item["key"] for item in harness["custom_parameters"]],
+                format_parameter_surface(
+                    harness["runtime_parameters"],
+                    open_ended=harness.get("runtime_parameters_open_ended", False),
+                ),
+                format_parameter_surface(
+                    harness["custom_parameters"],
+                    open_ended=harness.get("custom_parameters_open_ended", False),
+                ),
                 [item["relative_path"] for item in harness["memory_files"]],
                 harness["provider_families"],
                 harness["output_fields"],
@@ -1210,6 +1228,21 @@ def render_file_index(inventory: dict[str, Any]) -> str:
 
 def render_inventory_json(inventory: dict[str, Any]) -> str:
     return json.dumps(inventory, indent=2, sort_keys=True) + "\n"
+
+
+def format_parameter_surface(
+    parameters: list[dict[str, Any]],
+    *,
+    open_ended: bool,
+) -> list[str] | str:
+    keys = [item["key"] for item in parameters]
+    if keys and open_ended:
+        return [*keys, "open-ended"]
+    if keys:
+        return keys
+    if open_ended:
+        return "open-ended"
+    return "-"
 
 
 def expected_outputs() -> dict[Path, str]:

--- a/tests/test_harness_manifests.py
+++ b/tests/test_harness_manifests.py
@@ -7,6 +7,7 @@ import unittest
 from harnessiq.cli.common import parse_manifest_parameter_assignments
 from harnessiq.shared import HARNESS_MANIFESTS, get_harness_manifest
 from harnessiq.shared.exa_outreach import EXA_OUTREACH_HARNESS_MANIFEST
+from harnessiq.shared.instagram import INSTAGRAM_HARNESS_MANIFEST
 from harnessiq.shared.leads import LEADS_HARNESS_MANIFEST
 from harnessiq.shared.linkedin import LINKEDIN_HARNESS_MANIFEST
 
@@ -35,6 +36,13 @@ class HarnessManifestCoercionTests(unittest.TestCase):
         )
         self.assertEqual(payload["target_level"], "staff")
         self.assertTrue(payload["remote_only"])
+
+    def test_instagram_manifest_allows_open_ended_custom_parameters(self) -> None:
+        payload = INSTAGRAM_HARNESS_MANIFEST.coerce_custom_parameters(
+            {"icp_profiles": ["fitness creators"], "research_mode": True}
+        )
+        self.assertEqual(payload["icp_profiles"], ["fitness creators"])
+        self.assertTrue(payload["research_mode"])
 
     def test_leads_manifest_coerces_nullable_runtime_parameters(self) -> None:
         payload = LEADS_HARNESS_MANIFEST.coerce_runtime_parameters(

--- a/tests/test_instagram_agent.py
+++ b/tests/test_instagram_agent.py
@@ -111,6 +111,7 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertTrue(Path(temp_dir, "search_history.json").exists())
             self.assertTrue(Path(temp_dir, "lead_database.json").exists())
             self.assertTrue(Path(temp_dir, "runtime_parameters.json").exists())
+            self.assertTrue(Path(temp_dir, "custom_parameters.json").exists())
             self.assertEqual(
                 [section.title for section in model.requests[0].parameter_sections],
                 ["ICP Profiles", "Recent Searches"],
@@ -249,6 +250,32 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertEqual(agent.config.recent_result_window, 3)
             self.assertEqual(agent.config.search_result_limit, 2)
             self.assertIn("ugc skincare creators", agent.load_parameter_sections()[0].content)
+
+    def test_from_memory_uses_custom_icp_override_and_custom_parameter_section(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = InstagramMemoryStore(memory_path=temp_dir)
+            store.prepare()
+            store.write_icp_profiles(["fitness creators"])
+            store.write_custom_parameters({"research_mode": True})
+            model = _FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)])
+
+            agent = InstagramKeywordDiscoveryAgent.from_memory(
+                model=model,
+                search_backend=_FakeSearchBackend(_build_execution("skincare")),
+                memory_path=temp_dir,
+                custom_overrides={
+                    "icp_profiles": ["ugc skincare creators"],
+                    "target_segment": "micro-creators",
+                },
+            )
+
+            sections = agent.load_parameter_sections()
+
+            self.assertEqual([section.title for section in sections], ["ICP Profiles", "Recent Searches", "Custom Parameters"])
+            self.assertIn("ugc skincare creators", sections[0].content)
+            self.assertIn("target_segment", sections[2].content)
+            self.assertIn("research_mode", sections[2].content)
+            self.assertNotIn("icp_profiles", sections[2].content)
 
     def test_agent_is_importable_from_harnessiq_agents(self) -> None:
         from harnessiq.agents import InstagramKeywordDiscoveryAgent as Imported

--- a/tests/test_instagram_cli.py
+++ b/tests/test_instagram_cli.py
@@ -81,11 +81,14 @@ class InstagramCliTests(unittest.TestCase):
                         "ugc skincare creators",
                         "--runtime-param",
                         "search_result_limit=3",
+                        "--custom-param",
+                        'target_segment="micro-creators"',
                     ]
                 )
             self.assertEqual(result, 0)
             payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
             self.assertEqual(payload["icp_profiles"], ["fitness creators", "ugc skincare creators"])
+            self.assertEqual(payload["custom_parameters"]["target_segment"], "micro-creators")
             self.assertEqual(payload["runtime_parameters"]["search_result_limit"], 3)
 
     def test_show_returns_counts(self) -> None:
@@ -151,7 +154,7 @@ class InstagramCliTests(unittest.TestCase):
                 patch(
                     "harnessiq.agents.instagram.InstagramKeywordDiscoveryAgent.from_memory",
                     return_value=mock_agent,
-                ),
+                ) as patched_from_memory,
                 patch("sys.stdout.write") as mock_write,
             ):
                 result = _run(
@@ -164,6 +167,10 @@ class InstagramCliTests(unittest.TestCase):
                         temp_dir,
                         "--model-factory",
                         "mod:model",
+                        "--custom-param",
+                        'target_segment="micro-creators"',
+                        "--icp",
+                        "fitness creators",
                     ]
                 )
 
@@ -171,6 +178,13 @@ class InstagramCliTests(unittest.TestCase):
             payload = json.loads("".join(call.args[0] for call in mock_write.call_args_list))
             self.assertEqual(payload["email_count"], 1)
             self.assertEqual(payload["result"]["cycles_completed"], 2)
+            self.assertEqual(
+                patched_from_memory.call_args.kwargs["custom_overrides"],
+                {
+                    "icp_profiles": ["fitness creators"],
+                    "target_segment": "micro-creators",
+                },
+            )
 
     def test_run_seeds_langsmith_environment_from_repo_env(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -36,6 +36,10 @@ def create_empty_browser_tools() -> tuple[object, ...]:
     return ()
 
 
+def create_instagram_search_backend() -> object:
+    return object()
+
+
 def _run(argv: list[str]) -> tuple[int, dict[str, object]]:
     stdout = io.StringIO()
     with redirect_stdout(stdout):
@@ -271,3 +275,46 @@ def test_run_generic_prospecting_seeds_model_factory_environment_from_local_env(
     assert exit_code == 0
     assert payload["result"]["status"] == "completed"
     assert _LAST_PROVIDER_ENV["XAI_API_KEY"] == "local-xai-key"
+
+
+def test_run_generic_instagram_accepts_custom_params_and_icp_override(tmp_path: Path) -> None:
+    _run(["prepare", "instagram", "--agent", "creator-a", "--memory-root", str(tmp_path)])
+
+    mock_agent = MagicMock()
+    mock_agent.get_emails.return_value = ("creator@example.com",)
+    mock_agent.run.return_value = SimpleNamespace(
+        cycles_completed=1,
+        pause_reason=None,
+        resets=0,
+        status="completed",
+    )
+
+    with patch(
+        "harnessiq.cli.adapters.instagram.InstagramKeywordDiscoveryAgent.from_memory",
+        return_value=mock_agent,
+    ) as patched_from_memory:
+        exit_code, payload = _run(
+            [
+                "run",
+                "instagram",
+                "--agent",
+                "creator-a",
+                "--memory-root",
+                str(tmp_path),
+                "--model-factory",
+                "tests.test_platform_cli:create_static_model",
+                "--search-backend-factory",
+                "tests.test_platform_cli:create_instagram_search_backend",
+                "--custom-param",
+                'target_segment="micro-creators"',
+                "--icp",
+                "fitness creators",
+            ]
+        )
+
+    assert exit_code == 0
+    assert payload["result"]["status"] == "completed"
+    assert patched_from_memory.call_args.kwargs["custom_overrides"] == {
+        "icp_profiles": ["fitness creators"],
+        "target_segment": "micro-creators",
+    }


### PR DESCRIPTION
## Summary
- add open-ended Instagram custom parameter support to the harness manifest, memory store, and agent
- allow both `harnessiq instagram run` and `harnessiq run instagram` to accept run-time custom params plus direct ICP input
- update generated docs and add regression coverage for the new CLI/agent behavior

## Testing
- `python -m pytest -q tests/test_instagram_cli.py tests/test_instagram_agent.py tests/test_platform_cli.py tests/test_harness_manifests.py tests/test_docs_sync.py`
- `python scripts/sync_repo_docs.py --check`
