### PR TITLE
Add master prompt session activation commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Scripts/
 .skill-staging/
 .harnessiq/
 .worktrees/
+AGENTS.override.md
 
 # Credentials
 harnessiq/agents/linkedin/credentials.py

--- a/docs/master-prompt-session-injection.md
+++ b/docs/master-prompt-session-injection.md
@@ -1,0 +1,49 @@
+# Master Prompt Session Injection
+
+`harnessiq prompts` can activate one bundled master prompt as always-on project instructions for fresh Claude Code and Codex sessions.
+
+If you are running from this repository checkout rather than an installed package, install the editable console entrypoint first:
+
+```bash
+pip install -e .
+```
+
+## Commands
+
+List the bundled prompt catalog:
+
+```bash
+harnessiq prompts list
+```
+
+Activate one prompt for the current repository:
+
+```bash
+harnessiq prompts activate create_master_prompts
+```
+
+Show the current active prompt selection:
+
+```bash
+harnessiq prompts current
+```
+
+Clear the generated overlays:
+
+```bash
+harnessiq prompts clear
+```
+
+## Generated Files
+
+Activation writes these repo-local files:
+
+- `.claude/CLAUDE.md` for Claude Code
+- `AGENTS.override.md` for Codex
+- `.harnessiq/master_prompt_session/active_prompt.json` for local activation metadata
+
+`.claude/` and `.harnessiq/` are already ignored in this repository. `AGENTS.override.md` is also ignored so the active prompt choice stays local by default.
+
+## Behavior
+
+This mechanism does not attempt to mutate an already-open chat. Instead, it prepares project instruction files that Claude Code and Codex read when you start a fresh session from the repository. Because the selected prompt is loaded as project guidance, it remains available for every request in that session until you clear or replace it.

--- a/harnessiq/cli/master_prompts/commands.py
+++ b/harnessiq/cli/master_prompts/commands.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import argparse
 
-from harnessiq.cli.common import emit_json
+from harnessiq.cli.common import emit_json, resolve_repo_root
 from harnessiq.master_prompts import get_prompt, get_prompt_text, list_prompt_keys, list_prompts
+from harnessiq.master_prompts.session_injection import (
+    activate_prompt_session,
+    clear_prompt_session,
+    get_active_prompt_session,
+)
 
 
 def register_master_prompt_commands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -23,6 +28,40 @@ def register_master_prompt_commands(subparsers: argparse._SubParsersAction[argpa
     text_parser = prompts_subparsers.add_parser("text", help="Print the raw prompt text for one prompt")
     text_parser.add_argument("key", help="Prompt key, derived from the prompt filename.")
     text_parser.set_defaults(command_handler=_handle_text)
+
+    activate_parser = prompts_subparsers.add_parser(
+        "activate",
+        help="Activate one bundled prompt as always-on project session context for Claude Code and Codex",
+    )
+    activate_parser.add_argument("key", help="Prompt key, derived from the prompt filename.")
+    activate_parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Project path used to resolve the repo root for generated instruction files.",
+    )
+    activate_parser.set_defaults(command_handler=_handle_activate)
+
+    current_parser = prompts_subparsers.add_parser(
+        "current",
+        help="Show the currently active project-scoped master prompt, if any",
+    )
+    current_parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Project path used to resolve the repo root for generated instruction files.",
+    )
+    current_parser.set_defaults(command_handler=_handle_current)
+
+    clear_parser = prompts_subparsers.add_parser(
+        "clear",
+        help="Remove generated Claude Code and Codex prompt injection overlays",
+    )
+    clear_parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Project path used to resolve the repo root for generated instruction files.",
+    )
+    clear_parser.set_defaults(command_handler=_handle_clear)
 
 
 def _handle_list(args: argparse.Namespace) -> int:
@@ -62,6 +101,37 @@ def _handle_show(args: argparse.Namespace) -> int:
 
 def _handle_text(args: argparse.Namespace) -> int:
     print(get_prompt_text(args.key))
+    return 0
+
+
+def _handle_activate(args: argparse.Namespace) -> int:
+    activation = activate_prompt_session(args.key, repo_root=resolve_repo_root(args.repo_root))
+    emit_json(activation.to_payload())
+    return 0
+
+
+def _handle_current(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+    activation = get_active_prompt_session(repo_root=repo_root)
+    if activation is None:
+        emit_json(
+            {
+                "active": False,
+                "prompt": None,
+                "files": {
+                    "claude": repo_root / ".claude" / "CLAUDE.md",
+                    "codex": repo_root / "AGENTS.override.md",
+                    "state": repo_root / ".harnessiq" / "master_prompt_session" / "active_prompt.json",
+                },
+            }
+        )
+        return 0
+    emit_json(activation.to_payload())
+    return 0
+
+
+def _handle_clear(args: argparse.Namespace) -> int:
+    emit_json(clear_prompt_session(repo_root=resolve_repo_root(args.repo_root)))
     return 0
 
 

--- a/harnessiq/master_prompts/session_injection.py
+++ b/harnessiq/master_prompts/session_injection.py
@@ -1,0 +1,256 @@
+"""Helpers for activating one bundled master prompt as project session context."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from harnessiq.master_prompts import get_prompt
+
+_CLAUDE_FILE = Path(".claude") / "CLAUDE.md"
+_CODEX_FILE = Path("AGENTS.override.md")
+_STATE_FILE = Path(".harnessiq") / "master_prompt_session" / "active_prompt.json"
+_GENERATOR_HINT = "harnessiq prompts activate <prompt-key>"
+_BLOCK_BEGIN = "<!-- HARNESSIQ_MASTER_PROMPT_SESSION:BEGIN -->"
+_BLOCK_END = "<!-- HARNESSIQ_MASTER_PROMPT_SESSION:END -->"
+_BLOCK_PATTERN = re.compile(
+    rf"{re.escape(_BLOCK_BEGIN)}.*?{re.escape(_BLOCK_END)}\n?",
+    flags=re.DOTALL,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptSessionActivation:
+    """Resolved metadata for one active project-scoped master prompt."""
+
+    repo_root: Path
+    key: str
+    title: str
+    description: str
+    claude_path: Path
+    codex_path: Path
+    state_path: Path
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a deterministic JSON-serializable payload."""
+        return {
+            "active": True,
+            "prompt": {
+                "key": self.key,
+                "title": self.title,
+                "description": self.description,
+            },
+            "files": {
+                "claude": self.claude_path,
+                "codex": self.codex_path,
+                "state": self.state_path,
+            },
+        }
+
+
+def activate_prompt_session(prompt_key: str, *, repo_root: str | Path) -> PromptSessionActivation:
+    """Write project instruction overlays for the selected bundled prompt."""
+    root = Path(repo_root).expanduser().resolve()
+    prompt = get_prompt(prompt_key)
+    paths = _PromptSessionPaths.for_repo(root)
+
+    _write_text(paths.claude_path, _render_claude_document(prompt.key, prompt.title, prompt.description, prompt.prompt))
+    _write_text(paths.codex_path, _render_codex_document(prompt.key, prompt.title, prompt.description, prompt.prompt))
+    _write_state(
+        paths.state_path,
+        {
+            "prompt": {
+                "key": prompt.key,
+                "title": prompt.title,
+                "description": prompt.description,
+            }
+        },
+    )
+    return PromptSessionActivation(
+        repo_root=root,
+        key=prompt.key,
+        title=prompt.title,
+        description=prompt.description,
+        claude_path=paths.claude_path,
+        codex_path=paths.codex_path,
+        state_path=paths.state_path,
+    )
+
+
+def get_active_prompt_session(*, repo_root: str | Path) -> PromptSessionActivation | None:
+    """Return the currently active project prompt, if any."""
+    root = Path(repo_root).expanduser().resolve()
+    paths = _PromptSessionPaths.for_repo(root)
+    if not paths.state_path.exists():
+        return None
+    payload = json.loads(paths.state_path.read_text(encoding="utf-8"))
+    prompt_payload = payload.get("prompt")
+    if not isinstance(prompt_payload, dict):
+        return None
+    key = str(prompt_payload.get("key", "")).strip()
+    title = str(prompt_payload.get("title", "")).strip()
+    description = str(prompt_payload.get("description", "")).strip()
+    if not key or not title or not description:
+        return None
+    return PromptSessionActivation(
+        repo_root=root,
+        key=key,
+        title=title,
+        description=description,
+        claude_path=paths.claude_path,
+        codex_path=paths.codex_path,
+        state_path=paths.state_path,
+    )
+
+
+def clear_prompt_session(*, repo_root: str | Path) -> dict[str, object]:
+    """Remove generated project overlays and local active-state metadata."""
+    root = Path(repo_root).expanduser().resolve()
+    paths = _PromptSessionPaths.for_repo(root)
+    removed: list[Path] = []
+    for path in (paths.claude_path, paths.codex_path):
+        if _remove_generated_block(path):
+            removed.append(path)
+    if paths.state_path.exists():
+        paths.state_path.unlink()
+        removed.append(paths.state_path)
+    _remove_empty_parent(paths.claude_path.parent, stop=root)
+    _remove_empty_parent(paths.state_path.parent, stop=root)
+    return {
+        "active": False,
+        "removed_files": removed,
+        "files": {
+            "claude": paths.claude_path,
+            "codex": paths.codex_path,
+            "state": paths.state_path,
+        },
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class _PromptSessionPaths:
+    repo_root: Path
+    claude_path: Path
+    codex_path: Path
+    state_path: Path
+
+    @classmethod
+    def for_repo(cls, repo_root: Path) -> _PromptSessionPaths:
+        return cls(
+            repo_root=repo_root,
+            claude_path=repo_root / _CLAUDE_FILE,
+            codex_path=repo_root / _CODEX_FILE,
+            state_path=repo_root / _STATE_FILE,
+        )
+
+
+def _write_state(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _remove_empty_parent(path: Path, *, stop: Path) -> None:
+    current = path
+    stop = stop.resolve()
+    while current != stop:
+        if current.exists() and any(current.iterdir()):
+            return
+        if current.exists():
+            current.rmdir()
+        current = current.parent
+
+
+def _render_claude_document(key: str, title: str, description: str, prompt_text: str) -> str:
+    return _render_instruction_document(
+        platform_name="Claude Code",
+        instruction_file=".claude/CLAUDE.md",
+        key=key,
+        title=title,
+        description=description,
+        prompt_text=prompt_text,
+    )
+
+
+def _render_codex_document(key: str, title: str, description: str, prompt_text: str) -> str:
+    return _render_instruction_document(
+        platform_name="Codex",
+        instruction_file="AGENTS.override.md",
+        key=key,
+        title=title,
+        description=description,
+        prompt_text=prompt_text,
+    )
+
+
+def _render_instruction_document(
+    *,
+    platform_name: str,
+    instruction_file: str,
+    key: str,
+    title: str,
+    description: str,
+    prompt_text: str,
+) -> str:
+    lines = [
+        _BLOCK_BEGIN,
+        f"# Generated {platform_name} Master Prompt Context",
+        "",
+        f"This file is generated by `{_GENERATOR_HINT}`. Do not hand-edit it.",
+        "",
+        "Apply the active master prompt below as always-on project guidance for every request in this repository session unless the user explicitly overrides it.",
+        "",
+        "## Active Prompt",
+        "",
+        f"- Key: `{key}`",
+        f"- Title: {title}",
+        f"- Description: {description}",
+        f"- Instruction file: `{instruction_file}`",
+        "",
+        "## Active Master Prompt",
+        "",
+        prompt_text.strip(),
+        "",
+        _BLOCK_END,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    path.write_text(_merge_generated_block(existing, content), encoding="utf-8")
+
+
+def _merge_generated_block(existing: str, generated_block: str) -> str:
+    if _BLOCK_BEGIN in existing and _BLOCK_END in existing:
+        merged = _BLOCK_PATTERN.sub(generated_block, existing, count=1)
+    elif existing.strip():
+        merged = existing.rstrip() + "\n\n" + generated_block
+    else:
+        merged = generated_block
+    return merged.rstrip() + "\n"
+
+
+def _remove_generated_block(path: Path) -> bool:
+    if not path.exists():
+        return False
+    existing = path.read_text(encoding="utf-8")
+    if _BLOCK_BEGIN not in existing or _BLOCK_END not in existing:
+        return False
+    cleaned = _BLOCK_PATTERN.sub("", existing, count=1).strip()
+    if cleaned:
+        path.write_text(cleaned + "\n", encoding="utf-8")
+        return True
+    path.unlink()
+    return True
+
+
+__all__ = [
+    "PromptSessionActivation",
+    "activate_prompt_session",
+    "clear_prompt_session",
+    "get_active_prompt_session",
+]

--- a/tests/test_master_prompt_session_injection.py
+++ b/tests/test_master_prompt_session_injection.py
@@ -1,0 +1,92 @@
+"""Tests for project-scoped master prompt session injection helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harnessiq.master_prompts.session_injection import (
+    activate_prompt_session,
+    clear_prompt_session,
+    get_active_prompt_session,
+)
+
+
+def test_activate_prompt_session_writes_generated_instruction_files(tmp_path: Path) -> None:
+    activation = activate_prompt_session("create_master_prompts", repo_root=tmp_path)
+
+    assert activation.key == "create_master_prompts"
+    assert activation.claude_path.exists()
+    assert activation.codex_path.exists()
+    assert activation.state_path.exists()
+
+    claude_text = activation.claude_path.read_text(encoding="utf-8")
+    codex_text = activation.codex_path.read_text(encoding="utf-8")
+    assert "Apply the active master prompt below as always-on project guidance" in claude_text
+    assert "Apply the active master prompt below as always-on project guidance" in codex_text
+    assert "create_master_prompts" in claude_text
+    assert "create_master_prompts" in codex_text
+    assert "You are a world-class prompt engineer and AI systems architect." in claude_text
+    assert "You are a world-class prompt engineer and AI systems architect." in codex_text
+
+    state_payload = json.loads(activation.state_path.read_text(encoding="utf-8"))
+    assert state_payload["prompt"]["key"] == "create_master_prompts"
+
+
+def test_get_active_prompt_session_reads_local_state(tmp_path: Path) -> None:
+    activate_prompt_session("create_master_prompts", repo_root=tmp_path)
+
+    activation = get_active_prompt_session(repo_root=tmp_path)
+
+    assert activation is not None
+    assert activation.key == "create_master_prompts"
+    assert activation.claude_path == tmp_path / ".claude" / "CLAUDE.md"
+    assert activation.codex_path == tmp_path / "AGENTS.override.md"
+
+
+def test_get_active_prompt_session_returns_none_when_inactive(tmp_path: Path) -> None:
+    assert get_active_prompt_session(repo_root=tmp_path) is None
+
+
+def test_clear_prompt_session_removes_generated_files_and_state(tmp_path: Path) -> None:
+    activation = activate_prompt_session("create_master_prompts", repo_root=tmp_path)
+
+    payload = clear_prompt_session(repo_root=tmp_path)
+
+    assert payload["active"] is False
+    removed_files = {Path(path) for path in payload["removed_files"]}
+    assert activation.claude_path in removed_files
+    assert activation.codex_path in removed_files
+    assert activation.state_path in removed_files
+    assert not activation.claude_path.exists()
+    assert not activation.codex_path.exists()
+    assert not activation.state_path.exists()
+
+
+def test_clear_prompt_session_is_idempotent_when_nothing_is_active(tmp_path: Path) -> None:
+    payload = clear_prompt_session(repo_root=tmp_path)
+
+    assert payload["active"] is False
+    assert payload["removed_files"] == []
+
+
+def test_activate_preserves_existing_instruction_content_and_clear_removes_only_managed_block(tmp_path: Path) -> None:
+    claude_path = tmp_path / ".claude" / "CLAUDE.md"
+    codex_path = tmp_path / "AGENTS.override.md"
+    claude_path.parent.mkdir(parents=True, exist_ok=True)
+    claude_path.write_text("# Existing Claude guidance\n", encoding="utf-8")
+    codex_path.write_text("# Existing Codex guidance\n", encoding="utf-8")
+
+    activate_prompt_session("create_master_prompts", repo_root=tmp_path)
+
+    claude_text = claude_path.read_text(encoding="utf-8")
+    codex_text = codex_path.read_text(encoding="utf-8")
+    assert "# Existing Claude guidance" in claude_text
+    assert "# Existing Codex guidance" in codex_text
+    assert "HARNESSIQ_MASTER_PROMPT_SESSION:BEGIN" in claude_text
+    assert "HARNESSIQ_MASTER_PROMPT_SESSION:BEGIN" in codex_text
+
+    clear_prompt_session(repo_root=tmp_path)
+
+    assert claude_path.read_text(encoding="utf-8") == "# Existing Claude guidance\n"
+    assert codex_path.read_text(encoding="utf-8") == "# Existing Codex guidance\n"

--- a/tests/test_master_prompts_cli.py
+++ b/tests/test_master_prompts_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -34,6 +35,21 @@ class TestMasterPromptParserRegistration:
         parser = build_parser()
         args, _ = parser.parse_known_args(["prompts", "text", "create_master_prompts"])
         assert args.prompts_command == "text"
+
+    def test_prompts_activate_subcommand_registered(self) -> None:
+        parser = build_parser()
+        args, _ = parser.parse_known_args(["prompts", "activate", "create_master_prompts"])
+        assert args.prompts_command == "activate"
+
+    def test_prompts_current_subcommand_registered(self) -> None:
+        parser = build_parser()
+        args, _ = parser.parse_known_args(["prompts", "current"])
+        assert args.prompts_command == "current"
+
+    def test_prompts_clear_subcommand_registered(self) -> None:
+        parser = build_parser()
+        args, _ = parser.parse_known_args(["prompts", "clear"])
+        assert args.prompts_command == "clear"
 
 
 class TestMasterPromptCommands:
@@ -67,3 +83,78 @@ class TestMasterPromptCommands:
     def test_show_unknown_prompt_raises_key_error(self) -> None:
         with pytest.raises(KeyError):
             _run(["prompts", "show", "does_not_exist"])
+
+    def test_activate_emits_active_prompt_payload_and_writes_files(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        result = _run(["prompts", "activate", "create_master_prompts", "--repo-root", str(tmp_path)])
+        assert result == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["active"] is True
+        assert payload["prompt"]["key"] == "create_master_prompts"
+        assert Path(payload["files"]["claude"]).exists()
+        assert Path(payload["files"]["codex"]).exists()
+        assert Path(payload["files"]["state"]).exists()
+
+    def test_current_reports_inactive_state_when_no_prompt_is_active(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        result = _run(["prompts", "current", "--repo-root", str(tmp_path)])
+        assert result == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["active"] is False
+        assert payload["prompt"] is None
+
+    def test_current_reports_active_prompt_after_activation(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        assert _run(["prompts", "activate", "create_master_prompts", "--repo-root", str(tmp_path)]) == 0
+        capsys.readouterr()
+
+        result = _run(["prompts", "current", "--repo-root", str(tmp_path)])
+        assert result == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["active"] is True
+        assert payload["prompt"]["key"] == "create_master_prompts"
+
+    def test_clear_removes_active_prompt_files(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        assert _run(["prompts", "activate", "create_master_prompts", "--repo-root", str(tmp_path)]) == 0
+        capsys.readouterr()
+
+        result = _run(["prompts", "clear", "--repo-root", str(tmp_path)])
+        assert result == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["active"] is False
+        assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+        assert not (tmp_path / "AGENTS.override.md").exists()
+
+    def test_activate_resolves_to_nearest_git_root(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        nested = repo_root / "services" / "api"
+        nested.mkdir(parents=True)
+        (repo_root / ".git").write_text("gitdir: fake\n", encoding="utf-8")
+
+        result = _run(["prompts", "activate", "create_master_prompts", "--repo-root", str(nested)])
+        assert result == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert Path(payload["files"]["claude"]) == repo_root / ".claude" / "CLAUDE.md"
+        assert Path(payload["files"]["codex"]) == repo_root / "AGENTS.override.md"


### PR DESCRIPTION
## Summary
- add `harnessiq prompts activate`, `current`, and `clear` for repo-scoped master prompt session activation
- generate managed prompt blocks for Claude Code and Codex plus local active-state metadata without overwriting existing instruction files
- document the workflow and add CLI/helper coverage for activation, clear, and git-root resolution

## Verification
- pytest tests/test_master_prompts.py tests/test_master_prompt_session_injection.py tests/test_master_prompts_cli.py
- python -m compileall harnessiq\\master_prompts harnessiq\\cli\\master_prompts
