### PR TITLE
Append Instagram search progress context

### DIFF
--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -51,6 +51,8 @@ from harnessiq.shared.tools import INSTAGRAM_SEARCH_KEYWORD, RegisteredTool, Too
 from harnessiq.toolset import get_tool
 from harnessiq.tools.instagram import create_instagram_tools
 from harnessiq.tools.registry import create_tool_registry
+from harnessiq.utils.ledger import new_run_id
+
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _MASTER_PROMPT_PATH = _PROMPTS_DIR / "master_prompt.md"
 _DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
@@ -462,6 +464,10 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         result = super()._execute_tool(tool_call)
         if tool_call.tool_key == INSTAGRAM_SEARCH_KEYWORD:
             self.refresh_parameters()
+            self._append_recent_search_context_entry(
+                keyword=tool_call.arguments.get("keyword"),
+                result=result,
+            )
         return result
 
     def _record_assistant_response(self, response: AgentModelResponse) -> None:
@@ -527,6 +533,33 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             self._attempted_search_keywords = self._attempted_search_keywords[
                 -self._config.recent_search_window :
             ]
+
+    def _append_recent_search_context_entry(
+        self,
+        *,
+        keyword: Any,
+        result: ToolResult,
+    ) -> None:
+        cleaned_keyword = keyword.strip() if isinstance(keyword, str) else ""
+        recent_searches = self._recent_search_keywords_for_context()
+        if not recent_searches and not cleaned_keyword:
+            return
+        output = result.output if isinstance(result.output, Mapping) else {}
+        payload = {
+            "active_icp": self._current_icp_description(),
+            "keyword": cleaned_keyword,
+            "recent_searches": list(recent_searches),
+            "status": str(output.get("status", "unknown")),
+        }
+        if "error" in output:
+            payload["error"] = str(output["error"])
+        self._transcript.append(
+            AgentTranscriptEntry(
+                entry_type="context",
+                label="Recent Searches",
+                content=json.dumps(payload, indent=2, sort_keys=True),
+            )
+        )
 
     def _activate_icp(self, icp_index: int) -> None:
         self._active_icp_index = icp_index

--- a/memory/fix-instagram-recent-searches/clarifications.md
+++ b/memory/fix-instagram-recent-searches/clarifications.md
@@ -1,0 +1,1 @@
+No material ambiguities remained after Phase 1. Direct reproduction showed the durable `Recent Searches` parameter already updates correctly; the missing behavior is transcript/context-window visibility for Instagram search progress.

--- a/memory/fix-instagram-recent-searches/internalization.md
+++ b/memory/fix-instagram-recent-searches/internalization.md
@@ -1,0 +1,27 @@
+### 1a: Structural Survey
+
+- The repository is a Python package under `harnessiq/` with agent-specific harnesses in `harnessiq/agents/`, shared domain models and file-backed memory stores in `harnessiq/shared/`, tool definitions and handlers in `harnessiq/tools/`, CLI adapters/builders in `harnessiq/cli/`, and regression coverage in `tests/`.
+- `harnessiq/agents/base/agent.py` owns the generic request loop. It builds each model request from durable parameter sections plus the rolling transcript, processes tool calls, records transcript entries, and supports compaction-class context updates.
+- `harnessiq/agents/base/agent_helpers.py` defines how context windows are materialized. `entry_type="context"` transcript entries are first-class citizens and render into the transcript zone as `[CONTEXT: ...]` blocks.
+- `harnessiq/agents/instagram/agent.py` specializes the base loop for the Instagram keyword harness. It persists ICP-scoped search history through `InstagramMemoryStore`, refreshes the `Recent Searches` parameter section after each `instagram.search_keyword` call, and intentionally suppresses raw Instagram search tool calls/results from the transcript.
+- `harnessiq/shared/instagram.py` contains the persistent Instagram memory model. ICP states keep their own `searches` lists, and `read_recent_searches()` already returns the expected per-ICP tail used by the agent’s parameter sections.
+- `harnessiq/tools/instagram/operations.py` defines `instagram.search_keyword`. The handler validates input, checks duplicate searches for the active ICP, persists a search record on success, and returns a compact status payload.
+- `tests/test_instagram_agent.py` already covers parameter refresh after one search, failed-search fallback behavior, ICP scoping, and transcript suppression of raw Instagram tool calls/results. It does not currently assert that the context window shows incremental search progress across multiple search cycles.
+
+### 1b: Task Cross-Reference
+
+- The user-reported bug maps to the boundary between durable parameter refresh and transcript/context-window visibility inside `harnessiq/agents/instagram/agent.py`.
+- The `Recent Searches` parameter section is built from `_recent_search_keywords_for_context()` and is refreshed inside `_execute_tool()` after every Instagram search. A direct reproduction confirms that request 2 sees the first keyword and request 3 sees both first and second keywords.
+- The visible gap is that `_record_assistant_response()` and `_record_tool_result()` both suppress `instagram.search_keyword` events, leaving the transcript empty during search-only cycles. As a result, the context window does not append any search-progress artifact even though the parameter section is refreshed.
+- The least invasive fix surface is `harnessiq/agents/instagram/agent.py`: keep suppressing noisy raw tool payloads, but append a compact transcript-level context snapshot after each Instagram search tool execution so the next request and any trace graph show evolving search history.
+- `tests/test_instagram_agent.py` needs new regression coverage for sequential search cycles and updated expectations for post-search transcript state.
+
+### 1c: Assumption & Risk Inventory
+
+- Assumption: the user wants the context window itself to show incremental Instagram search progress, not merely the durable parameter block to be refreshed invisibly.
+- Assumption: preserving suppression of raw `instagram.search_keyword` tool calls/results is still desirable because full tool payloads are noisy; a compact context snapshot is the intended compromise.
+- Risk: appending a transcript snapshot after every search increases token usage. The snapshot must stay small and deterministic.
+- Risk: changing transcript behavior will invalidate existing tests that assert the transcript remains empty after a search. Those expectations need to be updated deliberately rather than silently loosened.
+- Risk: if the snapshot is appended before parameter refresh or before attempted-keyword bookkeeping, failed searches would still look stale. The new entry must be created only after the agent refreshes its recent-search state.
+
+Phase 1 complete

--- a/memory/fix-instagram-recent-searches/tickets/index.md
+++ b/memory/fix-instagram-recent-searches/tickets/index.md
@@ -1,0 +1,1 @@
+1. `ticket-1.md` - Append compact Instagram search-progress snapshots into the transcript context window after each search.

--- a/memory/fix-instagram-recent-searches/tickets/ticket-1-critique.md
+++ b/memory/fix-instagram-recent-searches/tickets/ticket-1-critique.md
@@ -1,0 +1,5 @@
+## Self-Critique
+
+- Initial risk: re-enabling raw Instagram tool call/result transcript entries would have solved visibility, but it would also have reintroduced noisy payloads and broken the existing low-noise harness design.
+- Adjustment made: used a compact `entry_type="context"` snapshot instead. It carries only the active ICP, requested keyword, status, current recent-search window, and error text when relevant.
+- Result: the context window now grows in a traceable way, while the transcript still avoids bulky search payloads and the durable `Recent Searches` parameter section remains the source of truth.

--- a/memory/fix-instagram-recent-searches/tickets/ticket-1-quality.md
+++ b/memory/fix-instagram-recent-searches/tickets/ticket-1-quality.md
@@ -1,0 +1,25 @@
+## Static Analysis
+
+- Manually reviewed [harnessiq/agents/instagram/agent.py](C:/Users/422mi/HarnessHub/harnessiq/agents/instagram/agent.py) and [tests/test_instagram_agent.py](C:/Users/422mi/HarnessHub/tests/test_instagram_agent.py) for consistency with existing Instagram-agent conventions.
+- Kept the change additive: raw Instagram tool call/result transcript suppression remains intact, and only a compact `context` entry is appended after each search.
+
+## Type Checking
+
+- Ran `python -m compileall harnessiq/agents/instagram/agent.py tests/test_instagram_agent.py`
+- Result: passed
+
+## Unit Tests
+
+- Ran `python -m pytest tests/test_instagram_agent.py`
+- Result: `17 passed`
+
+## Integration / Contract Tests
+
+- No separate integration suite exists for this narrow transcript-behavior change.
+- Existing agent-level regression coverage now exercises sequential search cycles and transcript/context growth.
+
+## Smoke Verification
+
+- Ran a local fake-model reproduction with two sequential `instagram.search_keyword` calls.
+- Observed request 2 include one `Recent Searches` context entry and request 3 include a second cumulative entry with both keywords.
+- This confirms the context window now shows incremental search progress between search turns.

--- a/memory/fix-instagram-recent-searches/tickets/ticket-1.md
+++ b/memory/fix-instagram-recent-searches/tickets/ticket-1.md
@@ -1,0 +1,36 @@
+Title: Append Instagram recent-search progress to the context window
+
+Intent: Make the Instagram discovery loop expose search progress in the live context window after each `instagram.search_keyword` call so successive search turns visibly build on prior search attempts.
+
+Scope:
+- Update the Instagram agent to append a compact transcript/context entry after each Instagram search tool execution.
+- Preserve the existing durable `Recent Searches` parameter refresh and the suppression of raw Instagram search tool call/result transcript noise.
+- Add regression tests for sequential search cycles and refreshed transcript state.
+- Do not change the Instagram memory schema, CLI contract, or raw search tool payload shape.
+
+Relevant Files:
+- `harnessiq/agents/instagram/agent.py`: append a compact search-progress context entry after each Instagram search tool execution.
+- `tests/test_instagram_agent.py`: cover multi-search context growth and updated transcript expectations.
+
+Approach: Keep the durable parameter block as the source of truth and add a lightweight `entry_type="context"` transcript note after each Instagram search finishes. The note should include the active ICP, the tool-call outcome status, the just-attempted keyword, and the current merged recent-search window. This gives the model and any runtime graph an append-only, low-noise record of progress without reintroducing full raw tool payloads.
+
+Assumptions:
+- The user-visible problem is lack of transcript/context-window progression, not incorrect persistence in `InstagramMemoryStore`.
+- A compact context snapshot is preferable to re-enabling full Instagram tool call/result transcript entries.
+
+Acceptance Criteria:
+- [ ] After one Instagram search, the next model request includes a transcript context entry describing the recent-search window.
+- [ ] After multiple sequential Instagram searches in the same ICP, later model requests include cumulative recent-search state in transcript context entries.
+- [ ] Raw `instagram.search_keyword` tool call/result entries remain suppressed from the transcript.
+- [ ] Existing single-search and failed-search flows still refresh `Recent Searches` correctly.
+
+Verification Steps:
+- Static analysis: inspect changed files for consistency with existing agent conventions.
+- Type checking: run `python -m compileall harnessiq/agents/instagram/agent.py tests/test_instagram_agent.py`.
+- Unit tests: run `python -m pytest tests/test_instagram_agent.py`.
+- Integration tests: none beyond the targeted harness regression coverage for this change.
+- Smoke verification: run a small in-process fake-model reproduction and inspect the emitted request transcript.
+
+Dependencies: None
+
+Drift Guard: This ticket must not redesign Instagram search persistence, touch unrelated agents, or expose bulky Instagram tool payloads back into the transcript. The change is limited to making recent-search progress visible in the context window between search turns.

--- a/tests/test_instagram_agent.py
+++ b/tests/test_instagram_agent.py
@@ -172,11 +172,65 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertEqual(backend.calls, [("fitness coach", 5)])
             self.assertEqual(model.requests[1].parameter_sections[0].content, "fitness creators")
             self.assertEqual(model.requests[1].parameter_sections[2].content, "fitness coach")
-            self.assertEqual(model.requests[1].transcript, ())
+            self.assertEqual(len(model.requests[1].transcript), 1)
+            self.assertEqual(model.requests[1].transcript[0].entry_type, "context")
+            self.assertEqual(model.requests[1].transcript[0].label, "Recent Searches")
+            self.assertEqual(
+                json.loads(model.requests[1].transcript[0].content),
+                {
+                    "active_icp": "fitness creators",
+                    "keyword": "fitness coach",
+                    "recent_searches": ["fitness coach"],
+                    "status": "searched",
+                },
+            )
             self.assertFalse(any(entry.entry_type == "tool_call" for entry in agent.transcript))
             self.assertFalse(any(entry.entry_type == "tool_result" for entry in agent.transcript))
             database = json.loads(Path(temp_dir, "lead_database.json").read_text(encoding="utf-8"))
             self.assertEqual(database["emails"], ["creator@example.com"])
+
+    def test_sequential_searches_append_recent_search_context_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model = _FakeModel(
+                [
+                    AgentModelResponse(
+                        assistant_message="Search fitness coach.",
+                        tool_calls=(ToolCall(tool_key="instagram.search_keyword", arguments={"keyword": "fitness coach"}),),
+                        should_continue=True,
+                    ),
+                    AgentModelResponse(
+                        assistant_message="Search pilates creator.",
+                        tool_calls=(ToolCall(tool_key="instagram.search_keyword", arguments={"keyword": "pilates creator"}),),
+                        should_continue=True,
+                    ),
+                    AgentModelResponse(assistant_message="done", should_continue=False),
+                ]
+            )
+            backend = _FakeSearchBackend(_build_execution())
+            agent = InstagramKeywordDiscoveryAgent(
+                model=model,
+                search_backend=backend,
+                memory_path=temp_dir,
+                icp_descriptions=("fitness creators",),
+            )
+
+            result = agent.run(max_cycles=3)
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(model.requests[1].parameter_sections[2].content, "fitness coach")
+            self.assertEqual(model.requests[2].parameter_sections[2].content, "fitness coach, pilates creator")
+            self.assertEqual(len(model.requests[1].transcript), 1)
+            self.assertEqual(len(model.requests[2].transcript), 2)
+            self.assertEqual(
+                json.loads(model.requests[1].transcript[0].content)["recent_searches"],
+                ["fitness coach"],
+            )
+            self.assertEqual(
+                json.loads(model.requests[2].transcript[-1].content)["recent_searches"],
+                ["fitness coach", "pilates creator"],
+            )
+            self.assertFalse(any(entry.entry_type == "tool_call" for entry in model.requests[2].transcript))
+            self.assertFalse(any(entry.entry_type == "tool_result" for entry in model.requests[2].transcript))
 
     def test_failed_search_attempt_still_updates_recent_searches_without_persisted_history(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- append a compact `Recent Searches` context entry after each `instagram.search_keyword` execution
- keep raw Instagram tool call/result transcript entries suppressed so the context stays low-noise
- add regression coverage for sequential search cycles and refreshed transcript state

## Verification
- `python -m compileall harnessiq/agents/instagram/agent.py tests/test_instagram_agent.py`
- `python -m pytest tests/test_instagram_agent.py`