### PR TITLE
Add Hunter provider and tool integration

### DIFF
--- a/harnessiq/config/provider_credentials/catalog.py
+++ b/harnessiq/config/provider_credentials/catalog.py
@@ -13,6 +13,7 @@ from harnessiq.shared.credentials import (
     CreatifyCredentials,
     ExaCredentials,
     ExpandiCredentials,
+    HunterCredentials,
     InboxAppCredentials,
     InstantlyCredentials,
     LeadIQCredentials,
@@ -95,6 +96,12 @@ PROVIDER_CREDENTIAL_SPECS = MappingProxyType(
                 ProviderCredentialFieldSpec("api_secret", "Expandi API secret."),
             ),
             builder=build_dataclass_credential_builder(ExpandiCredentials),
+        ),
+        "hunter": ProviderCredentialSpec(
+            family="hunter",
+            description="Hunter.io API credentials.",
+            fields=(ProviderCredentialFieldSpec("api_key", "Hunter API key."),),
+            builder=build_dataclass_credential_builder(HunterCredentials),
         ),
         "google_drive": ProviderCredentialSpec(
             family="google_drive",

--- a/harnessiq/providers/http.py
+++ b/harnessiq/providers/http.py
@@ -129,6 +129,8 @@ def _infer_provider_name(url: str) -> str:
         return "creatify"
     if "arcads" in host:
         return "arcads"
+    if "hunter.io" in host:
+        return "hunter"
     if "instantly" in host:
         return "instantly"
     if "outreach" in host:

--- a/harnessiq/providers/hunter/__init__.py
+++ b/harnessiq/providers/hunter/__init__.py
@@ -1,0 +1,22 @@
+"""Hunter.io provider client and operation metadata."""
+
+from .api import DEFAULT_BASE_URL as HUNTER_BASE_URL
+from .client import HunterClient, HunterCredentials
+from .operations import (
+    HUNTER_REQUEST,
+    HunterOperation,
+    HunterPreparedRequest,
+    build_hunter_operation_catalog,
+    get_hunter_operation,
+)
+
+__all__ = [
+    "HUNTER_REQUEST",
+    "HUNTER_BASE_URL",
+    "HunterClient",
+    "HunterCredentials",
+    "HunterOperation",
+    "HunterPreparedRequest",
+    "build_hunter_operation_catalog",
+    "get_hunter_operation",
+]

--- a/harnessiq/providers/hunter/api.py
+++ b/harnessiq/providers/hunter/api.py
@@ -1,0 +1,42 @@
+"""Hunter.io API endpoint constants and authentication helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from harnessiq.providers.http import join_url
+from harnessiq.shared.providers import HUNTER_DEFAULT_BASE_URL as DEFAULT_BASE_URL
+
+
+def build_headers(
+    *,
+    extra_headers: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build base request headers for Hunter.
+
+    Hunter authentication is injected via the ``api_key`` query parameter, not
+    request headers.
+    """
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return headers
+
+
+def url(
+    base_url: str,
+    path: str,
+    *,
+    query: Mapping[str, str | int | float | bool] | None = None,
+) -> str:
+    """Return a fully qualified Hunter API URL."""
+
+    return join_url(base_url, path, query=query)
+
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "build_headers",
+    "url",
+]

--- a/harnessiq/providers/hunter/client.py
+++ b/harnessiq/providers/hunter/client.py
@@ -1,0 +1,67 @@
+"""Hunter credentials and HTTP client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from harnessiq.providers.http import RequestExecutor, request_json
+from harnessiq.shared.credentials import HunterCredentials
+
+
+@dataclass(frozen=True, slots=True)
+class HunterClient:
+    """Minimal Hunter HTTP client suitable for tool execution and tests."""
+
+    credentials: HunterCredentials
+    request_executor: RequestExecutor = request_json
+
+    def prepare_request(
+        self,
+        operation_name: str,
+        *,
+        path_params: Mapping[str, object] | None = None,
+        query: Mapping[str, object] | None = None,
+        payload: Any | None = None,
+    ) -> Any:
+        """Validate inputs and build an executable request."""
+
+        from harnessiq.providers.hunter.operations import _build_prepared_request
+
+        return _build_prepared_request(
+            operation_name=operation_name,
+            credentials=self.credentials,
+            path_params=path_params,
+            query=query,
+            payload=payload,
+        )
+
+    def execute_operation(
+        self,
+        operation_name: str,
+        *,
+        path_params: Mapping[str, object] | None = None,
+        query: Mapping[str, object] | None = None,
+        payload: Any | None = None,
+    ) -> Any:
+        """Execute one validated Hunter operation and return the decoded response."""
+
+        prepared = self.prepare_request(
+            operation_name,
+            path_params=path_params,
+            query=query,
+            payload=payload,
+        )
+        return self.request_executor(
+            prepared.method,
+            prepared.url,
+            headers=prepared.headers,
+            json_body=prepared.json_body,
+            timeout_seconds=self.credentials.timeout_seconds,
+        )
+
+
+__all__ = [
+    "HunterClient",
+    "HunterCredentials",
+]

--- a/harnessiq/providers/hunter/operations.py
+++ b/harnessiq/providers/hunter/operations.py
@@ -1,0 +1,271 @@
+"""Hunter operation catalog, tool definition, and request preparation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from urllib.parse import quote
+
+from harnessiq.interfaces import RequestPreparingClient
+from harnessiq.providers.hunter.api import build_headers, url
+from harnessiq.shared.hunter import (
+    HunterOperation,
+    HunterPreparedRequest,
+    build_hunter_operation_catalog,
+    get_hunter_operation,
+)
+from harnessiq.shared.tools import (
+    HUNTER_REQUEST,
+    RegisteredTool,
+    ToolArguments,
+    ToolDefinition,
+    build_grouped_operation_description,
+)
+
+if TYPE_CHECKING:
+    from harnessiq.shared.credentials import HunterCredentials
+
+
+def build_hunter_request_tool_definition(
+    *,
+    allowed_operations: Sequence[str] | None = None,
+) -> ToolDefinition:
+    """Return the canonical tool definition for the Hunter request surface."""
+
+    operations = _select_operations(allowed_operations)
+    operation_names = [operation.name for operation in operations]
+    return ToolDefinition(
+        key=HUNTER_REQUEST,
+        name="hunter_request",
+        description=_build_tool_description(operations),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": operation_names,
+                    "description": "Hunter operation name.",
+                },
+                "path_params": {
+                    "type": "object",
+                    "description": "Path parameters such as the Hunter lead id for resource-specific operations.",
+                    "additionalProperties": True,
+                },
+                "query": {
+                    "type": "object",
+                    "description": (
+                        "Query parameters for GET operations such as domain/company filters, email lookup fields, "
+                        "pagination, and optional enrichment controls."
+                    ),
+                    "additionalProperties": True,
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "JSON body for Hunter lead create and lead update operations.",
+                },
+            },
+            "required": ["operation"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def create_hunter_tools(
+    *,
+    credentials: "HunterCredentials | None" = None,
+    client: RequestPreparingClient | None = None,
+    allowed_operations: Sequence[str] | None = None,
+) -> tuple[RegisteredTool, ...]:
+    """Return the MCP-style Hunter request tool backed by the provided client."""
+
+    hunter_client = _coerce_client(credentials=credentials, client=client)
+    selected = _select_operations(allowed_operations)
+    allowed_names = frozenset(operation.name for operation in selected)
+    definition = build_hunter_request_tool_definition(
+        allowed_operations=tuple(operation.name for operation in selected)
+    )
+
+    def handler(arguments: ToolArguments) -> dict[str, Any]:
+        operation_name = _require_operation_name(arguments, allowed_names)
+        prepared = hunter_client.prepare_request(
+            operation_name,
+            path_params=_optional_mapping(arguments, "path_params"),
+            query=_optional_mapping(arguments, "query"),
+            payload=arguments.get("payload"),
+        )
+        response = hunter_client.request_executor(
+            prepared.method,
+            prepared.url,
+            headers=prepared.headers,
+            json_body=prepared.json_body,
+            timeout_seconds=hunter_client.credentials.timeout_seconds,
+        )
+        return {
+            "operation": prepared.operation.name,
+            "method": prepared.method,
+            "path": prepared.path,
+            "response": response,
+        }
+
+    return (RegisteredTool(definition=definition, handler=handler),)
+
+
+def _build_prepared_request(
+    *,
+    operation_name: str,
+    credentials: "HunterCredentials",
+    path_params: Mapping[str, object] | None,
+    query: Mapping[str, object] | None,
+    payload: Any | None,
+) -> HunterPreparedRequest:
+    operation = get_hunter_operation(operation_name)
+    normalized_path_params = {str(key): str(value) for key, value in (path_params or {}).items()}
+    missing = [key for key in operation.required_path_params if not normalized_path_params.get(key)]
+    if missing:
+        raise ValueError(
+            f"Operation '{operation.name}' requires path parameters: {', '.join(missing)}."
+        )
+
+    if operation.payload_kind == "none" and payload is not None:
+        raise ValueError(f"Operation '{operation.name}' does not accept a payload.")
+    if operation.payload_required and payload is None:
+        raise ValueError(f"Operation '{operation.name}' requires a payload.")
+    if payload is not None and not isinstance(payload, dict):
+        raise ValueError(f"Operation '{operation.name}' requires an object payload.")
+
+    if query is not None and not operation.allow_query:
+        raise ValueError(f"Operation '{operation.name}' does not accept query parameters.")
+
+    normalized_query = _normalize_query(query)
+    _validate_required_query(operation, normalized_query)
+    _validate_required_any_of_sets(operation, normalized_query)
+
+    path = operation.path_hint
+    for key, value in normalized_path_params.items():
+        path = path.replace(f"{{{key}}}", quote(value, safe=""))
+
+    merged_query: dict[str, str | int | float | bool] = {
+        "api_key": credentials.api_key,
+        **normalized_query,
+    }
+
+    return HunterPreparedRequest(
+        operation=operation,
+        method=operation.method,
+        path=path,
+        url=url(credentials.base_url, path, query=merged_query),
+        headers=build_headers(),
+        json_body=deepcopy(payload) if payload is not None else None,
+    )
+
+
+def _select_operations(allowed: Sequence[str] | None) -> tuple[HunterOperation, ...]:
+    if allowed is None:
+        return build_hunter_operation_catalog()
+    seen: set[str] = set()
+    selected: list[HunterOperation] = []
+    for name in allowed:
+        operation = get_hunter_operation(name)
+        if operation.name not in seen:
+            seen.add(operation.name)
+            selected.append(operation)
+    return tuple(selected)
+
+
+def _coerce_client(*, credentials: Any, client: RequestPreparingClient | None) -> RequestPreparingClient:
+    from harnessiq.providers.hunter.client import HunterClient
+
+    if client is not None:
+        return client
+    if credentials is None:
+        raise ValueError("Either Hunter credentials or a Hunter client must be provided.")
+    return HunterClient(credentials=credentials)
+
+
+def _require_operation_name(arguments: Mapping[str, object], allowed: frozenset[str]) -> str:
+    value = arguments["operation"]
+    if not isinstance(value, str):
+        raise ValueError("The 'operation' argument must be a string.")
+    if value not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        raise ValueError(f"Unsupported Hunter operation '{value}'. Allowed: {allowed_str}.")
+    return value
+
+
+def _optional_mapping(arguments: Mapping[str, object], key: str) -> Mapping[str, object] | None:
+    value = arguments.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(f"The '{key}' argument must be an object when provided.")
+    return value
+
+
+def _build_tool_description(operations: Sequence[HunterOperation]) -> str:
+    return build_grouped_operation_description(
+        operations,
+        lead="Execute authenticated Hunter.io email discovery, verification, enrichment, and lead management API operations.",
+        usage=(
+            "Use discovery operations to find domains, companies, and professional emails; verification to assess deliverability; "
+            "enrichment to attach person and company context; and lead/campaign operations for lightweight outbound workflow management."
+        ),
+        closing=(
+            "Use 'path_params' for lead ids, 'query' for GET filters, and 'payload' for lead create/update request bodies. "
+            "Hunter authentication is always injected as the 'api_key' query parameter."
+        ),
+    )
+
+
+def _normalize_query(
+    query: Mapping[str, object] | None,
+) -> dict[str, str | int | float | bool]:
+    if query is None:
+        return {}
+    return {str(key): value for key, value in query.items() if _has_value(value)}
+
+
+def _validate_required_query(
+    operation: HunterOperation,
+    query: Mapping[str, object],
+) -> None:
+    missing = [field_name for field_name in operation.required_query_params if not _has_value(query.get(field_name))]
+    if missing:
+        raise ValueError(
+            f"Operation '{operation.name}' requires query parameters: {', '.join(missing)}."
+        )
+
+
+def _validate_required_any_of_sets(
+    operation: HunterOperation,
+    query: Mapping[str, object],
+) -> None:
+    for option_set in operation.required_any_of_sets:
+        if any(all(_has_value(query.get(field_name)) for field_name in combination) for combination in option_set):
+            continue
+        rendered = " or ".join(
+            " + ".join(field_name for field_name in combination)
+            for combination in option_set
+        )
+        raise ValueError(
+            f"Operation '{operation.name}' requires one of: {rendered}."
+        )
+
+
+def _has_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+__all__ = [
+    "HUNTER_REQUEST",
+    "HunterOperation",
+    "HunterPreparedRequest",
+    "_build_prepared_request",
+    "build_hunter_operation_catalog",
+    "build_hunter_request_tool_definition",
+    "create_hunter_tools",
+    "get_hunter_operation",
+]

--- a/harnessiq/shared/credentials.py
+++ b/harnessiq/shared/credentials.py
@@ -13,6 +13,7 @@ from harnessiq.shared.providers import (
     CREATIFY_DEFAULT_BASE_URL,
     EXA_DEFAULT_BASE_URL,
     EXPANDI_DEFAULT_BASE_URL,
+    HUNTER_DEFAULT_BASE_URL,
     INBOXAPP_DEFAULT_BASE_URL,
     INSTANTLY_DEFAULT_BASE_URL,
     LEMLIST_DEFAULT_BASE_URL,
@@ -336,6 +337,33 @@ class ExpandiCredentials:
 
 
 @dataclass(frozen=True, slots=True)
+class HunterCredentials:
+    """Runtime credentials for the Hunter.io API."""
+
+    api_key: str
+    base_url: str = HUNTER_DEFAULT_BASE_URL
+    timeout_seconds: float = 60.0
+
+    def __post_init__(self) -> None:
+        _validate_text_fields(self, "api_key")
+        _validate_url_fields(self, "base_url")
+        _validate_timeout(self)
+
+    def masked_api_key(self) -> str:
+        key = self.api_key
+        if len(key) <= 4:
+            return "*" * len(key)
+        return f"{key[:3]}{'*' * max(1, len(key) - 7)}{key[-4:]}"
+
+    def as_redacted_dict(self) -> dict[str, object]:
+        return {
+            "api_key_masked": self.masked_api_key(),
+            "base_url": self.base_url,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class InboxAppCredentials:
     """Runtime credentials for the InboxApp API."""
 
@@ -589,6 +617,7 @@ __all__ = [
     "CreatifyCredentials",
     "ExaCredentials",
     "ExpandiCredentials",
+    "HunterCredentials",
     "InboxAppCredentials",
     "InstantlyCredentials",
     "LeadIQCredentials",

--- a/harnessiq/shared/hunter.py
+++ b/harnessiq/shared/hunter.py
@@ -1,0 +1,198 @@
+"""Hunter.io shared operation metadata."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Literal, Sequence
+
+PayloadKind = Literal["none", "object"]
+
+
+@dataclass(frozen=True, slots=True)
+class HunterOperation:
+    """Declarative metadata for one Hunter.io API operation."""
+
+    name: str
+    category: str
+    method: Literal["GET", "POST", "PUT", "DELETE"]
+    path_hint: str
+    required_path_params: tuple[str, ...] = ()
+    payload_kind: PayloadKind = "none"
+    payload_required: bool = False
+    allow_query: bool = False
+    required_query_params: tuple[str, ...] = ()
+    required_any_of_sets: tuple[tuple[tuple[str, ...], ...], ...] = ()
+
+    def summary(self) -> str:
+        return f"{self.name} ({self.method} {self.path_hint})"
+
+
+@dataclass(frozen=True, slots=True)
+class HunterPreparedRequest:
+    """A validated Hunter request ready for execution."""
+
+    operation: HunterOperation
+    method: str
+    path: str
+    url: str
+    headers: dict[str, str]
+    json_body: Any | None
+
+
+def _op(
+    name: str,
+    category: str,
+    method: Literal["GET", "POST", "PUT", "DELETE"],
+    path_hint: str,
+    *,
+    required_path_params: Sequence[str] = (),
+    payload_kind: PayloadKind = "none",
+    payload_required: bool = False,
+    allow_query: bool = False,
+    required_query_params: Sequence[str] = (),
+    required_any_of_sets: Sequence[Sequence[Sequence[str]]] = (),
+) -> tuple[str, HunterOperation]:
+    normalized_any_of_sets = tuple(
+        tuple(tuple(field_name for field_name in combination) for combination in option_set)
+        for option_set in required_any_of_sets
+    )
+    return (
+        name,
+        HunterOperation(
+            name=name,
+            category=category,
+            method=method,
+            path_hint=path_hint,
+            required_path_params=tuple(required_path_params),
+            payload_kind=payload_kind,
+            payload_required=payload_required,
+            allow_query=allow_query,
+            required_query_params=tuple(required_query_params),
+            required_any_of_sets=normalized_any_of_sets,
+        ),
+    )
+
+
+_HUNTER_CATALOG: OrderedDict[str, HunterOperation] = OrderedDict(
+    (
+        _op(
+            "domain_search",
+            "Email Discovery",
+            "GET",
+            "/domain-search",
+            allow_query=True,
+            required_any_of_sets=(
+                (("domain",), ("company",)),
+            ),
+        ),
+        _op(
+            "email_finder",
+            "Email Discovery",
+            "GET",
+            "/email-finder",
+            allow_query=True,
+            required_any_of_sets=(
+                (("domain",), ("company",)),
+                (("full_name",), ("first_name", "last_name")),
+            ),
+        ),
+        _op(
+            "email_verifier",
+            "Email Verification",
+            "GET",
+            "/email-verifier",
+            allow_query=True,
+            required_query_params=("email",),
+        ),
+        _op(
+            "email_count",
+            "Email Discovery",
+            "GET",
+            "/email-count",
+            allow_query=True,
+            required_any_of_sets=(
+                (("domain",), ("company",)),
+            ),
+        ),
+        _op("discover", "Company Discovery", "GET", "/discover", allow_query=True),
+        _op(
+            "email_enrichment",
+            "Contact Enrichment",
+            "GET",
+            "/combined-enrichment",
+            allow_query=True,
+            required_query_params=("email",),
+        ),
+        _op(
+            "company_enrichment",
+            "Company Enrichment",
+            "GET",
+            "/company-enrichment",
+            allow_query=True,
+            required_any_of_sets=(
+                (("domain",), ("company",)),
+            ),
+        ),
+        _op("account_info", "Account Management", "GET", "/account"),
+        _op("leads_list", "Lead Management", "GET", "/leads", allow_query=True),
+        _op(
+            "lead_get",
+            "Lead Management",
+            "GET",
+            "/leads/{id}",
+            required_path_params=("id",),
+        ),
+        _op(
+            "lead_create",
+            "Lead Management",
+            "POST",
+            "/leads",
+            payload_kind="object",
+            payload_required=True,
+        ),
+        _op(
+            "lead_update",
+            "Lead Management",
+            "PUT",
+            "/leads/{id}",
+            required_path_params=("id",),
+            payload_kind="object",
+            payload_required=True,
+        ),
+        _op(
+            "lead_delete",
+            "Lead Management",
+            "DELETE",
+            "/leads/{id}",
+            required_path_params=("id",),
+        ),
+        _op("campaigns_list", "Campaign Management", "GET", "/campaigns", allow_query=True),
+    )
+)
+
+
+def build_hunter_operation_catalog() -> tuple[HunterOperation, ...]:
+    """Return the supported Hunter operation catalog in stable order."""
+
+    return tuple(_HUNTER_CATALOG.values())
+
+
+def get_hunter_operation(operation_name: str) -> HunterOperation:
+    """Return a supported Hunter operation or raise a clear error."""
+
+    operation = _HUNTER_CATALOG.get(operation_name)
+    if operation is None:
+        available = ", ".join(_HUNTER_CATALOG)
+        raise ValueError(
+            f"Unsupported Hunter operation '{operation_name}'. Available: {available}."
+        )
+    return operation
+
+
+__all__ = [
+    "HunterOperation",
+    "HunterPreparedRequest",
+    "build_hunter_operation_catalog",
+    "get_hunter_operation",
+]

--- a/harnessiq/shared/providers.py
+++ b/harnessiq/shared/providers.py
@@ -51,6 +51,7 @@ GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 GOOGLE_DRIVE_JSON_MIME_TYPE = "application/json"
 GOOGLE_DRIVE_UPLOAD_FILES_PATH = "/files"
 GROK_DEFAULT_BASE_URL = "https://api.x.ai"
+HUNTER_DEFAULT_BASE_URL = "https://api.hunter.io/v2"
 INBOXAPP_DEFAULT_BASE_URL = "https://inboxapp.com/api/v1"
 INSTANTLY_DEFAULT_BASE_URL = "https://api.instantly.ai/api/v2"
 LEADIQ_DEFAULT_BASE_URL = "https://api.leadiq.com"
@@ -94,6 +95,7 @@ __all__ = [
     "GOOGLE_DRIVE_JSON_MIME_TYPE",
     "GOOGLE_DRIVE_UPLOAD_FILES_PATH",
     "GROK_DEFAULT_BASE_URL",
+    "HUNTER_DEFAULT_BASE_URL",
     "INBOXAPP_DEFAULT_BASE_URL",
     "INSTANTLY_DEFAULT_BASE_URL",
     "LEADIQ_DEFAULT_BASE_URL",

--- a/harnessiq/shared/tools.py
+++ b/harnessiq/shared/tools.py
@@ -252,6 +252,7 @@ ARCADS_REQUEST = "arcads.request"
 ARXIV_REQUEST = "arxiv.request"
 CREATIFY_REQUEST = "creatify.request"
 EXA_REQUEST = "exa.request"
+HUNTER_REQUEST = "hunter.request"
 INSTANTLY_REQUEST = "instantly.request"
 INBOXAPP_REQUEST = "inboxapp.request"
 LEMLIST_REQUEST = "lemlist.request"
@@ -486,6 +487,7 @@ __all__ = [
     "EXA_OUTREACH_LOG_EMAIL_SENT",
     "EXA_OUTREACH_LOG_LEAD",
     "EXA_REQUEST",
+    "HUNTER_REQUEST",
     "FILESYSTEM_APPEND_TEXT_FILE",
     "FILESYSTEM_COPY_PATH",
     "FILESYSTEM_GET_CURRENT_DIRECTORY",

--- a/harnessiq/tools/hunter/__init__.py
+++ b/harnessiq/tools/hunter/__init__.py
@@ -1,0 +1,11 @@
+"""Hunter tool registration for the Harnessiq tool layer."""
+
+from harnessiq.tools.hunter.operations import (
+    build_hunter_request_tool_definition,
+    create_hunter_tools,
+)
+
+__all__ = [
+    "build_hunter_request_tool_definition",
+    "create_hunter_tools",
+]

--- a/harnessiq/tools/hunter/operations.py
+++ b/harnessiq/tools/hunter/operations.py
@@ -1,0 +1,11 @@
+"""Hunter MCP-style tool factory for the Harnessiq tool layer."""
+
+from harnessiq.providers.hunter.operations import (
+    build_hunter_request_tool_definition,
+    create_hunter_tools,
+)
+
+__all__ = [
+    "build_hunter_request_tool_definition",
+    "create_hunter_tools",
+]

--- a/harnessiq/toolset/catalog_provider.py
+++ b/harnessiq/toolset/catalog_provider.py
@@ -92,6 +92,13 @@ PROVIDER_ENTRIES: tuple[ToolEntry, ...] = (
         requires_credentials=True,
     ),
     ToolEntry(
+        key="hunter.request",
+        name="hunter_request",
+        description="Execute authenticated Hunter.io email discovery, verification, enrichment, and lead management API operations.",
+        family="hunter",
+        requires_credentials=True,
+    ),
+    ToolEntry(
         key="instantly.request",
         name="instantly_request",
         description="Execute authenticated Instantly cold email platform API operations.",
@@ -227,6 +234,7 @@ PROVIDER_FACTORY_MAP: dict[str, tuple[str, str]] = {
     "creatify": ("harnessiq.tools.creatify", "create_creatify_tools"),
     "exa": ("harnessiq.tools.exa", "create_exa_tools"),
     "expandi": ("harnessiq.tools.expandi", "create_expandi_tools"),
+    "hunter": ("harnessiq.tools.hunter", "create_hunter_tools"),
     "instantly": ("harnessiq.tools.instantly", "create_instantly_tools"),
     "inboxapp": ("harnessiq.tools.inboxapp", "create_inboxapp_tools"),
     "leadiq": ("harnessiq.tools.leadiq", "create_leadiq_tools"),

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -305,7 +305,7 @@ class HttpTransportHostnameTests(unittest.TestCase):
 
 
 class HttpHostnameMapTests(unittest.TestCase):
-    """Verify _infer_provider_name maps all six new provider hostnames."""
+    """Verify _infer_provider_name maps all seven new provider hostnames."""
 
     def _assert_provider(self, url: str, expected: str) -> None:
         self.assertEqual(_infer_provider_name(url), expected)
@@ -315,6 +315,9 @@ class HttpHostnameMapTests(unittest.TestCase):
 
     def test_arcads_hostname(self) -> None:
         self._assert_provider("https://external-api.arcads.ai/v1/products", "arcads")
+
+    def test_hunter_hostname(self) -> None:
+        self._assert_provider("https://api.hunter.io/v2/domain-search", "hunter")
 
     def test_instantly_hostname(self) -> None:
         self._assert_provider("https://api.instantly.ai/api/v2/campaigns", "instantly")

--- a/tests/test_hunter_provider.py
+++ b/tests/test_hunter_provider.py
@@ -1,0 +1,368 @@
+"""Tests for harnessiq.providers.hunter."""
+
+from __future__ import annotations
+
+import unittest
+
+from harnessiq.config.provider_credentials.catalog import PROVIDER_CREDENTIAL_SPECS
+from harnessiq.providers.hunter import HUNTER_BASE_URL, HunterClient, HunterCredentials
+from harnessiq.providers.hunter.api import DEFAULT_BASE_URL, build_headers
+from harnessiq.providers.hunter.operations import (
+    HUNTER_REQUEST,
+    build_hunter_operation_catalog,
+    build_hunter_request_tool_definition,
+    create_hunter_tools,
+    get_hunter_operation,
+)
+from harnessiq.toolset import ToolsetRegistry
+from harnessiq.toolset.catalog_provider import (
+    PROVIDER_ENTRIES,
+    PROVIDER_ENTRY_INDEX,
+    PROVIDER_FACTORY_MAP,
+)
+from harnessiq.tools.hunter import create_hunter_tools as create_hunter_tools_from_tools
+from harnessiq.tools.registry import ToolRegistry
+
+
+def _mock_executor(response: object):
+    def executor(method, url, *, headers, json_body, timeout_seconds):
+        return response
+
+    return executor
+
+
+class HunterCredentialsTests(unittest.TestCase):
+    def test_valid_credentials(self):
+        credentials = HunterCredentials(api_key="hunter-key")
+
+        self.assertEqual(credentials.api_key, "hunter-key")
+        self.assertEqual(credentials.base_url, DEFAULT_BASE_URL)
+        self.assertEqual(credentials.timeout_seconds, 60.0)
+
+    def test_blank_api_key_raises(self):
+        with self.assertRaises(ValueError):
+            HunterCredentials(api_key="")
+
+    def test_whitespace_api_key_raises(self):
+        with self.assertRaises(ValueError):
+            HunterCredentials(api_key="   ")
+
+    def test_zero_timeout_raises(self):
+        with self.assertRaises(ValueError):
+            HunterCredentials(api_key="hunter-key", timeout_seconds=0)
+
+    def test_negative_timeout_raises(self):
+        with self.assertRaises(ValueError):
+            HunterCredentials(api_key="hunter-key", timeout_seconds=-1)
+
+    def test_masked_api_key_hides_secret(self):
+        credentials = HunterCredentials(api_key="abcdefghijklmnop")
+        masked = credentials.masked_api_key()
+
+        self.assertNotIn("abcdefghijklmnop", masked)
+        self.assertTrue(masked.startswith("abc"))
+
+    def test_as_redacted_dict_hides_raw_key(self):
+        credentials = HunterCredentials(api_key="super-secret-hunter")
+        payload = credentials.as_redacted_dict()
+
+        self.assertNotIn("super-secret-hunter", str(payload))
+        self.assertEqual(payload["api_key_masked"], credentials.masked_api_key())
+
+
+class HunterApiTests(unittest.TestCase):
+    def test_build_headers_no_auth_header(self):
+        headers = build_headers()
+
+        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertNotIn("Authorization", headers)
+        self.assertNotIn("X-API-KEY", headers)
+
+
+class HunterOperationCatalogTests(unittest.TestCase):
+    def test_catalog_count(self):
+        catalog = build_hunter_operation_catalog()
+        self.assertEqual(len(catalog), 14)
+
+    def test_expected_operation_names_present(self):
+        names = {operation.name for operation in build_hunter_operation_catalog()}
+        self.assertEqual(
+            names,
+            {
+                "domain_search",
+                "email_finder",
+                "email_verifier",
+                "email_count",
+                "discover",
+                "email_enrichment",
+                "company_enrichment",
+                "account_info",
+                "leads_list",
+                "lead_get",
+                "lead_create",
+                "lead_update",
+                "lead_delete",
+                "campaigns_list",
+            },
+        )
+
+    def test_get_unknown_operation_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_hunter_operation("nonexistent")
+
+        self.assertIn("nonexistent", str(ctx.exception))
+
+
+class HunterClientTests(unittest.TestCase):
+    def _make_client(self, response=None):
+        credentials = HunterCredentials(api_key="hunter-test-key")
+        return HunterClient(
+            credentials=credentials,
+            request_executor=_mock_executor(response or {"ok": True}),
+        )
+
+    def test_api_key_is_injected_into_query(self):
+        prepared = self._make_client().prepare_request(
+            "email_verifier",
+            query={"email": "person@example.com"},
+        )
+
+        self.assertIn("api_key=hunter-test-key", prepared.url)
+
+    def test_api_key_is_not_put_in_headers(self):
+        prepared = self._make_client().prepare_request(
+            "email_verifier",
+            query={"email": "person@example.com"},
+        )
+
+        self.assertNotIn("api_key", prepared.headers)
+        self.assertNotIn("X-API-KEY", prepared.headers)
+
+    def test_domain_search_requires_domain_or_company(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_client().prepare_request("domain_search")
+
+        self.assertIn("domain", str(ctx.exception))
+
+    def test_domain_search_accepts_domain(self):
+        prepared = self._make_client().prepare_request(
+            "domain_search",
+            query={"domain": "stripe.com"},
+        )
+
+        self.assertIn("domain=stripe.com", prepared.url)
+        self.assertIsNone(prepared.json_body)
+
+    def test_domain_search_accepts_company(self):
+        prepared = self._make_client().prepare_request(
+            "domain_search",
+            query={"company": "Stripe"},
+        )
+
+        self.assertIn("company=Stripe", prepared.url)
+
+    def test_email_finder_requires_name_fields(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_client().prepare_request(
+                "email_finder",
+                query={"domain": "stripe.com"},
+            )
+
+        self.assertIn("full_name", str(ctx.exception))
+
+    def test_email_finder_requires_both_first_and_last_name_when_full_name_missing(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_client().prepare_request(
+                "email_finder",
+                query={"domain": "stripe.com", "first_name": "Jane"},
+            )
+
+        self.assertIn("first_name + last_name", str(ctx.exception))
+
+    def test_email_finder_accepts_first_and_last_name(self):
+        prepared = self._make_client().prepare_request(
+            "email_finder",
+            query={
+                "domain": "stripe.com",
+                "first_name": "Jane",
+                "last_name": "Doe",
+            },
+        )
+
+        self.assertIn("first_name=Jane", prepared.url)
+        self.assertIn("last_name=Doe", prepared.url)
+
+    def test_email_finder_accepts_full_name(self):
+        prepared = self._make_client().prepare_request(
+            "email_finder",
+            query={"company": "Stripe", "full_name": "Jane Doe"},
+        )
+
+        self.assertIn("full_name=Jane+Doe", prepared.url)
+
+    def test_email_verifier_requires_email(self):
+        with self.assertRaises(ValueError):
+            self._make_client().prepare_request("email_verifier")
+
+    def test_lead_get_interpolates_path_param(self):
+        prepared = self._make_client().prepare_request(
+            "lead_get",
+            path_params={"id": "123"},
+        )
+
+        self.assertIn("/leads/123", prepared.url)
+        self.assertEqual(prepared.path, "/leads/123")
+
+    def test_lead_update_interpolates_path_param(self):
+        prepared = self._make_client().prepare_request(
+            "lead_update",
+            path_params={"id": "456"},
+            payload={"email": "person@example.com"},
+        )
+
+        self.assertEqual(prepared.path, "/leads/456")
+
+    def test_lead_delete_interpolates_path_param(self):
+        prepared = self._make_client().prepare_request(
+            "lead_delete",
+            path_params={"id": "789"},
+        )
+
+        self.assertEqual(prepared.path, "/leads/789")
+
+    def test_lead_create_requires_payload(self):
+        with self.assertRaises(ValueError):
+            self._make_client().prepare_request("lead_create")
+
+    def test_get_operations_reject_payload(self):
+        with self.assertRaises(ValueError):
+            self._make_client().prepare_request(
+                "domain_search",
+                query={"domain": "stripe.com"},
+                payload={"bad": True},
+            )
+
+    def test_post_operations_store_payload_in_json_body(self):
+        prepared = self._make_client().prepare_request(
+            "lead_create",
+            payload={"email": "person@example.com", "first_name": "Jane"},
+        )
+
+        self.assertEqual(prepared.json_body["email"], "person@example.com")
+        self.assertIn("api_key=hunter-test-key", prepared.url)
+
+    def test_execute_operation_returns_response(self):
+        response = {"data": {"email": "person@example.com"}}
+        client = self._make_client(response=response)
+
+        result = client.execute_operation(
+            "email_verifier",
+            query={"email": "person@example.com"},
+        )
+
+        self.assertEqual(result, response)
+
+
+class HunterToolTests(unittest.TestCase):
+    def _make_credentials(self):
+        return HunterCredentials(api_key="hunter-tool-key")
+
+    def test_create_tools_returns_one_tool(self):
+        tools = create_hunter_tools(credentials=self._make_credentials())
+        self.assertEqual(len(tools), 1)
+
+    def test_tool_key_matches_constant(self):
+        tools = create_hunter_tools(credentials=self._make_credentials())
+        self.assertEqual(tools[0].key, HUNTER_REQUEST)
+
+    def test_tool_module_exports_factory(self):
+        tools = create_hunter_tools_from_tools(credentials=self._make_credentials())
+        self.assertEqual(len(tools), 1)
+        self.assertEqual(tools[0].key, HUNTER_REQUEST)
+
+    def test_no_credentials_or_client_raises(self):
+        with self.assertRaises(ValueError):
+            create_hunter_tools()
+
+    def test_handler_returns_expected_shape(self):
+        response = {"data": {"status": "valid"}}
+        client = HunterClient(
+            credentials=self._make_credentials(),
+            request_executor=_mock_executor(response),
+        )
+        registry = ToolRegistry(create_hunter_tools(client=client))
+
+        result = registry.execute(
+            HUNTER_REQUEST,
+            {
+                "operation": "email_verifier",
+                "query": {"email": "person@example.com"},
+            },
+        )
+
+        self.assertEqual(result.output["operation"], "email_verifier")
+        self.assertEqual(result.output["response"], response)
+        self.assertEqual(result.output["path"], "/email-verifier")
+
+    def test_tool_definition_requires_operation(self):
+        definition = build_hunter_request_tool_definition()
+        self.assertIn("operation", definition.input_schema["required"])
+
+    def test_allowed_operations_subset_filters_enum(self):
+        tools = create_hunter_tools(
+            credentials=self._make_credentials(),
+            allowed_operations=["domain_search", "email_verifier"],
+        )
+
+        enum_values = tools[0].definition.input_schema["properties"]["operation"]["enum"]
+        self.assertEqual(set(enum_values), {"domain_search", "email_verifier"})
+
+    def test_allowed_operations_runtime_rejects_other_operations(self):
+        tools = create_hunter_tools(
+            credentials=self._make_credentials(),
+            allowed_operations=["domain_search"],
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            tools[0].handler(
+                {
+                    "operation": "email_verifier",
+                    "query": {"email": "person@example.com"},
+                }
+            )
+
+        self.assertIn("email_verifier", str(ctx.exception))
+
+
+class HunterCatalogIntegrationTests(unittest.TestCase):
+    def test_hunter_request_constant(self):
+        self.assertEqual(HUNTER_REQUEST, "hunter.request")
+
+    def test_hunter_base_url_export(self):
+        self.assertEqual(HUNTER_BASE_URL, "https://api.hunter.io/v2")
+
+    def test_provider_credential_spec_registered(self):
+        self.assertIn("hunter", PROVIDER_CREDENTIAL_SPECS)
+
+    def test_provider_entry_registered(self):
+        self.assertIn("hunter.request", PROVIDER_ENTRY_INDEX)
+        self.assertEqual(PROVIDER_ENTRY_INDEX["hunter.request"].family, "hunter")
+
+    def test_provider_factory_registered(self):
+        self.assertEqual(
+            PROVIDER_FACTORY_MAP["hunter"],
+            ("harnessiq.tools.hunter", "create_hunter_tools"),
+        )
+
+    def test_provider_entries_contain_hunter(self):
+        self.assertTrue(any(entry.key == "hunter.request" for entry in PROVIDER_ENTRIES))
+
+    def test_toolset_registry_can_resolve_hunter_tool(self):
+        registry = ToolsetRegistry()
+        tool = registry.get("hunter.request", credentials=HunterCredentials(api_key="hunter-registry-key"))
+
+        self.assertEqual(tool.key, "hunter.request")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Hunter.io as a new provider family with shared credentials, base URL constants, and a 14-operation catalog
- add the Hunter request-preparing provider client and `hunter.request` tool surface with query-param auth and operation validation
- register Hunter in the provider credential/tool catalogs and add focused regression coverage

## Testing
- python -m pytest tests/test_hunter_provider.py tests/test_config_loader.py tests/test_toolset_registry.py tests/test_providers.py tests/test_sdk_package.py -q