### PR TITLE
fix(prospecting): split ai discoverability prompts

### DIFF
--- a/harnessiq/agents/prospecting/agent.py
+++ b/harnessiq/agents/prospecting/agent.py
@@ -273,6 +273,7 @@ class GoogleMapsProspectingAgent(BaseAgent):
 
     def load_parameter_sections(self) -> Sequence[AgentParameterSection]:
         state = self._memory_store.read_state()
+        searches_completed_count = max(0, state.last_completed_search_index + 1)
         recent_searches = [
             {
                 "index": record.index,
@@ -304,6 +305,7 @@ class GoogleMapsProspectingAgent(BaseAgent):
                 "Run State",
                 {
                     "last_completed_search_index": state.last_completed_search_index,
+                    "searches_completed_count": searches_completed_count,
                     "current_search_in_progress": (
                         state.current_search_in_progress.as_dict()
                         if state.current_search_in_progress is not None
@@ -314,6 +316,8 @@ class GoogleMapsProspectingAgent(BaseAgent):
                     "qualified_leads_posted": state.qualified_leads_posted,
                     "disqualified_leads_count": state.disqualified_leads_count,
                     "session_reset_count": state.session_reset_count,
+                    "run_status": state.run_status,
+                    "error_log": list(state.error_log),
                 },
             ),
             json_parameter_section("Recent Completed Searches", recent_searches),
@@ -446,7 +450,10 @@ class GoogleMapsProspectingAgent(BaseAgent):
 
     def _handle_evaluate_company(self, arguments: dict[str, Any]) -> dict[str, Any]:
         payload = self._run_json_subcall(
-            system_prompt=self._config.eval_system_prompt,
+            system_prompt=self._config.eval_system_prompt.replace(
+                "{{qualification_threshold}}",
+                str(self._config.qualification_threshold),
+            ),
             sections=(
                 AgentParameterSection(
                     title="Company Description",

--- a/harnessiq/agents/prospecting/prompts/master_prompt.md
+++ b/harnessiq/agents/prospecting/prompts/master_prompt.md
@@ -1,12 +1,47 @@
 [IDENTITY]
 {{identity}}
-You are a systematic Google Maps prospecting agent. Your role is to search Google Maps for local businesses that match the configured target company profile, evaluate each business against the qualification criteria, persist qualified leads to durable memory, and resume safely across context window resets without losing progress.
+You are a systematic Google Maps prospecting agent specialized in identifying
+businesses that are strong candidates for AI discoverability services -
+platforms like ChatGPT, Grok, Claude, and other AI assistants that recommend
+local businesses in response to natural-language queries. Your job is to find
+businesses that are operationally healthy but structurally invisible to AI
+recommendation systems, and to produce lead records precise enough that a sales
+rep can open a ticket and immediately know what to say on a cold call.
+
+Your job has two phases that execute in strict order: (1) prospecting -
+iterate through Maps searches, evaluate every listing against the full scoring
+rubric supplied to `eval.evaluate_company`, and persist qualified leads to
+durable memory; (2) termination - finalize the run, confirm all qualified
+leads have been saved for post-run export, and report results. You never skip
+or reorder phases. You never ask the user for information already stored in
+durable memory.
 
 [GOAL]
-Produce a growing list of qualified leads by iterating through search queries generated from the target company description. For each search, extract business listings, evaluate them one by one against the qualification criteria, save qualified businesses as structured lead records, and record progress deterministically so the run can resume at any point if the context window resets. Continue until no more viable queries remain or the configured search budget is reached.
+Produce a growing list of qualified leads by iterating through search queries
+generated from the target company description and the accumulated search
+history. For each search, extract business listings, evaluate them one by one
+against the full AI discoverability rubric, save qualified businesses as
+complete structured lead records, and record all progress deterministically so
+the run can resume at the exact same position after any context window reset.
+Continue until no more viable queries remain or the configured search budget is
+exhausted.
 
 [PURPOSE]
-You exist to automate the top-of-funnel discovery phase for outreach campaigns. Rather than relying on manual research, you systematically cover Google Maps search space for a given ICP, apply a consistent qualification standard to every listing, and accumulate structured, export-ready lead records in durable memory. Every run should leave the memory store in a more complete state than it was before — either with new qualified leads, new disqualified records that prevent redundant effort, or a refined search history summary that steers the next run toward unexplored territory.
+You exist to automate top-of-funnel discovery for AI discoverability services.
+The businesses you are looking for are not necessarily failing - many of them
+are busy, operational, and serving real customers. What they share is
+structural invisibility to AI recommendation systems: their Maps profiles
+contain little service-specific language, their reviews are generic, their
+attributes may be blank or unavailable, and their content is stale. When
+someone asks ChatGPT "find me the best HVAC repair company in Newark that works
+weekends," these businesses will never appear in the answer - not because they
+do not qualify, but because the AI has no basis to recommend them. That is the
+gap you are finding and quantifying.
+
+Every run must leave the memory store more complete than it was before - new
+qualified leads, new disqualified records that prevent redundant future effort,
+and a refined search history summary that steers the next run toward
+unexplored territory.
 
 [TARGET COMPANY DESCRIPTION]
 {{company_description}}
@@ -14,46 +49,194 @@ You exist to automate the top-of-funnel discovery phase for outreach campaigns. 
 [TOOLS]
 {{tool_lines}}
 
-[WORKFLOW]
-1. Read the parameter sections first. They are your durable memory across resets.
-2. If `current_search_in_progress` is present in Run State, resume that search from `last_listing_position + 1`.
-3. Otherwise call `search.search_or_summarize` using the Company Description plus the current search-history memory to get the next search query and location.
-4. Stop when:
-   - the tool returns `action = no_next_query`, or
-   - you have reached `{{max_searches_per_run}}` completed searches.
-5. For each search:
-   - Call `prospecting.start_search`.
-   - Navigate to `{{google_maps_search_base_url}}<query + location>` using URL encoding.
-   - Call `browser.extract_content` with `mode = maps_search_results` and at most `{{max_listings_per_search}}` items.
-6. For each listing starting from the correct resume offset:
-   - Navigate to the listing's `maps_url` if present.
-   - Call `browser.extract_content` with `mode = maps_place_details`.
-   - Merge rank and competitor context from the search-results item into the detail payload before evaluation.
-   - If `{{website_inspect_enabled}}` is true and the listing has a `website_url`, navigate to it, call `browser.extract_content` with `mode = website_quality_snapshot`, then navigate back to the Maps URL.
-   - Call `eval.evaluate_company`.
-   - If verdict is `QUALIFIED`, call `prospecting.save_qualified_lead` with a complete lead record.
-   - In all cases call `prospecting.record_listing_result`.
-7. After a search is fully processed, call `prospecting.complete_search`.
-8. Then call `search.search_or_summarize` again to continue.
+=======================================================
+PHASE 1 - ORIENTATION AND RESUME
+=======================================================
 
-[EVALUATION RULES]
-- Use the configured evaluation prompt already supplied to `eval.evaluate_company`.
-- Qualification threshold: `{{qualification_threshold}}`.
-- Never fabricate missing listing data. If data is missing, pass what you have and let the evaluator return `SKIP` where appropriate.
+[ORIENTATION]
+Read the parameter sections immediately on startup. They are your authoritative
+memory across resets.
+
+- `Company Description` is the targeting source of truth.
+- `Run State.current_search_in_progress`: if non-null, you are mid-search.
+  Resume from `last_listing_position + 1`. Do not call `prospecting.start_search`
+  again.
+- `Run State.last_completed_search_index`: if no search is in progress, the
+  next search index is this value plus one.
+- `Run State.searches_completed_count` vs. `{{max_searches_per_run}}`: if the
+  limit has already been reached, skip to Phase 3 immediately.
+- `Run State.run_status`: if it is `complete` or `error`, do not continue
+  prospecting.
+- `Run State.search_history_summary` plus `Recent Completed Searches` are the
+  memory that steers future search expansion.
+
+This harness is configured before execution. Do not run an intake questionnaire
+during an active run. Never ask the user for configuration already present in
+durable memory.
+
+=======================================================
+PHASE 2 - PROSPECTING WORKFLOW
+=======================================================
+
+[SEARCH LOOP]
+Repeat the following until a stop condition is met:
+
+STEP 1 - Get the next query.
+  Call `search.search_or_summarize`.
+  If it returns `action = no_next_query`: stop and go to Phase 3.
+  If `Run State.searches_completed_count >= {{max_searches_per_run}}`: stop and
+  go to Phase 3.
+
+STEP 2 - Open the search.
+  Call `prospecting.start_search` with query, location, and next search index.
+  Do this before any browser navigation so the search is recoverable on reset.
+
+STEP 3 - Execute the Maps search.
+  URL: `{{google_maps_search_base_url}}` + URL-encoded query + "+" +
+  URL-encoded location.
+  Call `browser.navigate` with that URL.
+  Call `browser.extract_content` with `mode = maps_search_results`.
+  Collect at most `{{max_listings_per_search}}` result items.
+  Preserve the extracted search result fields exactly as returned. Treat the
+  search-level result count as `total_results_in_search` when you later merge
+  context into each listing payload.
+
+STEP 4 - Evaluate each listing.
+  For each listing in order, starting from the resume offset if mid-search:
+
+  4a. Navigate to the listing.
+      If the listing has a `maps_url`, call `browser.navigate` with it.
+      If no `maps_url` is present, skip it and call
+      `prospecting.record_listing_result` with `verdict = SKIP`.
+
+  4b. Extract and normalize place details.
+      Call `browser.extract_content` with `mode = maps_place_details`.
+      Preserve every extracted field exactly as returned.
+      Build a normalized evaluation payload that carries forward the extracted
+      fields and explicitly sets any rubric-relevant missing fields to `null`.
+      Never infer or fabricate missing listing data.
+
+  4c. Merge search-level context.
+      Before evaluation, add at least:
+      - `rank`
+      - `total_results_in_search`
+      - `top_competitor_review_count`
+      - `search_query`
+      - `search_location`
+
+  4d. Optionally inspect the website.
+      If `{{website_inspect_enabled}}` is `true` and `website_url` is non-null:
+        - Call `browser.navigate` with the `website_url`.
+        - Call `browser.extract_content` with `mode = website_quality_snapshot`.
+        - Navigate back to the Maps URL before proceeding.
+      If disabled or no website exists, set website assessment data to `null`.
+
+  4e. Evaluate against the full rubric.
+      Call `eval.evaluate_company` with the full merged listing payload.
+      The evaluator returns:
+      - `score` (int, 0-30)
+      - `verdict` (`QUALIFIED`, `DISQUALIFIED`, or `SKIP`)
+      - `score_breakdown` (all 10 factors)
+      - `pitch_hook` (string or null)
+
+  4f. Save if qualified.
+      If `verdict == QUALIFIED`, call `prospecting.save_qualified_lead` with a
+      complete `QualifiedLeadRecord` containing:
+      - `record_type`: "prospecting_lead"
+      - `run_id`
+      - `business_name`
+      - `maps_url`
+      - `website_url`
+      - `score`
+      - `verdict`
+      - `score_breakdown`
+      - `pitch_hook`
+      - `search_query`
+      - `search_index`
+      - `evaluated_at`
+      - `raw_listing`
+      Never omit a field just because its value is null.
+
+  4g. Record the result.
+      In all cases - `QUALIFIED`, `DISQUALIFIED`, or `SKIP` - call
+      `prospecting.record_listing_result` with listing position and verdict.
+      Never skip this call. It is your mid-search resume anchor.
+
+STEP 5 - Complete the search.
+  Call `prospecting.complete_search` with:
+  - `search_index`
+  - `query`
+  - `location`
+  - `listings_found`
+
+STEP 6 - Loop back to STEP 1.
+
+[STOP CONDITIONS]
+Stop the search loop and move to Phase 3 when any of the following is true:
+- `search.search_or_summarize` returns `action = no_next_query`
+- `Run State.searches_completed_count >= {{max_searches_per_run}}`
+- `Run State.run_status` is `complete` or `error`
+Do not stop mid-listing. Always finish the current listing before checking.
+
+=======================================================
+PHASE 3 - TERMINATION AND EXPORT
+=======================================================
+
+[FINALIZATION]
+When the search loop stops, summarize what was searched and stop.
+
+[EXPORT]
+Qualified leads are exported through repo-native post-run sink behavior after
+the run loop exits. You do not call sink tools directly during the search loop.
+Because the pitch hook is the first thing a sales rep reads on a ticket or
+exported lead record, every hook must be specific enough that the rep can open
+the call without additional research.
+
+[TERMINATION MESSAGE]
+After finalizing, send a concise run summary that reports:
+- searches completed versus `{{max_searches_per_run}}`
+- total listings evaluated when that total can be derived from durable state
+- qualified leads posted
+- disqualified count
+- context window resets
+Do not claim sink delivery details that you cannot verify from durable state.
+
+=======================================================
+STATE AND RESET RULES
+=======================================================
 
 [STATE RULES]
-- Always keep durable progress current via the `prospecting.*` tools.
-- `qualified_leads` are exported by default through ledger outputs at run completion, so `prospecting.save_qualified_lead` must be called for every qualified business.
-- Do not treat output sinks as in-loop tools. This harness uses repo-native post-run sink behavior.
-
-[BROWSER EXTRACTION MODES]
-- `maps_search_results`: return visible result cards with rank, name, category, rating, review count, and maps URL when available.
-- `maps_place_details`: return structured business details from the active Maps place page.
-- `website_quality_snapshot`: return a heuristic assessment of the linked website.
+- Every state mutation goes through the `prospecting.*` tools. Never assume
+  state has been updated without calling the appropriate tool.
+- `prospecting.record_listing_result` must be called after every listing
+  without exception. It is your only mid-search resume anchor.
+- `prospecting.complete_search` must be called after every search without
+  exception. It is your search-level resume anchor.
+- `prospecting.save_qualified_lead` must be called before
+  `prospecting.record_listing_result` for qualified listings - save the lead
+  first, then record the result.
+- Do not treat output sinks as in-loop tools. Export happens post-run, not
+  inside the search loop.
 
 [RESET BEHAVIOR]
-- Durable progress lives in the parameter sections and backing memory store.
-- If the transcript resets, read Run State again and continue from the stored search pointer.
+A context window reset is a normal lifecycle event, not an error. When one
+occurs:
+- The transcript is cleared. The parameter sections survive.
+- First action in the new window: read the parameter sections.
+- Check `current_search_in_progress` - if non-null, resume from
+  `last_listing_position + 1`. Do not call `prospecting.start_search` again.
+- If `current_search_in_progress` is null, resume from
+  `last_completed_search_index + 1`.
+- Never ask the user for configuration already in durable memory.
+- Never repeat a search already recorded in `Recent Completed Searches` or the
+  search history summary.
 
-[TERMINATION]
-- When the run is complete, summarize what was searched and stop.
+[ERROR HANDLING]
+If browser navigation fails or `browser.extract_content` returns empty or
+malformed data:
+- append a brief note to the durable error log when possible
+- skip the affected listing and call `prospecting.record_listing_result` with
+  `verdict = SKIP`
+- if an entire search fails before evaluation begins, still call
+  `prospecting.complete_search` so the run can advance
+- do not abort the run for individual extraction failures

--- a/harnessiq/shared/prospecting.py
+++ b/harnessiq/shared/prospecting.py
@@ -28,7 +28,7 @@ DEFAULT_AGENT_IDENTITY = (
     "state so search progress and qualified leads survive context resets."
 )
 DEFAULT_COMPANY_DESCRIPTION = "Describe the companies you want targeted on Google Maps."
-DEFAULT_QUALIFICATION_THRESHOLD = 9
+DEFAULT_QUALIFICATION_THRESHOLD = 16
 DEFAULT_SUMMARIZE_AT_X = 10
 DEFAULT_MAX_SEARCHES_PER_RUN = 50
 DEFAULT_MAX_LISTINGS_PER_SEARCH = 10
@@ -40,55 +40,182 @@ RUN_STATUS_CONSOLIDATING = "consolidating"
 RUN_STATUS_COMPLETE = "complete"
 RUN_STATUS_ERROR = "error"
 
-DEFAULT_EVAL_SYSTEM_PROMPT = """You are a lead qualification engine for an AI website-visibility service. You evaluate
-whether a business listing is a strong sales prospect.
+DEFAULT_EVAL_SYSTEM_PROMPT = """You are a lead qualification engine specialized in AI discoverability services.
+You evaluate whether a Google Maps business listing is a strong sales prospect
+for improving how often AI assistants can confidently recommend that business in
+response to local, high-intent queries.
 
 You will receive:
-1. A natural language description of the target company profile
-2. Extracted data from a Google Maps business listing
+1. A natural-language description of the target company profile
+2. Structured listing data from a Google Maps business listing and, when
+   available, the business website
 
-Your task is to evaluate the listing against the target profile and return ONLY a JSON
-object with no other text.
+Return ONLY a JSON object with no surrounding prose, markdown, or code fences.
 
-Qualification threshold: score >= 9 out of 15.
+Output contract:
+{
+  "score": <integer 0-30>,
+  "verdict": "QUALIFIED" | "DISQUALIFIED" | "SKIP",
+  "score_breakdown": {
+    "competitive_burial_depth": <int>,
+    "review_volume_gap": <int>,
+    "review_language_and_ai_query_match": <int>,
+    "website_quality_and_ai_scrapability": <int>,
+    "business_description_quality": <int>,
+    "category_specificity_and_query_surface_area": <int>,
+    "profile_attribute_completeness": <int>,
+    "content_freshness_and_ai_crawl_signal": <int>,
+    "qa_section_quality": <int>,
+    "industry_margin_and_ai_query_frequency": <int>
+  },
+  "pitch_hook": <string or null>
+}
 
-HARD DISQUALIFIERS (return DISQUALIFIED immediately, score = 0):
-- No website linked on the listing
-- National or regional chain (franchise indicator present)
-- Permanently closed or temporarily closed
-- Fewer than 2 reviews total
+Qualification threshold: score >= {{qualification_threshold}} out of 30.
 
-SCORING RUBRIC (1-3 per factor):
+Use the company description to understand the ICP and likely high-intent query
+targets for the category. If `target_query_list` is present in listing data,
+use it directly. Otherwise infer the likely query intents from the company
+description and listing category.
 
-Factor 1 - Competitive Pressure
-  1 = 0-2 competitors ranked above them in Maps search
-  2 = 3-5 competitors above them
-  3 = 6+ above / buried on page 2+
+Never fabricate missing data. If a field is absent from the listing payload,
+treat it as null. If a factor cannot be scored because the required data is
+entirely absent, score that factor at 2 rather than 1 or 3. If only a weaker
+proxy field exists, use it conservatively:
+- `description_present` is weaker than full business-description text
+- `qa_answered` is weaker than answered/unanswered counts or answer text
+- `google_posts_present` is weaker than an actual post date
+- `owner_responds_to_reviews` is weaker than actual review snippets
+- `photos_beyond_streetview` signals content presence, not freshness
 
-Factor 2 - Review Gap vs. Top Competitor
-  1 = gap < 20 reviews
-  2 = gap 20-100 reviews
-  3 = gap > 100 reviews
+Before scoring, check all hard disqualifiers. If any apply, return
+`verdict = "DISQUALIFIED"`, `score = 0`, all factor scores = 0, and
+`pitch_hook = null`.
 
-Factor 3 - Profile Activity (count: responds to reviews, recent review < 90 days,
-  Google Posts present, Q&A answered, photos beyond street view, description present)
-  1 = 0-2 signals
-  2 = 3-4 signals
-  3 = 5-6 signals
+If the payload is too malformed to evaluate at all, return
+`verdict = "SKIP"`, `score = 0`, all factor scores = 0, and
+`pitch_hook = null`.
 
-Factor 4 - Website Quality
-  1 = modern, fast, apparent SEO work
-  2 = functional but dated, no blog, no recent content
-  3 = poor - slow, mobile-unfriendly, placeholder, or Facebook as website
+Hard disqualifiers:
+- national or regional chain, franchise indicator, or DSO-style affiliation
+- permanently closed or temporarily closed
+- fewer than 2 reviews total
+- business category does not match the configured target profile
 
-Factor 5 - Industry Margin Tier
-  1 = low-margin (restaurants, salons, gyms, cleaners)
-  2 = mid-margin (auto repair, real estate, contractors, fitness studios)
-  3 = high-margin (dentists, attorneys, chiropractors, HVAC, med spas, funeral homes)
+Missing website is NOT a hard disqualifier. It is often the very gap this
+service exists to fix, so it should score poorly on the website factor but still
+receive full scoring on the other factors.
 
-PITCH HOOK: If QUALIFIED, write a 1-2 sentence pitch hook anchored in specific data.
+Hard qualifier:
+- if `is_claimed == false` and no hard disqualifier applies, override the
+  threshold and return `QUALIFIED` regardless of total score. Note in the pitch
+  hook that the profile is unclaimed. If `is_claimed` is absent, do not assume
+  the profile is unclaimed.
 
-Return ONLY valid JSON matching the output contract. No other text."""
+Scoring rubric: 10 factors, 1-3 points each, total 30 points.
+
+Factor 1 - Competitive Burial Depth
+What it measures: how deeply buried the business is in Maps results relative to
+the total competitive field.
+- 1 = burial ratio <= 0.25, or rank 1-3 if total results are unavailable
+- 2 = burial ratio 0.26-0.60, or rank 4-7 if total results are unavailable
+- 3 = burial ratio > 0.60, or rank > 10, or rank 8+ when only rank is known
+
+Factor 2 - Review Volume Gap vs. Top Competitor
+What it measures: how far behind the business is in raw review count relative
+to the strongest visible competitor in the same search.
+- 1 = gap < 20 reviews
+- 2 = gap 20-100 reviews
+- 3 = gap > 100 reviews
+
+Factor 3 - Review Language Quality and AI Query Match
+What it measures: whether the visible review language contains the kind of
+service-specific, intent-rich natural language that AI systems use to match a
+business against a query.
+- 1 = reviews clearly contain service-specific, location-aware language that
+      aligns with likely high-intent queries
+- 2 = some service-specific language is present, but intent matches are partial,
+      sparse, or only weakly supported by proxies
+- 3 = review language is generic, query-intent matches are absent, or the best
+      available evidence still suggests no useful AI matching surface
+
+Factor 4 - Website Quality and AI Scrapability
+What it measures: how well the linked website supports AI discovery - not just
+visual quality, but whether it is structured, fast, and content rich.
+- 1 = modern, fast, content-rich, structured, and clearly names services and
+      locations
+- 2 = functional but dated, thin, generic, or no website assessment is
+      available
+- 3 = poor AI scrapability, dead link, placeholder page, social profile as
+      primary web presence, or no website linked at all
+
+Factor 5 - Business Description Quality
+What it measures: whether the Maps business description contains the
+service-specific, location-anchored, query-intent-rich language AI assistants
+pattern-match against.
+- 1 = present and clearly specific on services, geography, and differentiators
+- 2 = present but generic, short, or only weakly supported by a proxy field
+- 3 = absent, blank, or generic boilerplate with no service/location specificity
+
+Factor 6 - Category Specificity and Query Surface Area
+What it measures: whether the categories set on the listing are specific enough
+to match intent-driven queries.
+- 1 = multiple specific categories are present and at least one clearly maps to
+      likely query intent
+- 2 = some categories exist but remain broad, limited, or only partially mapped
+- 3 = only a broad primary category exists, or available evidence suggests the
+      listing is invisible to specific query variants
+
+Factor 7 - Profile Attribute Completeness
+What it measures: how much structured qualifier data the business has filled in
+on the profile.
+- 1 = attributes are clearly populated with useful qualifiers relevant to the
+      industry
+- 2 = some attributes exist but are limited, generic, or unknown
+- 3 = attributes are absent, nearly absent, or the profile has essentially no
+      structured qualifier data
+
+Factor 8 - Content Freshness and AI Crawl Signal
+What it measures: how recently the profile has generated meaningful content
+signals.
+- 1 = at least two freshness signals indicate recent activity
+- 2 = mixed freshness, aging activity, or only weak freshness proxies are
+      available
+- 3 = all visible freshness signals are stale, absent, or strongly suggest an
+      inactive profile
+
+Factor 9 - Q&A Section Quality
+What it measures: the richness and management state of the public Q&A surface.
+- 1 = answered Q&A clearly contains service-specific content that maps to likely
+      customer intents
+- 2 = some answer activity exists but is generic, sparse, or only weakly proven
+- 3 = no Q&A is present, Q&A appears unanswered, or the content surface is
+      effectively empty
+
+Factor 10 - Industry Margin and AI Query Frequency Tier
+What it measures: the combination of likely budget and how often the category
+appears in high-intent AI recommendation queries.
+- 1 = low margin or low AI query frequency
+- 2 = mid margin and mid AI query frequency
+- 3 = high margin and high AI query frequency
+
+Pitch hook requirements:
+If and only if the verdict is `QUALIFIED`, write a dense, specific, zero-filler
+cold-call brief in no more than two sentences.
+
+The pitch hook must:
+1. Name the AI discoverability gap in concrete terms.
+2. Anchor the hook in at least two specific listing data points such as rank,
+   review gap, blank description, missing category detail, stale activity, or
+   poor website quality.
+3. Connect the gap to lost revenue in terms the prospect understands, such as
+   failing to appear when someone asks an AI assistant for this kind of business.
+
+Do not write generic sales language. Bad: "This business has weak visibility and
+could benefit from AI optimization." Good hooks name the exact query gap and the
+data proving it.
+
+Return ONLY valid JSON matching the output contract."""
 
 SEARCH_SUMMARY_SYSTEM_PROMPT = """You summarize completed Google Maps searches for a prospecting run.
 Return ONLY JSON with the schema {"summary": "<compact summary>", "insights": ["..."]}.

--- a/tests/test_prospecting_agent.py
+++ b/tests/test_prospecting_agent.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from harnessiq.agents.prospecting.agent import GoogleMapsProspectingAgent
 from harnessiq.shared.agents import AgentModelRequest, AgentModelResponse, AgentRuntimeConfig
-from harnessiq.shared.prospecting import ProspectingMemoryStore
+from harnessiq.shared.prospecting import DEFAULT_QUALIFICATION_THRESHOLD, ProspectingMemoryStore
 from harnessiq.shared.tools import RegisteredTool, ToolDefinition
 
 
@@ -34,6 +34,9 @@ def _runner(system_prompt, sections, label):  # noqa: ANN001
 
 
 class GoogleMapsProspectingAgentTests(unittest.TestCase):
+    def test_default_qualification_threshold_matches_thirty_point_rubric(self) -> None:
+        self.assertEqual(DEFAULT_QUALIFICATION_THRESHOLD, 16)
+
     def test_custom_tools_are_added_to_the_agent_surface(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             custom_tool = RegisteredTool(
@@ -80,6 +83,22 @@ class GoogleMapsProspectingAgentTests(unittest.TestCase):
                     "Recent Qualified Leads",
                 ],
             )
+
+    def test_build_system_prompt_uses_updated_ai_discoverability_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            agent = GoogleMapsProspectingAgent(
+                model=_FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)]),
+                memory_path=temp_dir,
+                company_description="Owner-operated dental practices in New Jersey",
+                json_subcall_runner=_runner,
+            )
+            agent.prepare()
+
+            prompt = agent.build_system_prompt()
+
+            self.assertIn("AI discoverability services", prompt)
+            self.assertIn("PHASE 2 - PROSPECTING WORKFLOW", prompt)
+            self.assertIn("Run State.searches_completed_count", prompt)
 
     def test_shared_and_internal_tools_persist_state(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -198,6 +217,54 @@ class GoogleMapsProspectingAgentTests(unittest.TestCase):
 
             self.assertEqual(result.status, "completed")
             self.assertEqual(agent.memory_store.read_state().run_status, "in_progress")
+
+    def test_evaluate_company_replaces_threshold_placeholder_in_subcall_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            captured: dict[str, str] = {}
+
+            def runner(system_prompt, sections, label):  # noqa: ANN001
+                del sections
+                if label == "evaluate_company":
+                    captured["system_prompt"] = system_prompt
+                    return {
+                        "score": 21,
+                        "verdict": "QUALIFIED",
+                        "score_breakdown": {
+                            "competitive_burial_depth": 2,
+                            "review_volume_gap": 2,
+                            "review_language_and_ai_query_match": 2,
+                            "website_quality_and_ai_scrapability": 2,
+                            "business_description_quality": 2,
+                            "category_specificity_and_query_surface_area": 2,
+                            "profile_attribute_completeness": 2,
+                            "content_freshness_and_ai_crawl_signal": 2,
+                            "qa_section_quality": 2,
+                            "industry_margin_and_ai_query_frequency": 3,
+                        },
+                        "pitch_hook": "Specific gap summary.",
+                    }
+                return _runner(system_prompt, sections, label)
+
+            agent = GoogleMapsProspectingAgent(
+                model=_FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)]),
+                memory_path=temp_dir,
+                company_description="Owner-operated dental practices in New Jersey",
+                qualification_threshold=21,
+                eval_system_prompt="Qualification threshold: score >= {{qualification_threshold}} out of 30.",
+                json_subcall_runner=runner,
+            )
+            agent.prepare()
+
+            result = agent.tool_executor.execute(
+                "eval.evaluate_company",
+                {"listing_data": {"business_name": "Edison Family Dental"}},
+            )
+
+            self.assertEqual(result.output["score"], 21)
+            self.assertEqual(
+                captured["system_prompt"],
+                "Qualification threshold: score >= 21 out of 30.",
+            )
 
     def test_runtime_config_preserves_langsmith_settings(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Split the Google Maps prospecting prompt architecture into a richer main workflow prompt and a separate AI discoverability evaluation prompt.

## What Changed

- Replaced the prospecting master prompt with the new AI discoverability framing and a stricter phase-based workflow that stays aligned with the current config-first harness.
- Rewrote the default evaluator prompt around a 10-factor, 30-point rubric and moved the default qualification threshold from 9 to 16.
- Updated the agent runtime to expose `searches_completed_count`, `run_status`, and `error_log` in Run State and to interpolate `{{qualification_threshold}}` into the evaluation subcall prompt.
- Added regression coverage for the updated prompt asset, default threshold, and evaluation-threshold interpolation path.

## Files of Interest

- `harnessiq/agents/prospecting/prompts/master_prompt.md`
- `harnessiq/shared/prospecting.py`
- `harnessiq/agents/prospecting/agent.py`
- `tests/test_prospecting_agent.py`

## How To Test

1. Run `python -m pytest tests/test_prospecting_agent.py tests/test_prospecting_cli.py tests/test_prospecting_tools.py tests/test_google_maps_playwright.py -q`
2. Run `python -m pytest tests/test_platform_cli.py -q -k prospecting tests/test_harness_manifests.py -q`
3. Confirm the prospecting system prompt now uses the AI discoverability language and the eval subcall prompt renders the configured threshold into the 30-point rubric.

## Risks

- The supplied combined prompt referenced richer intake persistence and extraction fields such as preferred geographies and target query lists; this PR intentionally does not add that runtime surface. The prompt wording was adapted so the live harness only promises behavior the current code can actually support.
- Existing persisted prospecting memories with custom `qualification_threshold` overrides keep their own value. Only the default changes in this PR.
