### PR TITLE
docs(readme): add Google Cloud integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,25 @@ Harnessiq keeps the static tool path by default. When you need to narrow a large
 
 See `docs/dynamic-tool-selection.md` for the runtime contract, CLI flags, embedding-model configuration, and the boundary between existing tool keys and Python-only custom callables.
 
+## Google Cloud Integration
+
+Harnessiq ships a dedicated Google Cloud deployment surface for running manifest-backed harnesses as Cloud Run jobs without introducing a second runtime model.
+
+- `harnessiq gcloud init` saves one JSON deploy config per logical agent under `~/.harnessiq/gcloud/<agent>.json`, including region, Artifact Registry, Cloud Run, Scheduler, model-selection, sink, and parameter settings.
+- `harnessiq gcloud health` and `harnessiq gcloud credentials check` validate operator prerequisites such as the `gcloud` CLI, active auth, ADC, required APIs, and Secret Manager access.
+- `harnessiq gcloud credentials ...` reuses repo-local harness credential bindings and syncs runtime secrets into Secret Manager through `status`, `sync`, `set`, and `remove` flows.
+- Manifest-backed deploy specs are derived from the harness manifest plus saved profile state, so remote runs preserve model selection, runtime/custom parameters, adapter arguments, sink specs, provider families, and declared durable memory files.
+- `build`, `deploy`, `schedule`, and `execute` cover the Cloud Build, Cloud Run Jobs, and Cloud Scheduler lifecycle, while `logs` and `cost` provide runtime observability and monthly cost estimation.
+- The Cloud Run runtime wrapper syncs the harness memory directory to GCS before and after execution, preserving harness-native durable state rather than flattening everything into one blob.
+- The GCloud command family emits JSON and supports `--dry-run` on the mutating operations, so it stays scriptable in CI and operator tooling.
+
 ## Live Snapshot
 
 | Metric | Count |
 | --- | --- |
 | Concrete harness manifests | 9 |
-| Top-level CLI commands | 19 |
-| Registered CLI command paths | 153 |
+| Top-level CLI commands | 20 |
+| Registered CLI command paths | 168 |
 | Model providers | 4 |
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
@@ -120,6 +132,7 @@ The generated command catalog lives at `artifacts/commands.md`. Use it as the hi
 | harnessiq connections | list, remove, test | Inspect or manage configured sink connections |
 | harnessiq credentials | bind, show, test | Manage persisted harness credential bindings |
 | harnessiq export | - | Export ledger entries in a structured format |
+| harnessiq gcloud | build, cost, credentials, deploy, execute, health, init, logs, schedule | Manage Google Cloud deployment configuration and operations |
 | harnessiq inspect | exa_outreach (outreach), instagram, knowt, leads, linkedin, mission_driven, prospecting, research_sweep (research-sweep), spawn_specialized_subagents | Inspect one harness manifest and generated CLI surface |
 | harnessiq instagram | configure, get-emails, prepare, run, show | Manage and run the Instagram keyword discovery agent |
 | harnessiq leads | configure, prepare, run, show | Manage and run the leads discovery agent |

--- a/artifacts/commands.md
+++ b/artifacts/commands.md
@@ -6,8 +6,8 @@ This artifact is generated from the live `harnessiq/cli/` source tree by `python
 
 | Metric | Count |
 | --- | --- |
-| Top-level commands | 19 |
-| Registered command paths | 153 |
+| Top-level commands | 20 |
+| Registered command paths | 168 |
 
 Alias paths are included in the registered command total. Canonical commands list aliases where they exist.
 
@@ -19,6 +19,7 @@ Alias paths are included in the registered command total. Canonical commands lis
 | harnessiq connections | list, remove, test | Inspect or manage configured sink connections | `harnessiq/cli/ledger/commands.py` |
 | harnessiq credentials | bind, show, test | Manage persisted harness credential bindings | `harnessiq/cli/platform_commands.py` |
 | harnessiq export | - | Export ledger entries in a structured format | `harnessiq/cli/ledger/commands.py` |
+| harnessiq gcloud | build, cost, credentials, deploy, execute, health, init, logs, schedule | Manage Google Cloud deployment configuration and operations | `harnessiq/cli/gcloud/commands.py` |
 | harnessiq inspect | exa_outreach (outreach), instagram, knowt, leads, linkedin, mission_driven, prospecting, research_sweep (research-sweep), spawn_specialized_subagents | Inspect one harness manifest and generated CLI surface | `harnessiq/cli/platform_commands.py` |
 | harnessiq instagram | configure, get-emails, prepare, run, show | Manage and run the Instagram keyword discovery agent | `harnessiq/cli/instagram/commands.py` |
 | harnessiq leads | configure, prepare, run, show | Manage and run the leads discovery agent | `harnessiq/cli/leads/commands.py` |
@@ -91,6 +92,25 @@ Alias paths are included in the registered command total. Canonical commands lis
 | harnessiq credentials test prospecting | - | test Google Maps Prospecting | `harnessiq/cli/platform_commands.py` |
 | harnessiq credentials test research_sweep | research-sweep | test Research Sweep | `harnessiq/cli/platform_commands.py` |
 | harnessiq credentials test spawn_specialized_subagents | - | test Spawn Specialized Subagents | `harnessiq/cli/platform_commands.py` |
+
+## `harnessiq gcloud`
+
+| Command | Description | Source |
+| --- | --- | --- |
+| harnessiq gcloud build | Build and publish the configured container image | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud cost | Estimate the configured monthly GCP deployment cost | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials | Manage repo-local to GCP credential synchronization | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials check | Check local GCP authentication prerequisites | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials remove | Remove one registered credential from the GCP config | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials set | Register one custom credential in GCP Secret Manager | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials status | Show credential sync status for one GCP config | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud credentials sync | Sync repo-local credentials into GCP Secret Manager | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud deploy | Deploy or update the configured Cloud Run job | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud execute | Trigger an immediate Cloud Run job execution | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud health | Inspect GCP deployment prerequisites | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud init | Initialize or refresh one GCP deployment config | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud logs | Read Cloud Run execution logs | `harnessiq/cli/gcloud/commands.py` |
+| harnessiq gcloud schedule | Create or update the configured scheduler job | `harnessiq/cli/gcloud/commands.py` |
 
 ## `harnessiq inspect`
 

--- a/artifacts/file_index.md
+++ b/artifacts/file_index.md
@@ -9,8 +9,8 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Metric | Count |
 | --- | --- |
 | Concrete harness manifests | 9 |
-| Top-level CLI commands | 19 |
-| Registered CLI command paths | 153 |
+| Top-level CLI commands | 20 |
+| Registered CLI command paths | 168 |
 | Model providers | 4 |
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
@@ -32,6 +32,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Path | Kind | Responsibility |
 | --- | --- | --- |
 | `.harnessiq/` | generated/cache | Fallback local HarnessIQ home used by the ledger/output-sink runtime when the preferred home path is not writable. |
+| `.worktrees/` | local state | Git worktree checkouts used for isolated implementation branches; local-only and not part of the shipped package. |
 | `artifacts/` | repo docs | Generated and curated repository reference artifacts. |
 | `build/` | generated/cache | Setuptools build output; generated, not part of the live source tree. |
 | `docs/` | repo docs | Focused usage and architecture notes for the package. |
@@ -39,6 +40,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | `harnessiq.egg-info/` | generated/cache | Packaging metadata emitted by local builds. |
 | `memory/` | local state | Task artifacts plus durable agent runtime state; not part of the shipped package. |
 | `scripts/` | repo tooling | Repository maintenance and generation scripts. |
+| `src/` | generated/cache | Legacy or generated residue in this checkout; not the authoritative package source. |
 | `tests/` | source | unittest coverage for runtime, CLI, providers, and tools. |
 
 ## Package Layout
@@ -102,6 +104,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | harnessiq connections | list, remove, test | Inspect or manage configured sink connections | `harnessiq/cli/ledger/commands.py` |
 | harnessiq credentials | bind, show, test | Manage persisted harness credential bindings | `harnessiq/cli/platform_commands.py` |
 | harnessiq export | - | Export ledger entries in a structured format | `harnessiq/cli/ledger/commands.py` |
+| harnessiq gcloud | build, cost, credentials, deploy, execute, health, init, logs, schedule | Manage Google Cloud deployment configuration and operations | `harnessiq/cli/gcloud/commands.py` |
 | harnessiq inspect | exa_outreach (outreach), instagram, knowt, leads, linkedin, mission_driven, prospecting, research_sweep (research-sweep), spawn_specialized_subagents | Inspect one harness manifest and generated CLI surface | `harnessiq/cli/platform_commands.py` |
 | harnessiq instagram | configure, get-emails, prepare, run, show | Manage and run the Instagram keyword discovery agent | `harnessiq/cli/instagram/commands.py` |
 | harnessiq leads | configure, prepare, run, show | Manage and run the leads discovery agent | `harnessiq/cli/leads/commands.py` |

--- a/scripts/sync_repo_docs.py
+++ b/scripts/sync_repo_docs.py
@@ -811,13 +811,22 @@ def parse_cli_commands(harnesses: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 if isinstance(inner, ast.Assign) and len(inner.targets) == 1 and isinstance(inner.targets[0], ast.Name) and isinstance(inner.value, ast.Call):
                     target_name = inner.targets[0].id
                     call = inner.value
-                    if isinstance(call.func, ast.Attribute) and call.func.attr == "add_parser":
-                        base_name = get_name(call.func.value)
+                    if (
+                        isinstance(call.func, ast.Attribute)
+                        and call.func.attr == "add_parser"
+                    ) or get_name(call.func) == "_add_help_parser":
+                        if isinstance(call.func, ast.Attribute) and call.func.attr == "add_parser":
+                            base_name = get_name(call.func.value)
+                            parser_name = get_call_arg(call, 0, "name")
+                            help_value = get_call_keyword(call, "help")
+                            aliases_value = get_call_keyword(call, "aliases")
+                        else:
+                            base_name = get_name(call.args[0]) if call.args else None
+                            parser_name = get_call_arg(call, 1, "name")
+                            help_value = get_call_keyword(call, "help_text")
+                            aliases_value = None
                         if base_name not in subparser_paths:
                             continue
-                        parser_name = get_call_arg(call, 0, "name")
-                        help_value = get_call_keyword(call, "help")
-                        aliases_value = get_call_keyword(call, "aliases")
                         if parser_name is None:
                             continue
                         segment = str(eval_simple(parser_name, constants))
@@ -1080,6 +1089,18 @@ def render_readme(inventory: dict[str, Any]) -> str:
         "",
         "See `docs/dynamic-tool-selection.md` for the runtime contract, CLI flags, embedding-model configuration, and the boundary between existing tool keys and Python-only custom callables.",
         "",
+        "## Google Cloud Integration",
+        "",
+        "Harnessiq ships a dedicated Google Cloud deployment surface for running manifest-backed harnesses as Cloud Run jobs without introducing a second runtime model.",
+        "",
+        "- `harnessiq gcloud init` saves one JSON deploy config per logical agent under `~/.harnessiq/gcloud/<agent>.json`, including region, Artifact Registry, Cloud Run, Scheduler, model-selection, sink, and parameter settings.",
+        "- `harnessiq gcloud health` and `harnessiq gcloud credentials check` validate operator prerequisites such as the `gcloud` CLI, active auth, ADC, required APIs, and Secret Manager access.",
+        "- `harnessiq gcloud credentials ...` reuses repo-local harness credential bindings and syncs runtime secrets into Secret Manager through `status`, `sync`, `set`, and `remove` flows.",
+        "- Manifest-backed deploy specs are derived from the harness manifest plus saved profile state, so remote runs preserve model selection, runtime/custom parameters, adapter arguments, sink specs, provider families, and declared durable memory files.",
+        "- `build`, `deploy`, `schedule`, and `execute` cover the Cloud Build, Cloud Run Jobs, and Cloud Scheduler lifecycle, while `logs` and `cost` provide runtime observability and monthly cost estimation.",
+        "- The Cloud Run runtime wrapper syncs the harness memory directory to GCS before and after execution, preserving harness-native durable state rather than flattening everything into one blob.",
+        "- The GCloud command family emits JSON and supports `--dry-run` on the mutating operations, so it stays scriptable in CI and operator tooling.",
+        "",
         "## Live Snapshot",
         "",
         render_counts_table(inventory),
@@ -1339,8 +1360,34 @@ def expected_outputs() -> dict[Path, str]:
     }
 
 
-def write_outputs(outputs: dict[Path, str]) -> None:
+def existing_legacy_outputs() -> list[Path]:
+    detected: list[Path] = []
+    seen: set[Path] = set()
+
     for legacy_path in LEGACY_OUTPUTS:
+        for candidate in (legacy_path, legacy_path.resolve(strict=False)):
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if candidate.exists():
+                detected.append(candidate)
+
+    legacy_names = {path.name for path in LEGACY_OUTPUTS}
+    if ARTIFACTS_DIR.exists():
+        for candidate in ARTIFACTS_DIR.iterdir():
+            if candidate.name not in legacy_names:
+                continue
+            resolved = candidate.resolve(strict=False)
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            detected.append(candidate)
+
+    return detected
+
+
+def write_outputs(outputs: dict[Path, str]) -> None:
+    for legacy_path in {path.resolve(strict=False) for path in (*LEGACY_OUTPUTS, *existing_legacy_outputs())}:
         legacy_path.unlink(missing_ok=True)
     for path, content in outputs.items():
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -1352,7 +1399,7 @@ def check_outputs(outputs: dict[Path, str]) -> list[str]:
     for path, content in outputs.items():
         if not path.exists() or path.read_text(encoding="utf-8") != content:
             drifted.append(relative_path(path))
-    for legacy_path in LEGACY_OUTPUTS:
+    for legacy_path in existing_legacy_outputs():
         if legacy_path.exists():
             drifted.append(relative_path(legacy_path))
     return drifted

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -82,6 +82,11 @@ class DocsSyncTests(unittest.TestCase):
             }.issubset(top_level_commands)
         )
 
+    def test_inventory_includes_gcloud_command_family(self) -> None:
+        inventory = self.sync_repo_docs.build_inventory()
+        top_level_commands = {entry["command"] for entry in inventory["cli"]["top_level"]}
+        self.assertIn("harnessiq gcloud", top_level_commands)
+
     def test_inventory_matches_live_harness_manifests(self) -> None:
         inventory = self.sync_repo_docs.build_inventory()
         inventory_harnesses = {entry["manifest_id"]: entry for entry in inventory["harnesses"]}


### PR DESCRIPTION
## Summary

Add Google Cloud integration coverage to the repository README and fix the docs generator so the generated docs include the live `harnessiq gcloud` command family.

## What Changed

- add a dedicated Google Cloud Integration section to the generated README
- teach `scripts/sync_repo_docs.py` to recognize `_add_help_parser(...)` registrations used by the GCloud CLI
- regenerate `README.md`, `artifacts/commands.md`, and `artifacts/file_index.md` from the corrected inventory
- add a docs-sync regression test for the `harnessiq gcloud` command family
- harden legacy generated-artifact detection/removal in the docs sync script

## Files of Interest

- `scripts/sync_repo_docs.py`
- `README.md`
- `artifacts/commands.md`
- `artifacts/file_index.md`
- `tests/test_docs_sync.py`

## How To Test

1. Run `pytest tests/test_docs_sync.py tests/test_gcloud_cli.py -q`
2. Run `python scripts/sync_repo_docs.py --check`
3. Confirm the generated README includes the Google Cloud integration section and the `harnessiq gcloud` CLI row

## Risks

- Low risk; this only affects generated documentation and docs-sync coverage.
- The generated counts changed because the docs inventory now correctly includes the existing GCloud command family.
