### PR TITLE
Convert platform CLI and profile storage surfaces to DTO-based contracts

### DIFF
--- a/harnessiq/cli/adapters/base.py
+++ b/harnessiq/cli/adapters/base.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import argparse
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig
 from harnessiq.interfaces import PreparedStoreLoader
+from harnessiq.shared.dtos import (
+    HarnessAdapterResponseDTO,
+    HarnessParameterBundleDTO,
+    HarnessStatePayloadDTO,
+)
 
 from .context import HarnessAdapterContext
 
@@ -25,7 +30,7 @@ class HarnessCliAdapter(Protocol):
         """Create or normalize any native harness state before profile resolution."""
         ...
 
-    def load_native_parameters(self, context: HarnessAdapterContext) -> tuple[dict[str, Any], dict[str, Any]]:
+    def load_native_parameters(self, context: HarnessAdapterContext) -> HarnessParameterBundleDTO:
         """Read runtime/custom values from the harness-native storage layout."""
         ...
 
@@ -33,7 +38,7 @@ class HarnessCliAdapter(Protocol):
         """Persist resolved generic profile values back into native harness storage."""
         ...
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, Any]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         """Return a JSON-safe summary of the current harness state."""
         ...
 
@@ -44,7 +49,7 @@ class HarnessCliAdapter(Protocol):
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, Any]:
+    ) -> HarnessAdapterResponseDTO:
         """Execute the harness and return a JSON-safe result payload."""
         ...
 
@@ -60,19 +65,19 @@ class BaseHarnessCliAdapter(ABC):
         """Prepare native state before the platform profile is resolved."""
         del context
 
-    def load_native_parameters(self, context: HarnessAdapterContext) -> tuple[dict[str, Any], dict[str, Any]]:
+    def load_native_parameters(self, context: HarnessAdapterContext) -> HarnessParameterBundleDTO:
         """Load native runtime/custom values when a harness persists them itself."""
         del context
-        return {}, {}
+        return HarnessParameterBundleDTO()
 
     def synchronize_profile(self, context: HarnessAdapterContext) -> None:
         """Write resolved profile values back into native storage when needed."""
         del context
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, Any]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         """Summarize native state for `prepare`, `show`, or `run` responses."""
         del context
-        return {}
+        return HarnessStatePayloadDTO()
 
     @abstractmethod
     def run(
@@ -82,7 +87,7 @@ class BaseHarnessCliAdapter(ABC):
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, Any]:
+    ) -> HarnessAdapterResponseDTO:
         """Execute the harness and return any adapter-specific response fields."""
 
 
@@ -99,12 +104,12 @@ class StoreBackedHarnessCliAdapter(BaseHarnessCliAdapter, Generic[StoreT], ABC):
         """Ensure the underlying native store exists before profile resolution."""
         self.load_store(context)
 
-    def load_native_parameters(self, context: HarnessAdapterContext) -> tuple[dict[str, Any], dict[str, Any]]:
+    def load_native_parameters(self, context: HarnessAdapterContext) -> HarnessParameterBundleDTO:
         """Read native runtime/custom values from the prepared store."""
         store = self.load_store(context)
-        return (
-            self.read_native_runtime_parameters(store, context),
-            self.read_native_custom_parameters(store, context),
+        return HarnessParameterBundleDTO(
+            runtime_parameters=self.read_native_runtime_parameters(store, context),
+            custom_parameters=self.read_native_custom_parameters(store, context),
         )
 
     def synchronize_profile(self, context: HarnessAdapterContext) -> None:

--- a/harnessiq/cli/adapters/context.py
+++ b/harnessiq/cli/adapters/context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from harnessiq.config import HarnessProfile
 from harnessiq.shared.harness_manifest import HarnessManifest
@@ -19,9 +19,9 @@ class HarnessAdapterContext:
     memory_path: Path
     repo_root: Path
     profile: HarnessProfile
-    runtime_parameters: dict[str, Any]
-    custom_parameters: dict[str, Any]
-    bound_credentials: dict[str, object]
+    runtime_parameters: Mapping[str, Any]
+    custom_parameters: Mapping[str, Any]
+    bound_credentials: Mapping[str, object]
 
 
 __all__ = ["HarnessAdapterContext"]

--- a/harnessiq/cli/adapters/exa_outreach.py
+++ b/harnessiq/cli/adapters/exa_outreach.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, ExaOutreachAgent
 from harnessiq.cli.common import load_factory
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.exa_outreach import EmailTemplate, ExaOutreachMemoryStore
 
 from .base import StoreBackedHarnessCliAdapter
@@ -49,14 +50,16 @@ class ExaOutreachHarnessCliAdapter(StoreBackedHarnessCliAdapter[ExaOutreachMemor
             query_config[key] = value
         store.write_query_config(query_config)
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
-        return {
-            "additional_prompt": store.read_additional_prompt(),
-            "agent_identity": store.read_agent_identity(),
-            "query_config": store.read_query_config(),
-            "run_files": [path.name for path in store.list_run_files()],
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "additional_prompt": store.read_additional_prompt(),
+                "agent_identity": store.read_agent_identity(),
+                "query_config": store.read_query_config(),
+                "run_files": [path.name for path in store.list_run_files()],
+            }
+        )
 
     def run(
         self,
@@ -65,7 +68,7 @@ class ExaOutreachHarnessCliAdapter(StoreBackedHarnessCliAdapter[ExaOutreachMemor
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         search_only = bool(args.search_only)
         exa_credentials = context.bound_credentials.get("exa")
@@ -101,14 +104,16 @@ class ExaOutreachHarnessCliAdapter(StoreBackedHarnessCliAdapter[ExaOutreachMemor
         )
         result = agent.run(max_cycles=args.max_cycles)
         run_id = agent._current_run_id or "unknown"
-        return {
-            "instance_id": optional_string(getattr(agent, "instance_id", None)),
-            "instance_name": optional_string(getattr(agent, "instance_name", None)),
-            "ledger_run_id": optional_string(getattr(agent, "last_run_id", None)),
-            "result": result_payload(result),
-            "run_id": str(run_id),
-            "state": self.show(context),
-        }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            state=self.show(context),
+            extra={
+                "instance_id": optional_string(getattr(agent, "instance_id", None)),
+                "instance_name": optional_string(getattr(agent, "instance_name", None)),
+                "ledger_run_id": optional_string(getattr(agent, "last_run_id", None)),
+                "run_id": str(run_id),
+            },
+        )
 
 
 __all__ = ["ExaOutreachHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/instagram.py
+++ b/harnessiq/cli/adapters/instagram.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, InstagramKeywordDiscoveryAgent
 from harnessiq.cli.common import load_factory
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.instagram import InstagramMemoryStore, resolve_instagram_icp_profiles
 
 from .base import StoreBackedHarnessCliAdapter
@@ -64,25 +65,27 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
     def write_custom_parameters(self, store: InstagramMemoryStore, context: HarnessAdapterContext) -> None:
         store.write_custom_parameters(dict(context.profile.custom_parameters))
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
         search_history = store.read_search_history()
         lead_database = store.read_lead_database()
         custom_parameters = store.read_custom_parameters()
         run_state = store.read_run_state().as_dict() if store.run_state_path.exists() else None
-        return {
-            "additional_prompt": store.read_additional_prompt(),
-            "agent_identity": store.read_agent_identity(),
-            "custom_parameters": custom_parameters,
-            "email_count": len(lead_database.emails),
-            "icp_profiles": resolve_instagram_icp_profiles(store.read_icp_profiles(), custom_parameters),
-            "lead_count": len(lead_database.leads),
-            "recent_searches": [record.as_dict() for record in search_history[-5:]],
-            "recent_searches_by_icp": store.read_recent_searches_by_icp(5),
-            "run_state": run_state,
-            "runtime_parameters": store.read_runtime_parameters(),
-            "search_count": len(search_history),
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "additional_prompt": store.read_additional_prompt(),
+                "agent_identity": store.read_agent_identity(),
+                "custom_parameters": custom_parameters,
+                "email_count": len(lead_database.emails),
+                "icp_profiles": resolve_instagram_icp_profiles(store.read_icp_profiles(), custom_parameters),
+                "lead_count": len(lead_database.leads),
+                "recent_searches": [record.as_dict() for record in search_history[-5:]],
+                "recent_searches_by_icp": store.read_recent_searches_by_icp(5),
+                "run_state": run_state,
+                "runtime_parameters": store.read_runtime_parameters(),
+                "search_count": len(search_history),
+            }
+        )
 
     def run(
         self,
@@ -91,7 +94,7 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         set_env_path_if_missing("HARNESSIQ_INSTAGRAM_SESSION_DIR", store.memory_path / "browser-data")
         search_backend = load_factory(args.search_backend_factory)()
@@ -108,10 +111,10 @@ class InstagramHarnessCliAdapter(StoreBackedHarnessCliAdapter[InstagramMemorySto
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        return {
-            "email_count": len(agent.get_emails()),
-            "result": result_payload(result),
-        }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            extra={"email_count": len(agent.get_emails())},
+        )
 
 
 def _resolve_icp_input(inline_values: list[str], file_value: str | None) -> list[str] | None:

--- a/harnessiq/cli/adapters/knowt.py
+++ b/harnessiq/cli/adapters/knowt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, KnowtAgent
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.knowt import KnowtMemoryStore
 
 from .base import StoreBackedHarnessCliAdapter
@@ -17,15 +18,17 @@ class KnowtHarnessCliAdapter(StoreBackedHarnessCliAdapter[KnowtMemoryStore]):
 
     store_loader = staticmethod(load_knowt_store)
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
         creation_log = store.read_creation_log()
-        return {
-            "avatar_description": store.read_avatar_description(),
-            "creation_log_count": len(creation_log),
-            "recent_creation_log": [entry.as_dict() for entry in creation_log[-5:]],
-            "script": store.read_script(),
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "avatar_description": store.read_avatar_description(),
+                "creation_log_count": len(creation_log),
+                "recent_creation_log": [entry.as_dict() for entry in creation_log[-5:]],
+                "script": store.read_script(),
+            }
+        )
 
     def run(
         self,
@@ -34,7 +37,7 @@ class KnowtHarnessCliAdapter(StoreBackedHarnessCliAdapter[KnowtMemoryStore]):
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         self.load_store(context)
         agent = KnowtAgent(
             model=model,
@@ -45,10 +48,10 @@ class KnowtHarnessCliAdapter(StoreBackedHarnessCliAdapter[KnowtMemoryStore]):
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        return {
-            "result": result_payload(result),
-            "state": self.show(context),
-        }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            state=self.show(context),
+        )
 
 
 __all__ = ["KnowtHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/leads.py
+++ b/harnessiq/cli/adapters/leads.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, LeadsAgent
 from harnessiq.cli.common import load_factory
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.leads import (
     LeadsMemoryStore,
     RUNTIME_PARAMETERS_FILENAME as LEADS_RUNTIME_PARAMETERS_FILENAME,
@@ -64,14 +65,16 @@ class LeadsHarnessCliAdapter(StoreBackedHarnessCliAdapter[LeadsMemoryStore]):
         runtime_parameters.update(read_json_object(store.memory_path / LEADS_RUNTIME_PARAMETERS_FILENAME))
         return runtime_parameters
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
-        return {
-            "icp_states": [state.as_dict() for state in store.list_icp_states()],
-            "run_config": store.read_run_config().as_dict() if store.run_config_path.exists() else None,
-            "run_state": store.read_run_state().as_dict() if store.run_state_path.exists() else None,
-            "runtime_parameters": read_json_object(store.memory_path / LEADS_RUNTIME_PARAMETERS_FILENAME),
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "icp_states": [state.as_dict() for state in store.list_icp_states()],
+                "run_config": store.read_run_config().as_dict() if store.run_config_path.exists() else None,
+                "run_state": store.read_run_state().as_dict() if store.run_state_path.exists() else None,
+                "runtime_parameters": read_json_object(store.memory_path / LEADS_RUNTIME_PARAMETERS_FILENAME),
+            }
+        )
 
     def run(
         self,
@@ -80,7 +83,7 @@ class LeadsHarnessCliAdapter(StoreBackedHarnessCliAdapter[LeadsMemoryStore]):
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         if not store.run_config_path.exists():
             raise ValueError(
@@ -121,10 +124,10 @@ class LeadsHarnessCliAdapter(StoreBackedHarnessCliAdapter[LeadsMemoryStore]):
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        return {
-            "result": result_payload(result),
-            "run_state": store.read_run_state().as_dict() if store.run_state_path.exists() else None,
-        }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            extra={"run_state": store.read_run_state().as_dict() if store.run_state_path.exists() else None},
+        )
 
 
 __all__ = ["LeadsHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/linkedin.py
+++ b/harnessiq/cli/adapters/linkedin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, LinkedInJobApplierAgent
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.linkedin import LinkedInMemoryStore
 
 from .base import StoreBackedHarnessCliAdapter
@@ -51,9 +52,10 @@ class LinkedInHarnessCliAdapter(StoreBackedHarnessCliAdapter[LinkedInMemoryStore
     def write_custom_parameters(self, store: LinkedInMemoryStore, context: HarnessAdapterContext) -> None:
         store.write_custom_parameters(context.profile.custom_parameters)
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
-        return {
+        return HarnessStatePayloadDTO(
+            {
             "additional_prompt": store.read_additional_prompt(),
             "agent_identity": store.read_agent_identity(),
             "custom_parameters": store.read_custom_parameters(),
@@ -61,7 +63,8 @@ class LinkedInHarnessCliAdapter(StoreBackedHarnessCliAdapter[LinkedInMemoryStore
             "managed_files": [record.as_dict() for record in store.read_managed_files()],
             "runtime_parameters": store.read_runtime_parameters(),
             "user_profile": store.read_user_profile(),
-        }
+            }
+        )
 
     def run(
         self,
@@ -70,7 +73,7 @@ class LinkedInHarnessCliAdapter(StoreBackedHarnessCliAdapter[LinkedInMemoryStore
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         set_env_path_if_missing(
             "HARNESSIQ_BROWSER_SESSION_DIR",
@@ -86,13 +89,15 @@ class LinkedInHarnessCliAdapter(StoreBackedHarnessCliAdapter[LinkedInMemoryStore
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        return {
-            "applied_jobs_file": str(store.applied_jobs_path.resolve()),
-            "instance_id": optional_string(getattr(agent, "instance_id", None)),
-            "instance_name": optional_string(getattr(agent, "instance_name", None)),
-            "ledger_run_id": agent.last_run_id,
-            "result": result_payload(result),
-        }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            extra={
+                "applied_jobs_file": str(store.applied_jobs_path.resolve()),
+                "instance_id": optional_string(getattr(agent, "instance_id", None)),
+                "instance_name": optional_string(getattr(agent, "instance_name", None)),
+                "ledger_run_id": agent.last_run_id,
+            },
+        )
 
 
 __all__ = ["LinkedInHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/prospecting.py
+++ b/harnessiq/cli/adapters/prospecting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, GoogleMapsProspectingAgent
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.prospecting import ProspectingMemoryStore
 
 from .base import StoreBackedHarnessCliAdapter
@@ -56,20 +57,22 @@ class ProspectingHarnessCliAdapter(StoreBackedHarnessCliAdapter[ProspectingMemor
     def write_custom_parameters(self, store: ProspectingMemoryStore, context: HarnessAdapterContext) -> None:
         store.write_custom_parameters(context.profile.custom_parameters)
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
         state = store.read_state()
         qualified_leads = store.read_qualified_leads()
-        return {
-            "additional_prompt": store.read_additional_prompt(),
-            "agent_identity": store.read_agent_identity(),
-            "company_description": store.read_company_description(),
-            "custom_parameters": store.read_custom_parameters(),
-            "qualified_lead_count": len(qualified_leads),
-            "recent_qualified_leads": [record.as_dict() for record in qualified_leads[-5:]],
-            "run_state": state.as_dict(),
-            "runtime_parameters": store.read_runtime_parameters(),
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "additional_prompt": store.read_additional_prompt(),
+                "agent_identity": store.read_agent_identity(),
+                "company_description": store.read_company_description(),
+                "custom_parameters": store.read_custom_parameters(),
+                "qualified_lead_count": len(qualified_leads),
+                "recent_qualified_leads": [record.as_dict() for record in qualified_leads[-5:]],
+                "run_state": state.as_dict(),
+                "runtime_parameters": store.read_runtime_parameters(),
+            }
+        )
 
     def run(
         self,
@@ -78,7 +81,7 @@ class ProspectingHarnessCliAdapter(StoreBackedHarnessCliAdapter[ProspectingMemor
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         set_env_path_if_missing("HARNESSIQ_PROSPECTING_SESSION_DIR", store.browser_data_dir)
         browser_tools = load_optional_iterable_factory(args.browser_tools_factory)
@@ -91,14 +94,11 @@ class ProspectingHarnessCliAdapter(StoreBackedHarnessCliAdapter[ProspectingMemor
             runtime_config=runtime_config,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        payload = self.show(context)
-        payload.update(
-            {
-                "ledger_run_id": agent.last_run_id,
-                "result": result_payload(result),
-            }
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            state=self.show(context),
+            extra={"ledger_run_id": agent.last_run_id},
         )
-        return payload
 
 
 __all__ = ["ProspectingHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/research_sweep.py
+++ b/harnessiq/cli/adapters/research_sweep.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from harnessiq.agents import AgentModel, AgentRuntimeConfig, ResearchSweepAgent
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessStatePayloadDTO
 from harnessiq.shared.research_sweep import ResearchSweepMemoryStore, validate_query_for_run
 
 from .base import StoreBackedHarnessCliAdapter
@@ -46,17 +47,19 @@ class ResearchSweepHarnessCliAdapter(StoreBackedHarnessCliAdapter[ResearchSweepM
             store.write_query(str(payload["query"]))
         store.write_custom_parameters(payload)
 
-    def show(self, context: HarnessAdapterContext) -> dict[str, object]:
+    def show(self, context: HarnessAdapterContext) -> HarnessStatePayloadDTO:
         store = self.load_store(context)
-        return {
-            "additional_prompt": store.read_additional_prompt(),
-            "custom_parameters": store.read_custom_parameters(),
-            "final_report": store.read_final_report(),
-            "query": store.read_query(),
-            "research_memory": store.read_research_memory(),
-            "research_memory_summary": store.read_research_memory_summary(),
-            "runtime_parameters": store.read_runtime_parameters(),
-        }
+        return HarnessStatePayloadDTO(
+            {
+                "additional_prompt": store.read_additional_prompt(),
+                "custom_parameters": store.read_custom_parameters(),
+                "final_report": store.read_final_report(),
+                "query": store.read_query(),
+                "research_memory": store.read_research_memory(),
+                "research_memory_summary": store.read_research_memory_summary(),
+                "runtime_parameters": store.read_runtime_parameters(),
+            }
+        )
 
     def run(
         self,
@@ -65,7 +68,7 @@ class ResearchSweepHarnessCliAdapter(StoreBackedHarnessCliAdapter[ResearchSweepM
         context: HarnessAdapterContext,
         model: AgentModel,
         runtime_config: AgentRuntimeConfig,
-    ) -> dict[str, object]:
+    ) -> HarnessAdapterResponseDTO:
         store = self.load_store(context)
         serper_credentials = context.bound_credentials.get("serper")
         if serper_credentials is None:
@@ -84,16 +87,15 @@ class ResearchSweepHarnessCliAdapter(StoreBackedHarnessCliAdapter[ResearchSweepM
             instance_name=context.agent_name,
         )
         result = agent.run(max_cycles=args.max_cycles)
-        payload = self.show(context)
-        payload.update(
-            {
+        return HarnessAdapterResponseDTO(
+            result=result_payload(result),
+            state=self.show(context),
+            extra={
                 "instance_id": getattr(agent, "instance_id", None),
                 "instance_name": getattr(agent, "instance_name", None),
                 "ledger_run_id": agent.last_run_id,
-                "result": result_payload(result),
-            }
+            },
         )
-        return payload
 
 
 __all__ = ["ResearchSweepHarnessCliAdapter"]

--- a/harnessiq/cli/adapters/utils/payloads.py
+++ b/harnessiq/cli/adapters/utils/payloads.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from harnessiq.shared.dtos import HarnessRunResultDTO
+
 
 def read_json_object(path: Path) -> dict[str, Any]:
     """Load a JSON object file into a mutable dict while tolerating missing or blank files."""
@@ -25,14 +27,9 @@ def optional_string(value: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def result_payload(result: Any) -> dict[str, Any]:
+def result_payload(result: Any) -> HarnessRunResultDTO:
     """Project the common run-result fields adapters expose in CLI JSON output."""
-    return {
-        "cycles_completed": getattr(result, "cycles_completed", None),
-        "pause_reason": getattr(result, "pause_reason", None),
-        "resets": getattr(result, "resets", None),
-        "status": getattr(result, "status", None),
-    }
+    return HarnessRunResultDTO.from_result(result)
 
 
 __all__ = [

--- a/harnessiq/cli/builders/lifecycle.py
+++ b/harnessiq/cli/builders/lifecycle.py
@@ -19,6 +19,7 @@ from harnessiq.config import (
     HarnessProfileStore,
     get_provider_credential_spec,
 )
+from harnessiq.shared.dtos import HarnessParameterBundleDTO
 from harnessiq.shared.harness_manifest import HarnessManifest
 
 
@@ -54,13 +55,19 @@ class HarnessCliLifecycleBuilder:
             repo_root=repo_root,
         )
         adapter.prepare(preliminary_context)
-        native_runtime, native_custom = adapter.load_native_parameters(preliminary_context)
+        native_parameters = adapter.load_native_parameters(preliminary_context)
+        if isinstance(native_parameters, tuple):
+            native_runtime, native_custom = native_parameters
+            native_parameters = HarnessParameterBundleDTO(
+                runtime_parameters=dict(native_runtime),
+                custom_parameters=dict(native_custom),
+            )
         profile = self._load_or_seed_profile(
             manifest=manifest,
             agent_name=agent_name,
             memory_path=resolved_memory_path,
-            native_runtime=native_runtime,
-            native_custom=native_custom,
+            native_runtime=dict(native_parameters.runtime_parameters),
+            native_custom=dict(native_parameters.custom_parameters),
         )
         merged_profile = self._merge_profile_parameters(
             profile=profile,

--- a/harnessiq/cli/commands/command_helpers.py
+++ b/harnessiq/cli/commands/command_helpers.py
@@ -27,6 +27,12 @@ from harnessiq.config import (
     HarnessRunSnapshot,
     get_provider_credential_spec,
 )
+from harnessiq.shared.dtos import (
+    HarnessCommandPayloadDTO,
+    HarnessProfileViewDTO,
+    HarnessRunSnapshotDTO,
+    HarnessRunSummaryDTO,
+)
 from harnessiq.shared.harness_manifest import HarnessManifest
 from harnessiq.shared.harness_manifests import get_harness_manifest, list_harness_manifests
 
@@ -401,29 +407,34 @@ def _build_adapter(manifest: HarnessManifest):
     return adapter_factory()
 
 
-def _base_payload(context: HarnessAdapterContext) -> dict[str, Any]:
+def _base_payload(context: HarnessAdapterContext) -> HarnessCommandPayloadDTO:
     binding_name = _binding_name(context.manifest, context.agent_name)
-    return {
-        "agent": context.agent_name,
-        "bound_credential_families": sorted(context.bound_credentials),
-        "credential_binding_name": binding_name,
-        "harness": context.manifest.manifest_id,
-        "memory_path": str(context.memory_path.resolve()),
-        "profile": {
-            "config_path": str((context.memory_path / ".harnessiq-profile.json").resolve()),
-            "custom_parameters": dict(context.profile.custom_parameters),
-            "effective_custom_parameters": dict(context.custom_parameters),
-            "effective_runtime_parameters": dict(context.runtime_parameters),
-            "last_run": (
-                context.profile.last_run.as_dict()
+    return HarnessCommandPayloadDTO(
+        agent=context.agent_name,
+        bound_credential_families=tuple(sorted(context.bound_credentials)),
+        credential_binding_name=binding_name,
+        harness=context.manifest.manifest_id,
+        memory_path=str(context.memory_path.resolve()),
+        profile=HarnessProfileViewDTO(
+            config_path=str((context.memory_path / ".harnessiq-profile.json").resolve()),
+            runtime_parameters=dict(context.profile.runtime_parameters),
+            custom_parameters=dict(context.profile.custom_parameters),
+            effective_runtime_parameters=dict(context.runtime_parameters),
+            effective_custom_parameters=dict(context.custom_parameters),
+            last_run=(
+                HarnessRunSnapshotDTO.from_dict(context.profile.last_run.as_dict())
                 if context.profile.last_run is not None
                 else None
             ),
-            "run_count": len(context.profile.run_history),
-            "run_history": [snapshot.summary for snapshot in context.profile.run_history],
-            "runtime_parameters": dict(context.profile.runtime_parameters),
-        },
-    }
+            run_history=tuple(
+                HarnessRunSummaryDTO(
+                    recorded_at=snapshot.recorded_at,
+                    run_number=snapshot.run_number,
+                )
+                for snapshot in context.profile.run_history
+            ),
+        ),
+    )
 
 
 def _render_parameter_spec(spec) -> dict[str, Any]:

--- a/harnessiq/cli/commands/platform_commands.py
+++ b/harnessiq/cli/commands/platform_commands.py
@@ -228,10 +228,7 @@ def _handle_prepare(args: argparse.Namespace) -> int:
         incoming_custom=collect_manifest_parameter_values(args, manifest=manifest, scope="custom"),
         persist_profile=True,
     )
-    payload = _base_payload(context)
-    payload["state"] = adapter.show(context)
-    payload["status"] = "prepared"
-    emit_json(payload)
+    emit_json(_base_payload(context).with_state(adapter.show(context)).with_status("prepared").to_dict())
     return 0
 
 
@@ -248,9 +245,7 @@ def _handle_show(args: argparse.Namespace) -> int:
         incoming_custom={},
         persist_profile=False,
     )
-    payload = _base_payload(context)
-    payload["state"] = adapter.show(context)
-    emit_json(payload)
+    emit_json(_base_payload(context).with_state(adapter.show(context)).to_dict())
     return 0
 
 

--- a/harnessiq/cli/runners/lifecycle.py
+++ b/harnessiq/cli/runners/lifecycle.py
@@ -11,6 +11,7 @@ from harnessiq.cli._langsmith import seed_cli_environment
 from harnessiq.cli.adapters.context import HarnessAdapterContext
 from harnessiq.cli.common import emit_json, parse_allowed_tool_values, resolve_agent_model
 from harnessiq.config import HarnessProfile, HarnessRunSnapshot
+from harnessiq.shared.dtos import HarnessAdapterResponseDTO, HarnessCommandPayloadDTO, HarnessResumePayloadDTO
 from harnessiq.shared.hooks import DEFAULT_APPROVAL_POLICY
 from harnessiq.utils import ConnectionsConfigStore, build_output_sinks
 
@@ -175,7 +176,7 @@ class HarnessCliLifecycleRunner:
         args: argparse.Namespace,
         context: HarnessAdapterContext,
         run_request: ResolvedRunRequest,
-        base_payload: dict[str, Any],
+        base_payload: HarnessCommandPayloadDTO,
         source_snapshot: HarnessRunSnapshot | None = None,
     ) -> int:
         seed_cli_environment(context.repo_root)
@@ -189,9 +190,9 @@ class HarnessCliLifecycleRunner:
             approval_policy=getattr(args, "approval_policy", None),
             allowed_tools=getattr(args, "allowed_tools", ()),
         )
-        payload = dict(base_payload)
-        payload["resume"] = self._resume_payload(run_request=run_request, source_snapshot=source_snapshot)
-        payload.update(
+        payload = base_payload.with_resume(
+            self._resume_payload(run_request=run_request, source_snapshot=source_snapshot)
+        ).merge_response(
             adapter.run(
                 args=args,
                 context=context,
@@ -199,7 +200,7 @@ class HarnessCliLifecycleRunner:
                 runtime_config=runtime_config,
             )
         )
-        emit_json(payload)
+        emit_json(payload.to_dict())
         return 0
 
     def build_runtime_config(
@@ -221,22 +222,17 @@ class HarnessCliLifecycleRunner:
         *,
         run_request: ResolvedRunRequest,
         source_snapshot: HarnessRunSnapshot | None,
-    ) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "adapter_arguments": dict(run_request.adapter_arguments),
-            "max_cycles": run_request.max_cycles,
-            "sink_specs": list(run_request.sink_specs),
-        }
-        if run_request.model_factory is not None:
-            payload["model_factory"] = run_request.model_factory
-        if run_request.model is not None:
-            payload["model"] = run_request.model
-        if run_request.model_profile is not None:
-            payload["profile"] = run_request.model_profile
-        if source_snapshot is not None:
-            payload["source_recorded_at"] = source_snapshot.recorded_at
-            payload["source_run_number"] = source_snapshot.run_number
-        return payload
+    ) -> HarnessResumePayloadDTO:
+        return HarnessResumePayloadDTO(
+            adapter_arguments=dict(run_request.adapter_arguments),
+            max_cycles=run_request.max_cycles,
+            sink_specs=tuple(run_request.sink_specs),
+            model_factory=run_request.model_factory,
+            model=run_request.model,
+            model_profile=run_request.model_profile,
+            source_recorded_at=(source_snapshot.recorded_at if source_snapshot is not None else None),
+            source_run_number=(source_snapshot.run_number if source_snapshot is not None else None),
+        )
 
     def _collect_model_selection(
         self,

--- a/harnessiq/config/harness_profiles.py
+++ b/harnessiq/config/harness_profiles.py
@@ -8,6 +8,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
+from harnessiq.shared.dtos import (
+    HarnessProfileDTO,
+    HarnessProfileIndexDTO,
+    HarnessProfileIndexRecordDTO,
+    HarnessRunSnapshotDTO,
+)
 from harnessiq.utils.path_serialization import deserialize_repo_path, serialize_repo_path
 
 DEFAULT_HARNESS_PROFILE_FILENAME = ".harnessiq-profile.json"
@@ -65,23 +71,21 @@ class HarnessRunSnapshot:
             raise ValueError("run_number must be greater than or equal to 1 when present.")
 
     def as_dict(self) -> dict[str, Any]:
-        payload = {
-            "adapter_arguments": dict(self.adapter_arguments or {}),
-            "custom_parameters": dict(self.custom_parameters or {}),
-            "max_cycles": self.max_cycles,
-            "recorded_at": self.recorded_at,
-            "runtime_parameters": dict(self.runtime_parameters or {}),
-            "sink_specs": list(self.sink_specs),
-        }
-        if self.model_factory is not None:
-            payload["model_factory"] = self.model_factory
-        if self.model is not None:
-            payload["model"] = self.model
-        if self.model_profile is not None:
-            payload["model_profile"] = self.model_profile
-        if self.run_number is not None:
-            payload["run_number"] = self.run_number
-        return payload
+        return self.to_dto().to_dict()
+
+    def to_dto(self) -> HarnessRunSnapshotDTO:
+        return HarnessRunSnapshotDTO(
+            model_factory=self.model_factory,
+            model=self.model,
+            model_profile=self.model_profile,
+            sink_specs=self.sink_specs,
+            max_cycles=self.max_cycles,
+            adapter_arguments=dict(self.adapter_arguments or {}),
+            runtime_parameters=dict(self.runtime_parameters or {}),
+            custom_parameters=dict(self.custom_parameters or {}),
+            recorded_at=self.recorded_at,
+            run_number=self.run_number,
+        )
 
     def with_run_number(self, run_number: int) -> "HarnessRunSnapshot":
         return HarnessRunSnapshot(
@@ -106,41 +110,21 @@ class HarnessRunSnapshot:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessRunSnapshot":
-        sink_specs = payload.get("sink_specs", ())
-        adapter_arguments = payload.get("adapter_arguments", {})
-        model_factory = _normalize_optional_string(payload.get("model_factory"))
-        model = _normalize_optional_string(payload.get("model"))
-        model_profile = _normalize_optional_string(payload.get("model_profile"))
-        runtime_parameters = payload.get("runtime_parameters", {})
-        custom_parameters = payload.get("custom_parameters", {})
-        if not isinstance(sink_specs, (list, tuple)):
-            raise ValueError("Harness run snapshot 'sink_specs' must be a JSON array.")
-        if not isinstance(adapter_arguments, dict):
-            raise ValueError("Harness run snapshot 'adapter_arguments' must be a JSON object.")
-        if not isinstance(runtime_parameters, dict):
-            raise ValueError("Harness run snapshot 'runtime_parameters' must be a JSON object.")
-        if not isinstance(custom_parameters, dict):
-            raise ValueError("Harness run snapshot 'custom_parameters' must be a JSON object.")
-        max_cycles = payload.get("max_cycles")
-        if max_cycles is not None and not isinstance(max_cycles, int):
-            raise ValueError("Harness run snapshot 'max_cycles' must be an integer or null.")
-        recorded_at = payload.get("recorded_at")
-        if recorded_at is not None and not isinstance(recorded_at, str):
-            raise ValueError("Harness run snapshot 'recorded_at' must be a string when present.")
-        run_number = payload.get("run_number")
-        if run_number is not None and not isinstance(run_number, int):
-            raise ValueError("Harness run snapshot 'run_number' must be an integer when present.")
+        return cls.from_dto(HarnessRunSnapshotDTO.from_dict(payload))
+
+    @classmethod
+    def from_dto(cls, payload: HarnessRunSnapshotDTO) -> "HarnessRunSnapshot":
         return cls(
-            model_factory=model_factory,
-            model=model,
-            model_profile=model_profile,
-            sink_specs=tuple(str(spec) for spec in sink_specs),
-            max_cycles=max_cycles,
-            adapter_arguments=dict(adapter_arguments),
-            runtime_parameters=dict(runtime_parameters),
-            custom_parameters=dict(custom_parameters),
-            recorded_at=recorded_at,
-            run_number=run_number,
+            model_factory=payload.model_factory,
+            model=payload.model,
+            model_profile=payload.model_profile,
+            sink_specs=payload.sink_specs,
+            max_cycles=payload.max_cycles,
+            adapter_arguments=dict(payload.adapter_arguments),
+            runtime_parameters=dict(payload.runtime_parameters),
+            custom_parameters=dict(payload.custom_parameters),
+            recorded_at=payload.recorded_at,
+            run_number=payload.run_number,
         )
 
 
@@ -201,36 +185,29 @@ class HarnessProfile:
         )
 
     def as_dict(self) -> dict[str, Any]:
-        payload = {
-            "agent_name": self.agent_name,
-            "custom_parameters": dict(self.custom_parameters or {}),
-            "manifest_id": self.manifest_id,
-            "runtime_parameters": dict(self.runtime_parameters or {}),
-        }
-        if self.last_run is not None:
-            payload["last_run"] = self.last_run.as_dict()
-        if self.run_history:
-            payload["run_history"] = [snapshot.as_dict() for snapshot in self.run_history]
-        return payload
+        return self.to_dto().to_dict()
+
+    def to_dto(self) -> HarnessProfileDTO:
+        return HarnessProfileDTO(
+            manifest_id=self.manifest_id,
+            agent_name=self.agent_name,
+            runtime_parameters=dict(self.runtime_parameters or {}),
+            custom_parameters=dict(self.custom_parameters or {}),
+            last_run=(self.last_run.to_dto() if self.last_run is not None else None),
+            run_history=tuple(snapshot.to_dto() for snapshot in self.run_history),
+        )
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessProfile":
         runtime_parameters = payload.get("runtime_parameters", {})
         custom_parameters = payload.get("custom_parameters", {})
-        run_history_payload = payload.get("run_history", [])
-        if not isinstance(runtime_parameters, dict):
-            raise ValueError("Harness profile 'runtime_parameters' must be a JSON object.")
-        if not isinstance(custom_parameters, dict):
-            raise ValueError("Harness profile 'custom_parameters' must be a JSON object.")
-        if not isinstance(run_history_payload, list):
-            raise ValueError("Harness profile 'run_history' must be a JSON array when present.")
         last_run_payload = payload.get("last_run")
-        if last_run_payload is not None and not isinstance(last_run_payload, dict):
-            raise ValueError("Harness profile 'last_run' must be a JSON object when present.")
+        parsed = HarnessProfileDTO.from_dict(payload)
         last_run = None
-        if last_run_payload is not None:
-            last_run = HarnessRunSnapshot.from_dict(last_run_payload)
-            if "runtime_parameters" not in last_run_payload:
+        if parsed.last_run is not None:
+            last_run_payload = payload.get("last_run", {})
+            last_run = HarnessRunSnapshot.from_dto(parsed.last_run)
+            if isinstance(last_run_payload, Mapping) and "runtime_parameters" not in last_run_payload:
                 last_run = HarnessRunSnapshot(
                     model_factory=last_run.model_factory,
                     model=last_run.model,
@@ -243,7 +220,7 @@ class HarnessProfile:
                     recorded_at=last_run.recorded_at,
                     run_number=last_run.run_number,
                 )
-            if "custom_parameters" not in last_run_payload:
+            if isinstance(last_run_payload, Mapping) and "custom_parameters" not in last_run_payload:
                 last_run = HarnessRunSnapshot(
                     model_factory=last_run.model_factory,
                     model=last_run.model,
@@ -257,12 +234,12 @@ class HarnessProfile:
                     run_number=last_run.run_number,
                 )
         return cls(
-            manifest_id=str(payload["manifest_id"]),
-            agent_name=str(payload["agent_name"]),
-            runtime_parameters=dict(runtime_parameters),
-            custom_parameters=dict(custom_parameters),
+            manifest_id=parsed.manifest_id,
+            agent_name=parsed.agent_name,
+            runtime_parameters=dict(parsed.runtime_parameters),
+            custom_parameters=dict(parsed.custom_parameters),
             last_run=last_run,
-            run_history=tuple(HarnessRunSnapshot.from_dict(item) for item in run_history_payload),
+            run_history=tuple(HarnessRunSnapshot.from_dto(item) for item in parsed.run_history),
         )
 
 
@@ -299,20 +276,21 @@ class HarnessProfileIndexRecord:
         )
 
     def to_dict(self, *, repo_root: Path) -> dict[str, Any]:
-        return {
-            "agent_name": self.agent_name,
-            "manifest_id": self.manifest_id,
-            "memory_path": serialize_repo_path(self.memory_path, repo_root=repo_root),
-            "updated_at": self.updated_at,
-        }
+        return HarnessProfileIndexRecordDTO(
+            manifest_id=self.manifest_id,
+            agent_name=self.agent_name,
+            memory_path=serialize_repo_path(self.memory_path, repo_root=repo_root),
+            updated_at=self.updated_at,
+        ).to_dict()
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any], *, repo_root: Path) -> "HarnessProfileIndexRecord":
+        parsed = HarnessProfileIndexRecordDTO.from_dict(payload)
         return cls(
-            manifest_id=str(payload["manifest_id"]),
-            agent_name=str(payload["agent_name"]),
-            memory_path=deserialize_repo_path(str(payload["memory_path"]), repo_root=repo_root),
-            updated_at=str(payload["updated_at"]),
+            manifest_id=parsed.manifest_id,
+            agent_name=parsed.agent_name,
+            memory_path=deserialize_repo_path(parsed.memory_path, repo_root=repo_root),
+            updated_at=parsed.updated_at,
         )
 
 
@@ -362,19 +340,22 @@ class HarnessProfileIndex:
         return HarnessProfileIndex(records=tuple(indexed.values()))
 
     def to_dict(self, *, repo_root: Path) -> dict[str, Any]:
-        return {"records": [record.to_dict(repo_root=repo_root) for record in self.records]}
+        return HarnessProfileIndexDTO(
+            records=tuple(
+                HarnessProfileIndexRecordDTO(
+                    manifest_id=record.manifest_id,
+                    agent_name=record.agent_name,
+                    memory_path=serialize_repo_path(record.memory_path, repo_root=repo_root),
+                    updated_at=record.updated_at,
+                )
+                for record in self.records
+            )
+        ).to_dict()
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any], *, repo_root: Path) -> "HarnessProfileIndex":
-        raw_records = payload.get("records", [])
-        if not isinstance(raw_records, list):
-            raise ValueError("Harness profile index payload must define 'records' as a list.")
-        return cls(
-            records=tuple(
-                HarnessProfileIndexRecord.from_dict(item, repo_root=repo_root)
-                for item in raw_records
-            )
-        )
+        parsed = HarnessProfileIndexDTO.from_dict(payload)
+        return cls(records=tuple(HarnessProfileIndexRecord.from_dict(item.to_dict(), repo_root=repo_root) for item in parsed.records))
 
 
 @dataclass(slots=True)

--- a/harnessiq/providers/gcloud/runtime.py
+++ b/harnessiq/providers/gcloud/runtime.py
@@ -110,22 +110,27 @@ def run_runtime(
         )
         runtime_config = build_runtime_config(sink_specs=run_request.sink_specs)
         args = _build_runtime_args(adapter=adapter, run_request=run_request)
-        result_payload = _base_payload(context)
-        result_payload["remote_command"] = list(deploy_spec.remote_command)
-        result_payload["runtime"] = {
-            "memory_uri": ctx.storage.runtime_state_uri(config.memory_path),
-            "synced_from_gcs": synced_from_gcs,
-            "synced_to_gcs": False,
-        }
-        result_payload.update(
-            adapter.run(
-                args=args,
-                context=context,
-                model=model,
-                runtime_config=runtime_config,
+        result_payload = (
+            _base_payload(context)
+            .with_extra(
+                remote_command=list(deploy_spec.remote_command),
+                runtime={
+                    "memory_uri": ctx.storage.runtime_state_uri(config.memory_path),
+                    "synced_from_gcs": synced_from_gcs,
+                    "synced_to_gcs": False,
+                },
             )
+            .merge_response(
+                adapter.run(
+                    args=args,
+                    context=context,
+                    model=model,
+                    runtime_config=runtime_config,
+                )
+            )
+            .with_status("completed")
+            .to_dict()
         )
-        result_payload["status"] = "completed"
     except Exception as exc:  # pragma: no cover - exercised by tests with assertions on side effects
         execution_error = exc
 

--- a/harnessiq/shared/dtos/__init__.py
+++ b/harnessiq/shared/dtos/__init__.py
@@ -17,6 +17,20 @@ from .agents import (
     ResearchSweepAgentInstancePayload,
     StatelessAgentInstancePayload,
 )
+from .cli import (
+    HarnessAdapterResponseDTO,
+    HarnessCommandPayloadDTO,
+    HarnessParameterBundleDTO,
+    HarnessProfileDTO,
+    HarnessProfileIndexDTO,
+    HarnessProfileIndexRecordDTO,
+    HarnessProfileViewDTO,
+    HarnessResumePayloadDTO,
+    HarnessRunResultDTO,
+    HarnessRunSnapshotDTO,
+    HarnessRunSummaryDTO,
+    HarnessStatePayloadDTO,
+)
 from .base import SerializableDTO, coerce_serializable_mapping
 
 __all__ = [
@@ -27,6 +41,18 @@ __all__ = [
     "ExaAgentRequest",
     "InstagramAgentInstancePayload",
     "InstantlyAgentRequest",
+    "HarnessAdapterResponseDTO",
+    "HarnessCommandPayloadDTO",
+    "HarnessParameterBundleDTO",
+    "HarnessProfileDTO",
+    "HarnessProfileIndexDTO",
+    "HarnessProfileIndexRecordDTO",
+    "HarnessProfileViewDTO",
+    "HarnessResumePayloadDTO",
+    "HarnessRunResultDTO",
+    "HarnessRunSnapshotDTO",
+    "HarnessRunSummaryDTO",
+    "HarnessStatePayloadDTO",
     "KnowtAgentInstancePayload",
     "LeadsAgentInstancePayload",
     "LinkedInAgentInstancePayload",

--- a/harnessiq/shared/dtos/cli.py
+++ b/harnessiq/shared/dtos/cli.py
@@ -1,0 +1,437 @@
+"""Shared DTOs for platform CLI and profile persistence boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Mapping
+
+from .base import SerializableDTO, coerce_serializable_mapping
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, SerializableDTO):
+        return value.to_dict()
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessParameterBundleDTO(SerializableDTO):
+    """Explicit runtime/custom parameter bundle passed between CLI layers."""
+
+    runtime_parameters: Mapping[str, Any] = field(default_factory=dict)
+    custom_parameters: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "runtime_parameters": _normalize_value(self.runtime_parameters),
+            "custom_parameters": _normalize_value(self.custom_parameters),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRunSummaryDTO(SerializableDTO):
+    """Summary metadata for one persisted CLI run."""
+
+    recorded_at: str | None = None
+    run_number: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "recorded_at": self.recorded_at,
+            "run_number": self.run_number,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRunSnapshotDTO(SerializableDTO):
+    """Explicit persisted transport for one harness run snapshot."""
+
+    model_factory: str | None = None
+    model: str | None = None
+    model_profile: str | None = None
+    sink_specs: tuple[str, ...] = ()
+    max_cycles: int | None = None
+    adapter_arguments: Mapping[str, Any] = field(default_factory=dict)
+    runtime_parameters: Mapping[str, Any] = field(default_factory=dict)
+    custom_parameters: Mapping[str, Any] = field(default_factory=dict)
+    recorded_at: str | None = None
+    run_number: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "adapter_arguments": _normalize_value(self.adapter_arguments),
+            "custom_parameters": _normalize_value(self.custom_parameters),
+            "max_cycles": self.max_cycles,
+            "recorded_at": self.recorded_at,
+            "runtime_parameters": _normalize_value(self.runtime_parameters),
+            "sink_specs": list(self.sink_specs),
+        }
+        if self.model_factory is not None:
+            payload["model_factory"] = self.model_factory
+        if self.model is not None:
+            payload["model"] = self.model
+        if self.model_profile is not None:
+            payload["model_profile"] = self.model_profile
+        if self.run_number is not None:
+            payload["run_number"] = self.run_number
+        return payload
+
+    @property
+    def summary(self) -> HarnessRunSummaryDTO:
+        return HarnessRunSummaryDTO(
+            recorded_at=self.recorded_at,
+            run_number=self.run_number,
+        )
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessRunSnapshotDTO":
+        sink_specs = payload.get("sink_specs", ())
+        adapter_arguments = payload.get("adapter_arguments", {})
+        runtime_parameters = payload.get("runtime_parameters", {})
+        custom_parameters = payload.get("custom_parameters", {})
+        if not isinstance(sink_specs, (list, tuple)):
+            raise ValueError("Harness run snapshot 'sink_specs' must be a JSON array.")
+        if not isinstance(adapter_arguments, Mapping):
+            raise ValueError("Harness run snapshot 'adapter_arguments' must be a JSON object.")
+        if not isinstance(runtime_parameters, Mapping):
+            raise ValueError("Harness run snapshot 'runtime_parameters' must be a JSON object.")
+        if not isinstance(custom_parameters, Mapping):
+            raise ValueError("Harness run snapshot 'custom_parameters' must be a JSON object.")
+        max_cycles = payload.get("max_cycles")
+        if max_cycles is not None and not isinstance(max_cycles, int):
+            raise ValueError("Harness run snapshot 'max_cycles' must be an integer or null.")
+        recorded_at = payload.get("recorded_at")
+        if recorded_at is not None and not isinstance(recorded_at, str):
+            raise ValueError("Harness run snapshot 'recorded_at' must be a string when present.")
+        run_number = payload.get("run_number")
+        if run_number is not None and not isinstance(run_number, int):
+            raise ValueError("Harness run snapshot 'run_number' must be an integer when present.")
+        return cls(
+            model_factory=_normalize_optional_string(payload.get("model_factory")),
+            model=_normalize_optional_string(payload.get("model")),
+            model_profile=_normalize_optional_string(payload.get("model_profile")),
+            sink_specs=tuple(str(spec) for spec in sink_specs),
+            max_cycles=max_cycles,
+            adapter_arguments=dict(adapter_arguments),
+            runtime_parameters=dict(runtime_parameters),
+            custom_parameters=dict(custom_parameters),
+            recorded_at=recorded_at,
+            run_number=run_number,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProfileDTO(SerializableDTO):
+    """Explicit persisted transport for one harness profile file."""
+
+    manifest_id: str
+    agent_name: str
+    runtime_parameters: Mapping[str, Any] = field(default_factory=dict)
+    custom_parameters: Mapping[str, Any] = field(default_factory=dict)
+    last_run: HarnessRunSnapshotDTO | None = None
+    run_history: tuple[HarnessRunSnapshotDTO, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "agent_name": self.agent_name,
+            "custom_parameters": _normalize_value(self.custom_parameters),
+            "manifest_id": self.manifest_id,
+            "runtime_parameters": _normalize_value(self.runtime_parameters),
+        }
+        if self.last_run is not None:
+            payload["last_run"] = self.last_run.to_dict()
+        if self.run_history:
+            payload["run_history"] = [snapshot.to_dict() for snapshot in self.run_history]
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessProfileDTO":
+        runtime_parameters = payload.get("runtime_parameters", {})
+        custom_parameters = payload.get("custom_parameters", {})
+        run_history_payload = payload.get("run_history", [])
+        if not isinstance(runtime_parameters, Mapping):
+            raise ValueError("Harness profile 'runtime_parameters' must be a JSON object.")
+        if not isinstance(custom_parameters, Mapping):
+            raise ValueError("Harness profile 'custom_parameters' must be a JSON object.")
+        if not isinstance(run_history_payload, list):
+            raise ValueError("Harness profile 'run_history' must be a JSON array when present.")
+        last_run_payload = payload.get("last_run")
+        if last_run_payload is not None and not isinstance(last_run_payload, Mapping):
+            raise ValueError("Harness profile 'last_run' must be a JSON object when present.")
+        return cls(
+            manifest_id=str(payload["manifest_id"]),
+            agent_name=str(payload["agent_name"]),
+            runtime_parameters=dict(runtime_parameters),
+            custom_parameters=dict(custom_parameters),
+            last_run=(HarnessRunSnapshotDTO.from_dict(last_run_payload) if last_run_payload is not None else None),
+            run_history=tuple(HarnessRunSnapshotDTO.from_dict(item) for item in run_history_payload),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProfileIndexRecordDTO(SerializableDTO):
+    """Explicit persisted transport for one repo-level harness profile locator."""
+
+    manifest_id: str
+    agent_name: str
+    memory_path: str
+    updated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_name": self.agent_name,
+            "manifest_id": self.manifest_id,
+            "memory_path": self.memory_path,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessProfileIndexRecordDTO":
+        return cls(
+            manifest_id=str(payload["manifest_id"]),
+            agent_name=str(payload["agent_name"]),
+            memory_path=str(payload["memory_path"]),
+            updated_at=str(payload["updated_at"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProfileIndexDTO(SerializableDTO):
+    """Explicit persisted transport for the repo-level harness profile index."""
+
+    records: tuple[HarnessProfileIndexRecordDTO, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"records": [record.to_dict() for record in self.records]}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HarnessProfileIndexDTO":
+        raw_records = payload.get("records", [])
+        if not isinstance(raw_records, list):
+            raise ValueError("Harness profile index payload must define 'records' as a list.")
+        return cls(records=tuple(HarnessProfileIndexRecordDTO.from_dict(item) for item in raw_records))
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProfileViewDTO(SerializableDTO):
+    """Public CLI profile payload rendered into terminal JSON output."""
+
+    config_path: str
+    runtime_parameters: Mapping[str, Any]
+    custom_parameters: Mapping[str, Any]
+    effective_runtime_parameters: Mapping[str, Any]
+    effective_custom_parameters: Mapping[str, Any]
+    last_run: HarnessRunSnapshotDTO | None = None
+    run_history: tuple[HarnessRunSummaryDTO, ...] = ()
+
+    @property
+    def run_count(self) -> int:
+        return len(self.run_history)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "config_path": self.config_path,
+            "custom_parameters": _normalize_value(self.custom_parameters),
+            "effective_custom_parameters": _normalize_value(self.effective_custom_parameters),
+            "effective_runtime_parameters": _normalize_value(self.effective_runtime_parameters),
+            "last_run": (self.last_run.to_dict() if self.last_run is not None else None),
+            "run_count": self.run_count,
+            "run_history": [entry.to_dict() for entry in self.run_history],
+            "runtime_parameters": _normalize_value(self.runtime_parameters),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessStatePayloadDTO(SerializableDTO):
+    """Generic DTO wrapper for adapter `show()` state payloads."""
+
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return _normalize_value(self.payload)
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRunResultDTO(SerializableDTO):
+    """Shared CLI DTO for the common `agent.run()` result envelope."""
+
+    cycles_completed: int | None = None
+    pause_reason: str | None = None
+    resets: int | None = None
+    status: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cycles_completed": self.cycles_completed,
+            "pause_reason": self.pause_reason,
+            "resets": self.resets,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_result(cls, result: Any) -> "HarnessRunResultDTO":
+        return cls(
+            cycles_completed=getattr(result, "cycles_completed", None),
+            pause_reason=getattr(result, "pause_reason", None),
+            resets=getattr(result, "resets", None),
+            status=getattr(result, "status", None),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessResumePayloadDTO(SerializableDTO):
+    """CLI DTO for the resolved resume request payload emitted to stdout."""
+
+    adapter_arguments: Mapping[str, Any] = field(default_factory=dict)
+    sink_specs: tuple[str, ...] = ()
+    max_cycles: int | None = None
+    model_factory: str | None = None
+    model: str | None = None
+    model_profile: str | None = None
+    source_recorded_at: str | None = None
+    source_run_number: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "adapter_arguments": _normalize_value(self.adapter_arguments),
+            "max_cycles": self.max_cycles,
+            "sink_specs": list(self.sink_specs),
+        }
+        if self.model_factory is not None:
+            payload["model_factory"] = self.model_factory
+        if self.model is not None:
+            payload["model"] = self.model
+        if self.model_profile is not None:
+            payload["profile"] = self.model_profile
+        if self.source_recorded_at is not None:
+            payload["source_recorded_at"] = self.source_recorded_at
+        if self.source_run_number is not None:
+            payload["source_run_number"] = self.source_run_number
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessAdapterResponseDTO(SerializableDTO):
+    """Explicit DTO returned from platform CLI adapters for `run` responses."""
+
+    result: HarnessRunResultDTO | None = None
+    state: SerializableDTO | Mapping[str, Any] | None = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = _normalize_value(self.extra)
+        if self.result is not None:
+            payload["result"] = self.result.to_dict()
+        if self.state is not None:
+            payload["state"] = _normalize_value(self.state)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessCommandPayloadDTO(SerializableDTO):
+    """DTO for the top-level JSON payload emitted by platform CLI commands."""
+
+    agent: str
+    harness: str
+    memory_path: str
+    credential_binding_name: str
+    bound_credential_families: tuple[str, ...]
+    profile: HarnessProfileViewDTO
+    status: str | None = None
+    state: SerializableDTO | Mapping[str, Any] | None = None
+    resume: HarnessResumePayloadDTO | None = None
+    result: HarnessRunResultDTO | None = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def with_status(self, status: str | None) -> "HarnessCommandPayloadDTO":
+        return replace(self, status=status)
+
+    def with_state(self, state: SerializableDTO | Mapping[str, Any] | None) -> "HarnessCommandPayloadDTO":
+        return replace(self, state=state)
+
+    def with_resume(self, resume: HarnessResumePayloadDTO | None) -> "HarnessCommandPayloadDTO":
+        return replace(self, resume=resume)
+
+    def with_extra(self, **payload: Any) -> "HarnessCommandPayloadDTO":
+        merged = {**coerce_serializable_mapping(self.extra), **payload}
+        return replace(self, extra=merged)
+
+    def merge_response(
+        self,
+        response: HarnessAdapterResponseDTO | Mapping[str, Any],
+    ) -> "HarnessCommandPayloadDTO":
+        if not isinstance(response, HarnessAdapterResponseDTO):
+            coerced = coerce_serializable_mapping(response)
+            result_payload = coerced.pop("result", None)
+            state_payload = coerced.pop("state", None)
+            response = HarnessAdapterResponseDTO(
+                result=(
+                    HarnessRunResultDTO(
+                        cycles_completed=result_payload.get("cycles_completed"),
+                        pause_reason=result_payload.get("pause_reason"),
+                        resets=result_payload.get("resets"),
+                        status=result_payload.get("status"),
+                    )
+                    if isinstance(result_payload, Mapping)
+                    else None
+                ),
+                state=(state_payload if isinstance(state_payload, Mapping) else None),
+                extra=coerced,
+            )
+        merged_extra = {**coerce_serializable_mapping(self.extra), **coerce_serializable_mapping(response.extra)}
+        return replace(
+            self,
+            result=response.result or self.result,
+            state=response.state or self.state,
+            extra=merged_extra,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "agent": self.agent,
+            "bound_credential_families": list(self.bound_credential_families),
+            "credential_binding_name": self.credential_binding_name,
+            "harness": self.harness,
+            "memory_path": self.memory_path,
+            "profile": self.profile.to_dict(),
+        }
+        payload.update(_normalize_value(self.extra))
+        if self.status is not None:
+            payload["status"] = self.status
+        if self.state is not None:
+            payload["state"] = _normalize_value(self.state)
+        if self.resume is not None:
+            payload["resume"] = self.resume.to_dict()
+        if self.result is not None:
+            payload["result"] = self.result.to_dict()
+        return payload
+
+
+def _normalize_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+__all__ = [
+    "HarnessAdapterResponseDTO",
+    "HarnessCommandPayloadDTO",
+    "HarnessParameterBundleDTO",
+    "HarnessProfileDTO",
+    "HarnessProfileIndexDTO",
+    "HarnessProfileIndexRecordDTO",
+    "HarnessProfileViewDTO",
+    "HarnessResumePayloadDTO",
+    "HarnessRunResultDTO",
+    "HarnessRunSnapshotDTO",
+    "HarnessRunSummaryDTO",
+    "HarnessStatePayloadDTO",
+]

--- a/tests/test_cli_runners.py
+++ b/tests/test_cli_runners.py
@@ -18,6 +18,12 @@ from harnessiq.cli.runners import (
     ResolvedRunRequest,
 )
 from harnessiq.config import HarnessProfile, HarnessRunSnapshot
+from harnessiq.shared.dtos import (
+    HarnessAdapterResponseDTO,
+    HarnessCommandPayloadDTO,
+    HarnessProfileViewDTO,
+    HarnessRunResultDTO,
+)
 from harnessiq.shared.harness_manifest import HarnessManifest
 
 
@@ -157,7 +163,7 @@ def test_lifecycle_runner_execute_run_emits_expected_payload(monkeypatch: pytest
             del args, context
             assert model == "resolved-model"
             assert runtime_config == "runtime-config"
-            return {"result": {"status": "completed"}}
+            return HarnessAdapterResponseDTO(result=HarnessRunResultDTO(status="completed"))
 
     class _StubRunner(HarnessCliLifecycleRunner):
         def build_runtime_config(self, *args, **kwargs):  # type: ignore[override]
@@ -192,23 +198,43 @@ def test_lifecycle_runner_execute_run_emits_expected_payload(monkeypatch: pytest
             max_cycles=1,
             adapter_arguments={"search_backend_factory": "factory.path"},
         ),
-        base_payload={"agent": "alpha"},
+        base_payload=HarnessCommandPayloadDTO(
+            agent="alpha",
+            harness="demo",
+            memory_path=str((tmp_path / "memory").resolve()),
+            credential_binding_name="harness::demo::alpha",
+            bound_credential_families=(),
+            profile=HarnessProfileViewDTO(
+                config_path=str((tmp_path / "memory" / ".harnessiq-profile.json").resolve()),
+                runtime_parameters={},
+                custom_parameters={},
+                effective_runtime_parameters={},
+                effective_custom_parameters={},
+            ),
+        ),
         source_snapshot=None,
     )
 
     assert exit_code == 0
-    assert captured == [
-        {
-            "agent": "alpha",
-            "resume": {
-                "adapter_arguments": {"search_backend_factory": "factory.path"},
-                "max_cycles": 1,
-                "model_factory": "tests.test_platform_cli:create_static_model",
-                "sink_specs": [],
-            },
-            "result": {"status": "completed"},
-        }
-    ]
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["agent"] == "alpha"
+    assert payload["harness"] == "demo"
+    assert payload["credential_binding_name"] == "harness::demo::alpha"
+    assert payload["bound_credential_families"] == []
+    assert payload["profile"]["run_count"] == 0
+    assert payload["resume"] == {
+        "adapter_arguments": {"search_backend_factory": "factory.path"},
+        "max_cycles": 1,
+        "model_factory": "tests.test_platform_cli:create_static_model",
+        "sink_specs": [],
+    }
+    assert payload["result"] == {
+        "cycles_completed": None,
+        "pause_reason": None,
+        "resets": None,
+        "status": "completed",
+    }
 
 
 def test_linkedin_runner_run_uses_saved_browser_session_dir(

--- a/tests/test_harness_profiles.py
+++ b/tests/test_harness_profiles.py
@@ -9,6 +9,7 @@ from harnessiq.config import (
     HarnessProfileStore,
     HarnessRunSnapshot,
 )
+from harnessiq.shared.dtos import HarnessProfileDTO, HarnessRunSnapshotDTO
 
 
 def test_harness_profile_from_dict_remains_backward_compatible() -> None:
@@ -78,6 +79,7 @@ def test_harness_run_snapshot_round_trips_model_spec_selection() -> None:
     assert payload["model"] == "grok:grok-4-1-fast-reasoning"
     assert reloaded.model == "grok:grok-4-1-fast-reasoning"
     assert reloaded.model_factory is None
+    assert snapshot.to_dto() == HarnessRunSnapshotDTO.from_dict(payload)
 
 
 def test_harness_profile_from_legacy_last_run_populates_run_history() -> None:
@@ -163,3 +165,27 @@ def test_harness_profile_index_store_round_trips_paths(tmp_path: Path) -> None:
 
     payload = json.loads(index_store.index_path.read_text(encoding="utf-8"))
     assert payload["records"][0]["memory_path"] == "memory/instagram/creator-a"
+
+
+def test_harness_profile_dto_round_trips_transport_payload() -> None:
+    profile = HarnessProfile(
+        manifest_id="instagram",
+        agent_name="creator-a",
+        runtime_parameters={"max_tokens": 4096},
+        custom_parameters={"segment": "fitness"},
+        last_run=HarnessRunSnapshot(
+            model_factory="tests.test_platform_cli:create_static_model",
+            sink_specs=("jsonl:data/runs.jsonl",),
+            max_cycles=12,
+            adapter_arguments={"search_backend_factory": "tests.test_platform_cli:create_special_instagram_search_backend"},
+            runtime_parameters={"max_tokens": 4096},
+            custom_parameters={"segment": "fitness"},
+            recorded_at="2026-03-24T00:00:00Z",
+        ),
+    )
+
+    dto = profile.to_dto()
+    reloaded = HarnessProfile.from_dict(dto.to_dict())
+
+    assert dto == HarnessProfileDTO.from_dict(dto.to_dict())
+    assert reloaded.as_dict() == dto.to_dict()

--- a/tests/test_sdk_package.py
+++ b/tests/test_sdk_package.py
@@ -146,10 +146,12 @@ class HarnessiqPackageTests(unittest.TestCase):
         from harnessiq.providers import ProviderFormatError, ProviderHTTPError
         from harnessiq.providers.arxiv import ArxivConfig
         from harnessiq.providers.arcads import ArcadsOperation
-        from harnessiq.shared.dtos import AgentInstancePayload
+        from harnessiq.shared.dtos import AgentInstancePayload, HarnessCommandPayloadDTO, HarnessRunSnapshotDTO
         from harnessiq.tools import ResendCredentials
 
         self.assertEqual(AgentInstancePayload.__module__, "harnessiq.shared.dtos.agents")
+        self.assertEqual(HarnessCommandPayloadDTO.__module__, "harnessiq.shared.dtos.cli")
+        self.assertEqual(HarnessRunSnapshotDTO.__module__, "harnessiq.shared.dtos.cli")
         self.assertEqual(ApolloAgentRequest.__module__, "harnessiq.shared.dtos.agents")
         self.assertEqual(ApolloAgentConfig.__module__, "harnessiq.shared.apollo_agent")
         self.assertEqual(EmailAgentRequest.__module__, "harnessiq.shared.dtos.agents")


### PR DESCRIPTION
Title: Convert platform CLI and profile storage surfaces to DTO-based contracts

Intent:
Move the platform-first CLI and persisted harness-profile transport off anonymous dictionaries and onto explicit DTOs while keeping final CLI JSON output stable.

Issue URL:
https://github.com/cerredz/HarnessHub/issues/329

Scope:
- Add shared CLI/profile DTOs in `harnessiq.shared.dtos`.
- Convert platform adapter native-parameter, `show()`, and `run()` contracts to DTO-first boundaries.
- Convert command-helper and lifecycle payload assembly to compose explicit DTOs before final JSON emission.
- Make harness profile and run snapshot persistence DTO-aware without changing the stored JSON shape.
- Update the dependent gcloud runtime wrapper because it consumes the shared platform payload helper.

Relevant Files:
- `harnessiq/shared/dtos/cli.py`
- `harnessiq/shared/dtos/__init__.py`
- `harnessiq/cli/adapters/base.py`
- `harnessiq/cli/adapters/context.py`
- `harnessiq/cli/adapters/utils/payloads.py`
- `harnessiq/cli/adapters/linkedin.py`
- `harnessiq/cli/adapters/instagram.py`
- `harnessiq/cli/adapters/knowt.py`
- `harnessiq/cli/adapters/leads.py`
- `harnessiq/cli/adapters/exa_outreach.py`
- `harnessiq/cli/adapters/prospecting.py`
- `harnessiq/cli/adapters/research_sweep.py`
- `harnessiq/cli/builders/lifecycle.py`
- `harnessiq/cli/commands/command_helpers.py`
- `harnessiq/cli/commands/platform_commands.py`
- `harnessiq/cli/runners/lifecycle.py`
- `harnessiq/config/harness_profiles.py`
- `harnessiq/providers/gcloud/runtime.py`
- `tests/test_cli_runners.py`
- `tests/test_harness_profiles.py`
- `tests/test_sdk_package.py`

Approach:
Introduce a focused CLI DTO module for three seams: native parameter transport between adapters and lifecycle builders, top-level CLI response composition, and persisted harness profile/run snapshot JSON transport. The adapters now return DTOs for `show()` and `run()`, the lifecycle/command layers compose those DTOs into the final response envelope, and `HarnessProfile` / `HarnessRunSnapshot` serialize through explicit transport DTOs instead of hand-built dicts. Final stdout stays JSON by converting DTOs only at the terminal emission boundary.

Acceptance Criteria:
- [x] The platform CLI adapter/context/result contracts in scope use explicit DTOs rather than raw dicts.
- [x] Profile and run-snapshot persistence logic is DTO-aware and remains loadable from JSON storage.
- [x] The platform CLI tests continue to pass with stable final JSON output shape.
- [x] No platform command loses existing resume/profile behavior due to the DTO conversion.

Verification:
- `python -m pytest tests/test_harness_profiles.py tests/test_cli_builders.py tests/test_cli_runners.py tests/test_platform_cli.py tests/test_gcloud_runtime.py tests/test_gcloud_manifest_support.py tests/test_sdk_package.py -q`
- `py_compile` across all changed code and test files
- Manual `prepare` / `show` / `run` smoke script for the generic LinkedIn platform CLI path

Quality Artifacts:
- `memory/explicit-dtos-layer-boundaries/tickets/ticket-4-quality.md`
- `memory/explicit-dtos-layer-boundaries/tickets/ticket-4-critique.md`

Closes #329
