### PR TITLE
Add HarnessIQ CLI skill docs for built-in agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Harnessiq ships a dedicated Google Cloud deployment surface for running manifest
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 10 |
-| Test modules | 123 |
+| Test modules | 124 |
 
 ## Agent Matrix
 

--- a/artifacts/file_index.md
+++ b/artifacts/file_index.md
@@ -15,7 +15,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 10 |
-| Test modules | 123 |
+| Test modules | 124 |
 
 ## Codebase Standards
 
@@ -32,11 +32,16 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 
 | Path | Kind | Responsibility |
 | --- | --- | --- |
+| `.harnessiq/` | generated/cache | Fallback local HarnessIQ home used by the ledger/output-sink runtime when the preferred home path is not writable. |
+| `.worktrees/` | local state | Git worktree checkouts used for isolated implementation branches; local-only and not part of the shipped package. |
 | `artifacts/` | repo docs | Generated and curated repository reference artifacts. |
+| `build/` | generated/cache | Setuptools build output; generated, not part of the live source tree. |
 | `docs/` | repo docs | Focused usage and architecture notes for the package. |
 | `harnessiq/` | source | Live SDK package source. |
+| `harnessiq.egg-info/` | generated/cache | Packaging metadata emitted by local builds. |
 | `memory/` | local state | Task artifacts plus durable agent runtime state; not part of the shipped package. |
 | `scripts/` | repo tooling | Repository maintenance and generation scripts. |
+| `src/` | generated/cache | Legacy or generated residue in this checkout; not the authoritative package source. |
 | `tests/` | source | unittest coverage for runtime, CLI, providers, and tools. |
 
 ## Package Layout
@@ -44,9 +49,9 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Path | Live Subpackages | Responsibility |
 | --- | --- | --- |
 | `harnessiq/agents/` | apollo, base, email, exa, exa_outreach, instagram, instantly, knowt, leads, linkedin, mission_driven, outreach, prospecting, provider_base, research_sweep, spawn_specialized_subagents | Shared runtime bases plus the concrete harness packages exported by the SDK. |
-| `harnessiq/cli/` | adapters, builders, commands, email, exa_outreach, gcloud, instagram, leads, ledger, linkedin, master_prompts, models, prospecting, research_sweep, runners, stats | Argparse entrypoints and command-family modules for harness management plus ledger/output-sink operations. |
+| `harnessiq/cli/` | adapters, builders, commands, email, exa_outreach, gcloud, instagram, leads, ledger, linkedin, master_prompts, models, prospecting, research_sweep, runners, skills, stats | Argparse entrypoints and command-family modules for harness management plus ledger/output-sink operations. |
 | `harnessiq/config/` | provider_credentials | Environment loading, credential binding, and provider-credential spec models. |
-| `harnessiq/evaluations/` | - | Pytest-first evaluation helpers, lightweight scoring helpers, and plugin support for tagged eval runs. |
+| `harnessiq/evaluations/` | correctness, efficiency, output, tool_use | Pytest-first evaluation helpers, lightweight scoring helpers, and plugin support for tagged eval runs. |
 | `harnessiq/integrations/` | - | Concrete external runtime adapters such as Playwright backends and model factories. |
 | `harnessiq/master_prompts/` | prompts | Packaged prompt assets and prompt registry helpers. |
 | `harnessiq/providers/` | anthropic, apollo, arcads, arxiv, attio, browser_use, coresignal, creatify, exa, expandi, gcloud, gemini, google_drive, grok, hunter, inboxapp, instantly, leadiq, lemlist, lusha, openai, outreach, paperclip, peopledatalabs, phantombuster, playwright, proxycurl, salesforge, serper, smartlead, snovio, zerobounce, zoominfo | Model-provider adapters, external service clients, output-sink transport clients, and Playwright runtime support. |
@@ -190,7 +195,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 
 ## Test Surface
 
-`tests/` currently contains 123 test modules. The table below groups them by dominant responsibility.
+`tests/` currently contains 124 test modules. The table below groups them by dominant responsibility.
 
 | Area | Count | Examples |
 | --- | --- | --- |
@@ -198,5 +203,5 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | cli | 12 | `tests/test_email_cli.py`, `tests/test_exa_outreach_cli.py`, `tests/test_gcloud_cli.py` |
 | ledger | 1 | `tests/test_output_sinks.py` |
 | providers | 32 | `tests/test_anthropic_provider.py`, `tests/test_apollo_provider.py`, `tests/test_arcads_provider.py` |
-| support | 41 | `tests/test_cli_builders.py`, `tests/test_cli_common.py`, `tests/test_cli_environment.py` |
+| support | 42 | `tests/test_cli_builders.py`, `tests/test_cli_common.py`, `tests/test_cli_environment.py` |
 | tools | 16 | `tests/test_context_compaction_tools.py`, `tests/test_context_window_tools.py`, `tests/test_general_tools.py` |

--- a/harnessiq/cli/skills/README.md
+++ b/harnessiq/cli/skills/README.md
@@ -1,0 +1,144 @@
+# HarnessIQ CLI Skills
+
+This directory contains packaged markdown skill files for every built-in HarnessIQ harness. Each file is a concrete CLI playbook: what the harness does, which durable files it keeps, how to prepare/configure it, how to run it with different levels of customization, and how to inspect or export the results later.
+
+## Shared Workflow
+
+### 1. Install HarnessIQ and choose a durable working root
+
+Use the published package:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install harnessiq
+```
+
+Or install the local checkout while you are developing against unreleased code:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -e C:\Users\422mi\HarnessHub
+```
+
+Many browser-backed harnesses also need Playwright browsers installed:
+
+```powershell
+python -m playwright install chromium
+```
+
+For each harness, create a durable root folder that will hold the harness memory, any ledger exports, and other run artifacts. The per-agent skill files below show a concrete folder layout for each harness.
+
+### 2. Inspect the live harness contract before you configure it
+
+The manifest-backed inspect command is the fastest way to verify the current CLI surface, providers, runtime parameters, and memory files for any built-in harness:
+
+```powershell
+harnessiq inspect instagram
+harnessiq inspect mission_driven
+harnessiq inspect spawn_specialized_subagents
+```
+
+Use the manifest ID with `inspect`, even when the harness also has a friendlier top-level command such as `outreach` or `research-sweep`.
+
+### 3. Prepare memory before running
+
+Every harness persists durable state. Dedicated command families expose `prepare` under the command family itself:
+
+```powershell
+harnessiq instagram prepare --agent ig-demo --memory-root .\memory\instagram
+harnessiq leads prepare --agent outbound-a --memory-root .\memory\leads
+```
+
+Generic harnesses use the platform-first manifest surface:
+
+```powershell
+harnessiq prepare knowt --agent knowt-a --memory-root .\memory\knowt
+harnessiq prepare mission_driven --agent mission-a --memory-root .\memory\mission_driven --mission-goal "Build a docs site" --mission-type app_build
+```
+
+### 4. Persist reusable credentials
+
+When a harness depends on provider credentials, bind environment variables to the harness/profile once and reuse them later:
+
+```powershell
+harnessiq credentials bind email --agent campaign-a --memory-root .\memory\email --env resend.api_key=RESEND_API_KEY
+harnessiq credentials bind knowt --agent knowt-a --memory-root .\memory\knowt --env creatify.api_id=CREATIFY_API_ID --env creatify.api_key=CREATIFY_API_KEY
+```
+
+Inspect or validate the stored bindings with:
+
+```powershell
+harnessiq credentials show email --agent campaign-a --memory-root .\memory\email
+harnessiq credentials test knowt --agent knowt-a --memory-root .\memory\knowt
+```
+
+Playwright/browser-backed harnesses typically do not require API credential bindings, but they may require browser bootstrap steps such as `init-browser`.
+
+### 5. Reuse model selection with profiles
+
+Most run commands accept either `--model provider:model_name`, `--profile <name>`, or `--model-factory module:callable`.
+
+Persist a reusable profile when you do not want to repeat model settings:
+
+```powershell
+harnessiq models add --name fast-grok --model grok:grok-4-1-fast-reasoning --reasoning-effort high
+harnessiq models list
+```
+
+Then use it in runs:
+
+```powershell
+harnessiq linkedin run --agent candidate-a --memory-root .\memory\linkedin --profile fast-grok --browser-tools-factory myproject.browser:create_tools
+```
+
+### 6. Shared run-time controls
+
+Across the CLI you will see the same control patterns repeatedly:
+
+- `--runtime-param KEY=VALUE`: override one persisted typed runtime parameter for this run only.
+- `--custom-param KEY=VALUE`: override one persisted typed or open-ended custom parameter for this run only when the harness supports it.
+- `--sink kind:value` or `--sink kind:key=value,key=value`: add a per-run output sink override for harnesses that expose sink support.
+- `--approval`, `--allowed-tools`, `--dynamic-tools`, `--dynamic-tool-candidates`, `--dynamic-tool-top-k`, `--dynamic-tool-embedding-model`: control tool approval and dynamic tool selection on supported run commands.
+- `--resume` and `--run <N>`: available on the generic persisted-run harnesses such as `mission_driven` and `spawn_specialized_subagents`.
+
+### 7. Export, report, logs, and stats
+
+Most harnesses emit useful results into the local audit ledger. Common post-run commands:
+
+```powershell
+harnessiq export --format json --flatten-outputs --ledger-path .\ledger\instagram.jsonl
+harnessiq report --format markdown --ledger-path .\ledger\instagram.jsonl
+harnessiq logs
+harnessiq stats summary
+```
+
+`export` supports `json`, `jsonl`, `csv`, and `markdown`. `report` supports `markdown` and `json`.
+
+### 8. Output sink connections
+
+If you want runs to write to shared sinks such as Linear, Slack, Notion, MongoDB, or Supabase, configure a connection once:
+
+```powershell
+harnessiq connect linear
+harnessiq connections list
+harnessiq connections test --help
+```
+
+Then pass per-run `--sink` overrides on harnesses that support them.
+
+## Built-In Harness Skills
+
+| Harness | CLI Surface | Skill File |
+| --- | --- | --- |
+| Exa Outreach | `harnessiq outreach ...` plus `harnessiq inspect exa_outreach` | [`exa_outreach.md`](./exa_outreach.md) |
+| Email Campaign | `harnessiq email ...` plus `harnessiq inspect email` | [`email.md`](./email.md) |
+| Instagram Keyword Discovery | `harnessiq instagram ...` plus `harnessiq inspect instagram` | [`instagram.md`](./instagram.md) |
+| Knowt Content Creator | `harnessiq prepare/run/show knowt ...` plus `harnessiq inspect knowt` | [`knowt.md`](./knowt.md) |
+| Leads Agent | `harnessiq leads ...` plus `harnessiq inspect leads` | [`leads.md`](./leads.md) |
+| LinkedIn Job Applier | `harnessiq linkedin ...` plus `harnessiq inspect linkedin` | [`linkedin.md`](./linkedin.md) |
+| Mission Driven | `harnessiq prepare/run/show mission_driven ...` plus `harnessiq inspect mission_driven` | [`mission_driven.md`](./mission_driven.md) |
+| Google Maps Prospecting | `harnessiq prospecting ...` plus `harnessiq inspect prospecting` | [`prospecting.md`](./prospecting.md) |
+| Research Sweep | `harnessiq research-sweep ...` plus `harnessiq inspect research_sweep` | [`research_sweep.md`](./research_sweep.md) |
+| Spawn Specialized Subagents | `harnessiq prepare/run/show spawn_specialized_subagents ...` plus `harnessiq inspect spawn_specialized_subagents` | [`spawn_specialized_subagents.md`](./spawn_specialized_subagents.md) |

--- a/harnessiq/cli/skills/__init__.py
+++ b/harnessiq/cli/skills/__init__.py
@@ -1,0 +1,2 @@
+"""Bundled CLI skill documentation for built-in HarnessIQ harnesses."""
+

--- a/harnessiq/cli/skills/email.md
+++ b/harnessiq/cli/skills/email.md
@@ -1,0 +1,144 @@
+# Email Campaign
+
+`Email Campaign` is the built-in HarnessIQ harness for pulling a recipient batch from MongoDB, selecting the unsent records, and sending or staging campaign output through the email workflow.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect email` |
+| CLI family | `harnessiq email` |
+| Default memory root | `memory/email` |
+| Providers | `resend` |
+| Runtime parameters | `max_tokens`, `reset_threshold`, `batch_size`, `recipient_limit` |
+| Custom parameters | open-ended `--custom-param KEY=VALUE` payload |
+| Main outputs | `campaign`, `delivery_records`, `recipient_batch` |
+
+## Durable Files
+
+The harness persists its working state under `memory/email/<agent>/` by default.
+
+- `source_config.json`: MongoDB source configuration and recipient lookup settings.
+- `campaign_config.json`: sender metadata plus the authored campaign body/subject.
+- `sent_history.json`: append-only record of which recipients were already sent.
+- `runtime_parameters.json`: persisted typed overrides for `max_tokens`, `reset_threshold`, `batch_size`, and `recipient_limit`.
+- `custom_parameters.json`: open-ended custom payload that you can pass with `--custom-param`.
+- `agent_identity.txt`: optional system-identity override.
+- `additional_prompt.txt`: free-form extra prompt content.
+
+## Prepare and Configure
+
+Create the durable memory folder first:
+
+```powershell
+$Root = Join-Path (Get-Location) 'email_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\email" | Out-Null
+
+harnessiq email prepare --agent campaign-a --memory-root "$Root\memory\email"
+```
+
+Persist the MongoDB source, campaign body, and runtime knobs:
+
+```powershell
+harnessiq email configure `
+  --agent campaign-a `
+  --memory-root "$Root\memory\email" `
+  --mongodb-uri-env MONGODB_URI `
+  --mongodb-database growth `
+  --mongodb-collection prospects `
+  --source-filter-text '{\"status\":\"ready_to_email\"}' `
+  --email-path email `
+  --name-path full_name `
+  --from-address 'HarnessIQ <ops@example.com>' `
+  --reply-to ops@example.com `
+  --subject 'Quick intro from HarnessIQ' `
+  --text-body-file .\campaigns\intro.txt `
+  --html-body-file .\campaigns\intro.html `
+  --runtime-param batch_size=50 `
+  --runtime-param recipient_limit=200 `
+  --custom-param campaign_owner='\"growth\"'
+```
+
+If you want the harness to use a different authoring voice, add:
+
+```powershell
+--agent-identity-file .\prompts\email_identity.txt `
+--additional-prompt-file .\prompts\email_notes.txt
+```
+
+## Credentials
+
+Bind the Resend API key once:
+
+```powershell
+harnessiq credentials bind email `
+  --agent campaign-a `
+  --memory-root "$Root\memory\email" `
+  --env resend.api_key=RESEND_API_KEY
+```
+
+Validate the stored binding later:
+
+```powershell
+harnessiq credentials show email --agent campaign-a --memory-root "$Root\memory\email"
+harnessiq credentials test email --agent campaign-a --memory-root "$Root\memory\email"
+```
+
+## Run Patterns
+
+Run with an inline provider-backed model:
+
+```powershell
+harnessiq email run `
+  --agent campaign-a `
+  --memory-root "$Root\memory\email" `
+  --model openai:gpt-5.4 `
+  --max-cycles 25
+```
+
+Run with a reusable model profile and a one-off runtime override:
+
+```powershell
+harnessiq email run `
+  --agent campaign-a `
+  --memory-root "$Root\memory\email" `
+  --profile fast-grok `
+  --runtime-param batch_size=25 `
+  --custom-param send_reason='\"follow_up_wave_2\"'
+```
+
+Shared safety/tool controls are available here too:
+
+```powershell
+harnessiq email run `
+  --agent campaign-a `
+  --memory-root "$Root\memory\email" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools reasoning.*,resend.* `
+  --dynamic-tools `
+  --dynamic-tool-top-k 12
+```
+
+## Inspect and Export
+
+Preview the deduplicated unsent batch without running the full harness:
+
+```powershell
+harnessiq email get-recipients --agent campaign-a --memory-root "$Root\memory\email" --limit 20
+```
+
+Inspect the currently persisted state:
+
+```powershell
+harnessiq email show --agent campaign-a --memory-root "$Root\memory\email"
+```
+
+Export or report on ledger output after runs:
+
+```powershell
+harnessiq export --ledger-path "$Root\ledger\email.jsonl" --format csv --flatten-outputs > "$Root\exports\email.csv"
+harnessiq report --ledger-path "$Root\ledger\email.jsonl" --format markdown > "$Root\exports\email-report.md"
+```

--- a/harnessiq/cli/skills/exa_outreach.md
+++ b/harnessiq/cli/skills/exa_outreach.md
@@ -1,0 +1,116 @@
+# Exa Outreach
+
+`Exa Outreach` is the built-in HarnessIQ harness for finding leads from an Exa query and optionally selecting/sending email templates through Resend.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect exa_outreach` |
+| CLI family | `harnessiq outreach` |
+| Default memory root | `memory/outreach` |
+| Providers | `exa`, `resend` |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | no typed custom parameters |
+| Main outputs | `search_query`, `leads_found`, `emails_sent` |
+
+## Durable Files
+
+The harness persists its working state under `memory/outreach/<agent>/`.
+
+- `query_config.json`: the saved search query and runtime settings.
+- `agent_identity.txt`: optional system-identity override.
+- `additional_prompt.txt`: free-form extra operator guidance.
+- `runs/`: run-specific durable output and bookkeeping.
+
+## Prepare and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'outreach_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\outreach" | Out-Null
+
+harnessiq outreach prepare --agent outbound-a --memory-root "$Root\memory\outreach"
+
+harnessiq outreach configure `
+  --agent outbound-a `
+  --memory-root "$Root\memory\outreach" `
+  --query-file .\queries\series_a_revops.txt `
+  --runtime-param max_tokens=90000 `
+  --agent-identity-file .\prompts\outreach_identity.txt `
+  --additional-prompt-file .\prompts\outreach_constraints.txt
+```
+
+`query-file` or `query-text` should describe the audience you want Exa to search for.
+
+## Credentials and Required Factories
+
+At minimum, a full outreach run needs Exa credentials and usually Resend credentials plus email-template data.
+
+Reusable bindings:
+
+```powershell
+harnessiq credentials bind exa_outreach `
+  --agent outbound-a `
+  --memory-root "$Root\memory\outreach" `
+  --env exa.api_key=EXA_API_KEY `
+  --env resend.api_key=RESEND_API_KEY
+```
+
+The `run` command also requires factory hooks:
+
+- `--exa-credentials-factory module:callable`: required.
+- `--resend-credentials-factory module:callable`: required unless `--search-only`.
+- `--email-data-factory module:callable`: required unless `--search-only`; returns the email-template data used by the harness.
+
+## Run Patterns
+
+Search-only lead discovery:
+
+```powershell
+harnessiq outreach run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\outreach" `
+  --model grok:grok-4-1-fast-reasoning `
+  --exa-credentials-factory myproject.creds:create_exa_credentials `
+  --search-only `
+  --sink "jsonl:$Root\ledger\outreach-search.jsonl" `
+  --max-cycles 30
+```
+
+Full outreach flow with email templates:
+
+```powershell
+harnessiq outreach run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\outreach" `
+  --profile fast-grok `
+  --exa-credentials-factory myproject.creds:create_exa_credentials `
+  --resend-credentials-factory myproject.creds:create_resend_credentials `
+  --email-data-factory myproject.outreach:create_email_templates `
+  --sink "jsonl:$Root\ledger\outreach.jsonl" `
+  --max-cycles 50
+```
+
+You can still use the shared tool/runtime controls:
+
+```powershell
+harnessiq outreach run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\outreach" `
+  --profile fast-grok `
+  --exa-credentials-factory myproject.creds:create_exa_credentials `
+  --search-only `
+  --approval on-request `
+  --allowed-tools exa.*,reasoning.* `
+  --dynamic-tools
+```
+
+## Inspect and Export
+
+```powershell
+harnessiq outreach show --agent outbound-a --memory-root "$Root\memory\outreach"
+harnessiq export --ledger-path "$Root\ledger\outreach.jsonl" --format json --flatten-outputs > "$Root\exports\outreach.json"
+harnessiq report --ledger-path "$Root\ledger\outreach.jsonl" --format markdown > "$Root\exports\outreach-report.md"
+```

--- a/harnessiq/cli/skills/instagram.md
+++ b/harnessiq/cli/skills/instagram.md
@@ -1,0 +1,116 @@
+# Instagram Keyword Discovery
+
+`Instagram Keyword Discovery` is the built-in HarnessIQ harness for rotating through one or more ICP definitions, searching Instagram, and persisting deduplicated leads/emails over time.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect instagram` |
+| CLI family | `harnessiq instagram` |
+| Default memory root | `memory/instagram` |
+| Providers | `playwright` |
+| Runtime parameters | `max_tokens`, `recent_result_window`, `recent_search_window`, `reset_threshold`, `search_result_limit` |
+| Custom parameters | open-ended `--custom-param KEY=VALUE` payload |
+| Main outputs | `emails`, `leads`, `search_history` |
+
+## Durable Files
+
+The harness persists its working state under `memory/instagram/<agent>/`.
+
+- `icp_profiles.json`: the persisted ICP descriptions.
+- `search_history.json`: legacy flat search history kept for compatibility.
+- `run_state.json`: current multi-ICP run state.
+- `icps/*.json`: per-ICP history and completion state.
+- `lead_database.json`: deduplicated persisted leads/emails.
+- `runtime_parameters.json`: saved `max_tokens`, `recent_result_window`, `recent_search_window`, `reset_threshold`, and `search_result_limit`.
+- `custom_parameters.json`: open-ended custom payload from `--custom-param`.
+- `agent_identity.txt`: optional system-identity override.
+- `additional_prompt.txt`: extra prompt guidance.
+
+## Prepare and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'vidbyte_leads'
+New-Item -ItemType Directory -Force -Path "$Root\memory\instagram" | Out-Null
+New-Item -ItemType Directory -Force -Path "$Root\ledger" | Out-Null
+New-Item -ItemType Directory -Force -Path "$Root\exports" | Out-Null
+
+harnessiq instagram prepare --agent ig-ai-edu --memory-root "$Root\memory\instagram"
+
+harnessiq instagram configure `
+  --agent ig-ai-edu `
+  --memory-root "$Root\memory\instagram" `
+  --icp 'AI educational creators who produce content about artificial intelligence, machine learning, LLMs, and AI-powered learning tools' `
+  --icp 'STEM creators who explain science and engineering concepts for students and professionals' `
+  --runtime-param search_result_limit=5 `
+  --runtime-param recent_search_window=10 `
+  --runtime-param recent_result_window=10 `
+  --custom-param market='\"education\"' `
+  --additional-prompt-file .\prompts\instagram_notes.txt
+```
+
+There is no API credential binding requirement here, but most real runs use the default Playwright search backend and therefore need Playwright Chromium installed.
+
+## Run Patterns
+
+Minimal run using the default browser-backed search backend:
+
+```powershell
+harnessiq instagram run `
+  --agent ig-ai-edu `
+  --memory-root "$Root\memory\instagram" `
+  --model openai:gpt-5.4 `
+  --search-backend-factory harnessiq.integrations.instagram_playwright:create_search_backend `
+  --max-cycles 100
+```
+
+Run with a reusable profile and per-run ICP override:
+
+```powershell
+harnessiq instagram run `
+  --agent ig-ai-edu `
+  --memory-root "$Root\memory\instagram" `
+  --profile fast-grok `
+  --icp 'Founders and operators who post practical AI workflow content' `
+  --runtime-param search_result_limit=8 `
+  --custom-param campaign='\"spring_launch\"'
+```
+
+Run with shared tool controls:
+
+```powershell
+harnessiq instagram run `
+  --agent ig-ai-edu `
+  --memory-root "$Root\memory\instagram" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools instagram.*,reasoning.* `
+  --dynamic-tools `
+  --dynamic-tool-top-k 10
+```
+
+## Inspect and Export
+
+Return the currently persisted discovered emails:
+
+```powershell
+harnessiq instagram get-emails --agent ig-ai-edu --memory-root "$Root\memory\instagram"
+```
+
+Inspect the durable state:
+
+```powershell
+harnessiq instagram show --agent ig-ai-edu --memory-root "$Root\memory\instagram"
+```
+
+Export the ledger after runs:
+
+```powershell
+harnessiq export --ledger-path "$Root\ledger\ig-ai-edu.jsonl" --format csv --flatten-outputs > "$Root\exports\ig-ai-edu.csv"
+harnessiq report --ledger-path "$Root\ledger\ig-ai-edu.jsonl" --format markdown > "$Root\exports\ig-ai-edu-report.md"
+```
+
+Because the state lives under the same `--agent` and `--memory-root`, later runs continue from the saved `run_state.json`, `icps/*.json`, and `lead_database.json` files even without a separate `--resume` flag.

--- a/harnessiq/cli/skills/knowt.md
+++ b/harnessiq/cli/skills/knowt.md
@@ -1,0 +1,92 @@
+# Knowt Content Creator
+
+`Knowt Content Creator` is the built-in HarnessIQ content-creation harness for generating a script, an avatar description, and a durable creation log for the Knowt/TikTok-style workflow.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect knowt` |
+| CLI surface | `harnessiq prepare knowt`, `harnessiq run knowt`, `harnessiq show knowt` |
+| Default memory root | `memory/knowt` |
+| Providers | `creatify` |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | no typed custom parameters |
+| Main outputs | `script`, `avatar_description`, `creation_log` |
+
+## Durable Files
+
+The harness persists its working state under `memory/knowt/<agent>/`.
+
+- `current_script.md`: the latest generated script.
+- `current_avatar_description.md`: the latest generated avatar description.
+- `creation_log.jsonl`: append-only creation pipeline log.
+
+There is no dedicated `configure` command for this harness. The generic prepare/run/show surface is the supported CLI path.
+
+## Prepare and Credentials
+
+```powershell
+$Root = Join-Path (Get-Location) 'knowt_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\knowt" | Out-Null
+
+harnessiq prepare knowt `
+  --agent knowt-a `
+  --memory-root "$Root\memory\knowt" `
+  --max-tokens 90000 `
+  --reset-threshold 0.85
+```
+
+Bind the Creatify credentials once:
+
+```powershell
+harnessiq credentials bind knowt `
+  --agent knowt-a `
+  --memory-root "$Root\memory\knowt" `
+  --env creatify.api_id=CREATIFY_API_ID `
+  --env creatify.api_key=CREATIFY_API_KEY
+```
+
+Inspect or validate the stored bindings:
+
+```powershell
+harnessiq credentials show knowt --agent knowt-a --memory-root "$Root\memory\knowt"
+harnessiq credentials test knowt --agent knowt-a --memory-root "$Root\memory\knowt"
+```
+
+## Run Patterns
+
+Run with an inline provider-backed model:
+
+```powershell
+harnessiq run knowt `
+  --agent knowt-a `
+  --memory-root "$Root\memory\knowt" `
+  --model openai:gpt-5.4 `
+  --sink "jsonl:$Root\ledger\knowt.jsonl" `
+  --max-cycles 10
+```
+
+Run with a reusable model profile:
+
+```powershell
+harnessiq run knowt `
+  --agent knowt-a `
+  --memory-root "$Root\memory\knowt" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools knowt.*,creatify.*,reasoning.* `
+  --dynamic-tools
+```
+
+The generic surface also supports `--model-factory`, `--run <N>`, and `--resume` if you want to reuse the last persisted run payload for the same profile.
+
+## Inspect
+
+```powershell
+harnessiq show knowt --agent knowt-a --memory-root "$Root\memory\knowt"
+```
+
+That output summarizes the current `script`, `avatar_description`, and recent `creation_log` entries.

--- a/harnessiq/cli/skills/leads.md
+++ b/harnessiq/cli/skills/leads.md
@@ -1,0 +1,122 @@
+# Leads Agent
+
+`Leads Agent` is the built-in HarnessIQ multi-ICP prospect discovery harness. It rotates through saved ICPs, persists search history, and deduplicates saved leads through a pluggable storage backend.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect leads` |
+| CLI family | `harnessiq leads` |
+| Default memory root | `memory/leads` |
+| Providers | `apollo`, `arcads`, `arxiv`, `attio`, `browser_use`, `coresignal`, `creatify`, `exa`, `expandi`, `hunter`, `inboxapp`, `instantly`, `leadiq`, `lemlist`, `lusha`, `outreach`, `paperclip`, `peopledatalabs`, `phantombuster`, `proxycurl`, `resend`, `salesforge`, `serper`, `smartlead`, `snovio`, `zerobounce`, `zoominfo` |
+| Runtime parameters | `max_tokens`, `reset_threshold`, `prune_search_interval`, `prune_token_limit`, `search_summary_every`, `search_tail_size`, `max_leads_per_icp` |
+| Custom parameters | no typed custom parameters |
+| Main outputs | `run_config`, `run_state`, `icp_states`, `saved_leads` |
+
+## Durable Files
+
+The harness persists its working state under `memory/leads/<agent>/`.
+
+- `run_config.json`: company background, ICPs, and enabled provider families.
+- `run_state.json`: active run state and ICP pointer.
+- `runtime_parameters.json`: saved runtime settings including `prune_search_interval`, `prune_token_limit`, `search_summary_every`, `search_tail_size`, and `max_leads_per_icp`.
+- `icps/*.json`: per-ICP history, summaries, saved lead keys, and completion state.
+- `lead_storage/`: storage backend root.
+- `lead_storage/saved_leads.json`: default filesystem deduplicated lead database.
+
+## Prepare and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'leads_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\leads" | Out-Null
+
+harnessiq leads prepare --agent outbound-a --memory-root "$Root\memory\leads"
+
+harnessiq leads configure `
+  --agent outbound-a `
+  --memory-root "$Root\memory\leads" `
+  --company-background-file .\company\background.md `
+  --icp-text 'VP Sales at Series A SaaS companies' `
+  --icp-text 'Head of Revenue at 50-200 employee SaaS companies' `
+  --platform apollo `
+  --platform zoominfo `
+  --runtime-param search_summary_every=250 `
+  --runtime-param search_tail_size=15 `
+  --runtime-param prune_search_interval=25 `
+  --runtime-param max_leads_per_icp=50
+```
+
+## Credentials and Provider Wiring
+
+Bind whichever provider families you want the harness to use. Example for `apollo` and `zoominfo`:
+
+```powershell
+harnessiq credentials bind leads `
+  --agent outbound-a `
+  --memory-root "$Root\memory\leads" `
+  --env apollo.api_key=APOLLO_API_KEY `
+  --env zoominfo.username=ZOOMINFO_USERNAME `
+  --env zoominfo.password=ZOOMINFO_PASSWORD
+```
+
+The built-in provider families currently available to `harnessiq leads` are:
+
+`apollo`, `arcads`, `arxiv`, `attio`, `browser_use`, `coresignal`, `creatify`, `exa`, `expandi`, `hunter`, `inboxapp`, `instantly`, `leadiq`, `lemlist`, `lusha`, `outreach`, `paperclip`, `peopledatalabs`, `phantombuster`, `proxycurl`, `resend`, `salesforge`, `serper`, `smartlead`, `snovio`, `zerobounce`, `zoominfo`.
+
+You can also bypass the default provider construction:
+
+- `--provider-tools-factory module:callable`
+- `--provider-credentials-factory FAMILY=module:callable`
+- `--provider-client-factory FAMILY=module:callable`
+- `--storage-backend-factory module:callable`
+
+## Run Patterns
+
+Run with default provider construction from the configured `--platform` families:
+
+```powershell
+harnessiq leads run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\leads" `
+  --model openai:gpt-5.4 `
+  --max-cycles 40
+```
+
+Run with explicit factories and a custom storage backend:
+
+```powershell
+harnessiq leads run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\leads" `
+  --profile fast-grok `
+  --provider-credentials-factory apollo=myproject.creds:create_apollo_credentials `
+  --provider-credentials-factory zoominfo=myproject.creds:create_zoominfo_credentials `
+  --storage-backend-factory myproject.leads:create_storage_backend `
+  --runtime-param max_leads_per_icp=75 `
+  --max-cycles 60
+```
+
+Shared tool controls work here too:
+
+```powershell
+harnessiq leads run `
+  --agent outbound-a `
+  --memory-root "$Root\memory\leads" `
+  --profile fast-grok `
+  --allowed-tools apollo.*,zoominfo.*,reasoning.* `
+  --dynamic-tools `
+  --dynamic-tool-top-k 15
+```
+
+## Inspect and Export
+
+```powershell
+harnessiq leads show --agent outbound-a --memory-root "$Root\memory\leads"
+harnessiq export --ledger-path "$Root\ledger\leads.jsonl" --format json --flatten-outputs > "$Root\exports\leads.json"
+harnessiq report --ledger-path "$Root\ledger\leads.jsonl" --format markdown > "$Root\exports\leads-report.md"
+```
+
+Like the Instagram harness, the Leads Agent continues from its durable state when you reuse the same `--agent` and `--memory-root`; there is no separate dedicated `--resume` flag on `harnessiq leads run`.

--- a/harnessiq/cli/skills/linkedin.md
+++ b/harnessiq/cli/skills/linkedin.md
@@ -1,0 +1,104 @@
+# LinkedIn Job Applier
+
+`LinkedIn Job Applier` is the built-in HarnessIQ browser-backed job-application harness. It persists job preferences, user profile state, imported files, screenshots, and recent actions between runs.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect linkedin` |
+| CLI family | `harnessiq linkedin` |
+| Default memory root | `memory/linkedin` |
+| Providers | `playwright` |
+| Runtime parameters | `max_tokens`, `reset_threshold`, `action_log_window`, `linkedin_start_url`, `notify_on_pause`, `pause_webhook` |
+| Custom parameters | open-ended `--custom-param KEY=VALUE` payload |
+| Main outputs | `jobs_applied`, `managed_files`, `recent_actions` |
+
+## Durable Files
+
+The harness persists its working state under `memory/linkedin/<agent>/`.
+
+- `job_preferences.md`: saved target-role preferences.
+- `user_profile.md`: saved profile/background info for application decisions.
+- `agent_identity.md`: optional system-identity override.
+- `runtime_parameters.json`: saved `max_tokens`, `reset_threshold`, `action_log_window`, `linkedin_start_url`, `notify_on_pause`, and `pause_webhook`.
+- `custom_parameters.json`: open-ended custom payload from `--custom-param`.
+- `additional_prompt.md`: free-form extra operator guidance.
+- `applied_jobs.jsonl`: append-only application history.
+- `action_log.jsonl`: append-only recent action log.
+- `managed_files.json` plus `managed_files/`: imported resume/cover-letter files tracked by the CLI.
+- `screenshots/`: persisted screenshots captured during runs.
+
+## Prepare, Browser Bootstrap, and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'linkedin_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\linkedin" | Out-Null
+
+harnessiq linkedin prepare --agent candidate-a --memory-root "$Root\memory\linkedin"
+
+harnessiq linkedin init-browser --agent candidate-a --memory-root "$Root\memory\linkedin"
+
+harnessiq linkedin configure `
+  --agent candidate-a `
+  --memory-root "$Root\memory\linkedin" `
+  --job-preferences-file .\linkedin\job_preferences.md `
+  --user-profile-file .\linkedin\profile.md `
+  --agent-identity-file .\linkedin\identity.md `
+  --additional-prompt-file .\linkedin\notes.md `
+  --runtime-param action_log_window=25 `
+  --runtime-param notify_on_pause=true `
+  --custom-param preferred_locations='[\"Remote\",\"Chicago\"]' `
+  --import-file .\linkedin\resume.pdf `
+  --inline-file cover-letter.txt='Short cover letter text'
+```
+
+## Run Patterns
+
+Run with a provider-backed model and a browser-tools factory:
+
+```powershell
+harnessiq linkedin run `
+  --agent candidate-a `
+  --memory-root "$Root\memory\linkedin" `
+  --model openai:gpt-5.4 `
+  --browser-tools-factory myproject.linkedin:create_browser_tools `
+  --max-cycles 5
+```
+
+Run with a reusable model profile and a sink:
+
+```powershell
+harnessiq linkedin run `
+  --agent candidate-a `
+  --memory-root "$Root\memory\linkedin" `
+  --profile fast-grok `
+  --browser-tools-factory myproject.linkedin:create_browser_tools `
+  --sink "jsonl:$Root\ledger\linkedin.jsonl" `
+  --runtime-param notify_on_pause=false
+```
+
+Shared tool controls also apply:
+
+```powershell
+harnessiq linkedin run `
+  --agent candidate-a `
+  --memory-root "$Root\memory\linkedin" `
+  --profile fast-grok `
+  --browser-tools-factory myproject.linkedin:create_browser_tools `
+  --approval on-request `
+  --allowed-tools linkedin.*,browser_use.*,reasoning.* `
+  --dynamic-tools
+```
+
+## Inspect and Export
+
+```powershell
+harnessiq linkedin show --agent candidate-a --memory-root "$Root\memory\linkedin"
+harnessiq export --ledger-path "$Root\ledger\linkedin.jsonl" --format json --flatten-outputs > "$Root\exports\linkedin.json"
+harnessiq report --ledger-path "$Root\ledger\linkedin.jsonl" --format markdown > "$Root\exports\linkedin-report.md"
+```
+
+Reuse the same `--agent` and `--memory-root` later to continue from the saved `applied_jobs.jsonl`, `action_log.jsonl`, and managed file state.

--- a/harnessiq/cli/skills/mission_driven.md
+++ b/harnessiq/cli/skills/mission_driven.md
@@ -1,0 +1,115 @@
+# Mission Driven
+
+`Mission Driven` is the built-in HarnessIQ long-running mission harness for decomposing a mission goal, maintaining a durable task plan, and keeping a resumable mission artifact on disk.
+
+See [README.md](./README.md) for shared install, model-profile, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect mission_driven` |
+| CLI surface | `harnessiq prepare mission_driven`, `harnessiq run mission_driven`, `harnessiq show mission_driven` |
+| Default memory root | `memory/mission_driven` |
+| Providers | none |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | `mission_goal`, `mission_type` |
+| Main outputs | `mission_status`, `mission_goal`, `mission_type`, `current_task_pointer`, `next_actions`, `task_count`, `completed_task_count`, `blocked_task_count`, `artifact_count`, `file_record_count`, `research_entry_count`, `tool_call_count` |
+
+## Durable Files
+
+The harness persists its working state under `memory/mission_driven/<agent>/`.
+
+- `mission.json`: mission definition and top-level status.
+- `task_plan.json`: hierarchical task list and current task pointer.
+- `memory_store.json`: durable fact registry.
+- `decision_log.json`: decision records and rationale.
+- `file_manifest.json`: files created or modified by the mission.
+- `error_log.json`: blockers, failures, and retries.
+- `feedback_log.json`: human input/approval records.
+- `test_results.json`: verification history.
+- `artifacts.json`: registered outputs and deliverables.
+- `tool_call_history.json`: durable tool-call history.
+- `research_log.json`: durable research findings.
+- `next_actions.json`: prioritized next step queue.
+- `mission_status.json`: status snapshot.
+- `progress_log.jsonl`: append-only event journal.
+- `README.md`: human-readable mission summary.
+- `checkpoints/`: checkpoint snapshots for resumability.
+- `additional_prompt.md`: optional extra operator guidance you can edit directly.
+- `runtime_parameters.json`: saved `max_tokens` and `reset_threshold`.
+- `custom_parameters.json`: saved `mission_goal` and `mission_type`.
+
+## Prepare
+
+Because this harness uses the generic manifest surface, you persist the typed mission inputs directly through `prepare`:
+
+```powershell
+$Root = Join-Path (Get-Location) 'mission_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\mission_driven" | Out-Null
+
+harnessiq prepare mission_driven `
+  --agent docs-site `
+  --memory-root "$Root\memory\mission_driven" `
+  --mission-goal "Create a durable documentation site for the sales engineering team." `
+  --mission-type app_build `
+  --max-tokens 90000 `
+  --reset-threshold 0.8
+```
+
+If you want extra operator instructions beyond the typed parameters, edit `additional_prompt.md` inside the prepared memory folder before running.
+
+## Run Patterns
+
+Start a run from the persisted mission definition:
+
+```powershell
+harnessiq run mission_driven `
+  --agent docs-site `
+  --memory-root "$Root\memory\mission_driven" `
+  --model openai:gpt-5.4 `
+  --sink "jsonl:$Root\ledger\mission.jsonl" `
+  --max-cycles 50
+```
+
+Resume the latest persisted run payload for the same mission profile:
+
+```powershell
+harnessiq run mission_driven `
+  --agent docs-site `
+  --memory-root "$Root\memory\mission_driven" `
+  --resume `
+  --profile fast-grok
+```
+
+Override typed parameters for one run only:
+
+```powershell
+harnessiq run mission_driven `
+  --agent docs-site `
+  --memory-root "$Root\memory\mission_driven" `
+  --profile fast-grok `
+  --mission-goal "Audit and improve the docs IA for the support portal." `
+  --mission-type app_build `
+  --run-arg checkpoint_label='before_handoff'
+```
+
+Shared tool controls are also available:
+
+```powershell
+harnessiq run mission_driven `
+  --agent docs-site `
+  --memory-root "$Root\memory\mission_driven" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools context.*,reasoning.*,filesystem.* `
+  --dynamic-tools
+```
+
+## Inspect
+
+```powershell
+harnessiq show mission_driven --agent docs-site --memory-root "$Root\memory\mission_driven"
+```
+
+That returns the current `mission`, `task_plan`, state `snapshot`, and saved `readme`.

--- a/harnessiq/cli/skills/prospecting.md
+++ b/harnessiq/cli/skills/prospecting.md
@@ -1,0 +1,101 @@
+# Google Maps Prospecting
+
+`Google Maps Prospecting` is the built-in HarnessIQ harness for finding local businesses, evaluating them against a company description, and persisting qualified leads over time.
+
+See [README.md](./README.md) for shared install, model-profile, credential-binding, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect prospecting` |
+| CLI family | `harnessiq prospecting` |
+| Default memory root | `memory/prospecting` |
+| Providers | `playwright` |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | `qualification_threshold`, `summarize_at_x`, `max_searches_per_run`, `max_listings_per_search`, `website_inspect_enabled`, `sink_record_type`, `eval_system_prompt` |
+| Main outputs | `company_description`, `qualified_leads`, `searches_completed`, `summary`, `counts` |
+
+## Durable Files
+
+The harness persists its working state under `memory/prospecting/<agent>/`.
+
+- `company_description.md`: durable description of the company or offer you are prospecting for.
+- `agent_identity.md`: optional identity override.
+- `additional_prompt.md`: free-form extra prompt guidance.
+- `runtime_parameters.json`: saved `max_tokens` and `reset_threshold`.
+- `custom_parameters.json`: saved `qualification_threshold`, `summarize_at_x`, `max_searches_per_run`, `max_listings_per_search`, `website_inspect_enabled`, `sink_record_type`, and `eval_system_prompt`.
+- `prospecting_state.json`: current search/run state.
+- `qualified_leads.jsonl`: append-only qualified lead records.
+- `browser-data/`: persisted browser session data.
+
+## Prepare, Browser Bootstrap, and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'prospecting_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\prospecting" | Out-Null
+
+harnessiq prospecting prepare --agent chicago-restaurants --memory-root "$Root\memory\prospecting"
+
+harnessiq prospecting init-browser --agent chicago-restaurants --memory-root "$Root\memory\prospecting" --channel chrome
+
+harnessiq prospecting configure `
+  --agent chicago-restaurants `
+  --memory-root "$Root\memory\prospecting" `
+  --company-description-file .\prospecting\company.md `
+  --agent-identity-file .\prospecting\identity.md `
+  --additional-prompt-file .\prospecting\notes.md `
+  --eval-system-prompt-file .\prospecting\eval_prompt.md `
+  --custom-param qualification_threshold=0.8 `
+  --custom-param summarize_at_x=25 `
+  --custom-param max_searches_per_run=10 `
+  --custom-param max_listings_per_search=20 `
+  --custom-param website_inspect_enabled=true `
+  --custom-param sink_record_type='\"qualified_lead\"'
+```
+
+## Run Patterns
+
+Run with the default Google Maps Playwright browser-tools factory:
+
+```powershell
+harnessiq prospecting run `
+  --agent chicago-restaurants `
+  --memory-root "$Root\memory\prospecting" `
+  --model openai:gpt-5.4 `
+  --browser-tools-factory harnessiq.integrations.google_maps_playwright:create_browser_tools `
+  --sink "jsonl:$Root\ledger\prospecting.jsonl" `
+  --max-cycles 40
+```
+
+Run with a reusable model profile and per-run custom overrides:
+
+```powershell
+harnessiq prospecting run `
+  --agent chicago-restaurants `
+  --memory-root "$Root\memory\prospecting" `
+  --profile fast-grok `
+  --custom-param qualification_threshold=0.9 `
+  --custom-param max_searches_per_run=5 `
+  --sink "jsonl:$Root\ledger\prospecting-high-confidence.jsonl"
+```
+
+Shared tool controls work here too:
+
+```powershell
+harnessiq prospecting run `
+  --agent chicago-restaurants `
+  --memory-root "$Root\memory\prospecting" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools prospecting.*,browser_use.*,reasoning.* `
+  --dynamic-tools
+```
+
+## Inspect and Export
+
+```powershell
+harnessiq prospecting show --agent chicago-restaurants --memory-root "$Root\memory\prospecting"
+harnessiq export --ledger-path "$Root\ledger\prospecting.jsonl" --format csv --flatten-outputs > "$Root\exports\prospecting.csv"
+harnessiq report --ledger-path "$Root\ledger\prospecting.jsonl" --format markdown > "$Root\exports\prospecting-report.md"
+```

--- a/harnessiq/cli/skills/research_sweep.md
+++ b/harnessiq/cli/skills/research_sweep.md
@@ -1,0 +1,79 @@
+# Research Sweep
+
+`Research Sweep` is the built-in HarnessIQ harness for working through a research query, maintaining context runtime state, and producing a final report over multiple search steps.
+
+See [README.md](./README.md) for shared install, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect research_sweep` |
+| CLI family | `harnessiq research-sweep` |
+| Default memory root | `memory/research_sweep` |
+| Providers | `serper` |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | `query`, `allowed_serper_operations` |
+| Main outputs | `all_sites_empty`, `continuation_pointer`, `final_report`, `query`, `site_results` |
+
+## Durable Files
+
+The harness persists its working state under `memory/research_sweep/<agent>/`.
+
+- `query.txt`: the saved research question.
+- `additional_prompt.md`: extra operator guidance.
+- `runtime_parameters.json`: saved `max_tokens` and `reset_threshold`.
+- `custom_parameters.json`: saved `query` and `allowed_serper_operations`.
+- `context_runtime_state.json`: durable continuation/context state between runs.
+
+## Prepare and Configure
+
+```powershell
+$Root = Join-Path (Get-Location) 'research_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\research_sweep" | Out-Null
+
+harnessiq research-sweep prepare --agent ai-policy --memory-root "$Root\memory\research_sweep"
+
+harnessiq research-sweep configure `
+  --agent ai-policy `
+  --memory-root "$Root\memory\research_sweep" `
+  --query-file .\research\query.txt `
+  --additional-prompt-file .\research\notes.md `
+  --runtime-param max_tokens=90000 `
+  --custom-param allowed_serper_operations='[\"search\",\"scrape\"]'
+```
+
+## Credentials
+
+Bind the Serper API key once if you want to use the built-in provider credentials flow:
+
+```powershell
+harnessiq credentials bind research_sweep `
+  --agent ai-policy `
+  --memory-root "$Root\memory\research_sweep" `
+  --env serper.api_key=SERPER_API_KEY
+```
+
+## Run Patterns
+
+`harnessiq research-sweep run` currently requires `--model-factory`; unlike many other harnesses, it does not expose `--model` or `--profile` today.
+
+```powershell
+harnessiq research-sweep run `
+  --agent ai-policy `
+  --memory-root "$Root\memory\research_sweep" `
+  --model-factory myproject.models:create_research_model `
+  --serper-credentials-factory myproject.creds:create_serper_credentials `
+  --runtime-param reset_threshold=0.8 `
+  --custom-param query='\"What changed in US AI policy this quarter?\"' `
+  --sink "jsonl:$Root\ledger\research.jsonl" `
+  --max-cycles 30
+```
+
+## Inspect and Export
+
+```powershell
+harnessiq research-sweep show --agent ai-policy --memory-root "$Root\memory\research_sweep"
+harnessiq export --ledger-path "$Root\ledger\research.jsonl" --format json --flatten-outputs > "$Root\exports\research.json"
+harnessiq report --ledger-path "$Root\ledger\research.jsonl" --format markdown > "$Root\exports\research-report.md"
+```

--- a/harnessiq/cli/skills/spawn_specialized_subagents.md
+++ b/harnessiq/cli/skills/spawn_specialized_subagents.md
@@ -1,0 +1,106 @@
+# Spawn Specialized Subagents
+
+`Spawn Specialized Subagents` is the built-in HarnessIQ orchestration harness for breaking an objective into worker assignments, collecting worker outputs, and integrating them into a final response.
+
+See [README.md](./README.md) for shared install, model-profile, sink, export, and reporting flows.
+
+## Quick Facts
+
+| Item | Value |
+| --- | --- |
+| Inspect command | `harnessiq inspect spawn_specialized_subagents` |
+| CLI surface | `harnessiq prepare spawn_specialized_subagents`, `harnessiq run spawn_specialized_subagents`, `harnessiq show spawn_specialized_subagents` |
+| Default memory root | `memory/spawn_specialized_subagents` |
+| Providers | none |
+| Runtime parameters | `max_tokens`, `reset_threshold` |
+| Custom parameters | `objective`, `available_agent_types` |
+| Main outputs | `objective`, `immediate_local_step`, `assignment_count`, `worker_output_count`, `final_response` |
+
+## Durable Files
+
+The harness persists its working state under `memory/spawn_specialized_subagents/<agent>/`.
+
+- `objective.md`: the primary orchestration objective.
+- `current_context.md`: current context and constraints for the orchestrator.
+- `additional_prompt.md`: optional extra operator guidance.
+- `plan.json`: current delegation plan, assignments, and immediate local step.
+- `worker_outputs.json`: collected worker outputs awaiting or after integration.
+- `integration_summary.json`: integrated result and final response.
+- `execution_log.jsonl`: append-only orchestration event log.
+- `README.md`: human-readable orchestration summary.
+- `runtime_parameters.json`: saved `max_tokens` and `reset_threshold`.
+- `custom_parameters.json`: saved `objective` and `available_agent_types`.
+
+## Prepare
+
+Persist the typed objective and worker archetypes through `prepare`:
+
+```powershell
+$Root = Join-Path (Get-Location) 'subagent_ops'
+New-Item -ItemType Directory -Force -Path "$Root\memory\spawn_specialized_subagents" | Out-Null
+
+harnessiq prepare spawn_specialized_subagents `
+  --agent release-audit `
+  --memory-root "$Root\memory\spawn_specialized_subagents" `
+  --objective "Audit the release readiness of the onboarding product and produce an integration summary." `
+  --available-agent-types "researcher,reviewer,qa" `
+  --max-tokens 90000 `
+  --reset-threshold 0.8
+```
+
+If you want to seed more background before the first run, edit `current_context.md` or `additional_prompt.md` in the prepared memory folder.
+
+## Run Patterns
+
+Start the orchestration run:
+
+```powershell
+harnessiq run spawn_specialized_subagents `
+  --agent release-audit `
+  --memory-root "$Root\memory\spawn_specialized_subagents" `
+  --model openai:gpt-5.4 `
+  --sink "jsonl:$Root\ledger\spawn.jsonl" `
+  --max-cycles 40
+```
+
+Resume the latest persisted run payload:
+
+```powershell
+harnessiq run spawn_specialized_subagents `
+  --agent release-audit `
+  --memory-root "$Root\memory\spawn_specialized_subagents" `
+  --resume `
+  --profile fast-grok
+```
+
+Override the objective or available worker types for one run only:
+
+```powershell
+harnessiq run spawn_specialized_subagents `
+  --agent release-audit `
+  --memory-root "$Root\memory\spawn_specialized_subagents" `
+  --profile fast-grok `
+  --objective "Compare two onboarding launch plans and recommend the lower-risk option." `
+  --available-agent-types "researcher,reviewer,finance" `
+  --run-arg ticket='PLAT-412'
+```
+
+Shared tool controls are available here as well:
+
+```powershell
+harnessiq run spawn_specialized_subagents `
+  --agent release-audit `
+  --memory-root "$Root\memory\spawn_specialized_subagents" `
+  --profile fast-grok `
+  --approval on-request `
+  --allowed-tools context.*,reasoning.*,filesystem.* `
+  --dynamic-tools
+```
+
+## Inspect
+
+```powershell
+harnessiq show spawn_specialized_subagents --agent release-audit --memory-root "$Root\memory\spawn_specialized_subagents"
+```
+
+That returns the saved `plan`, `worker_outputs`, `integration_summary`, and current state `snapshot`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ include-package-data = true
 include = ["harnessiq*"]
 
 [tool.setuptools.package-data]
+"harnessiq.cli.skills" = ["*.md"]
 "harnessiq.master_prompts.prompts" = ["*.json"]
 "harnessiq.agents.exa_outreach" = ["prompts/*.md"]
 "harnessiq.agents.instagram" = ["prompts/*.md"]

--- a/tests/test_cli_skill_docs.py
+++ b/tests/test_cli_skill_docs.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from harnessiq.shared.harness_manifests import list_harness_manifests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "harnessiq" / "cli" / "skills"
+
+
+def test_cli_skills_readme_exists_and_indexes_every_manifest() -> None:
+    readme_path = SKILLS_DIR / "README.md"
+    assert readme_path.exists()
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    for manifest in list_harness_manifests():
+        assert manifest.display_name in readme_text
+        assert f"./{manifest.manifest_id}.md" in readme_text
+
+
+def test_each_manifest_has_a_matching_skill_file_with_core_inventory() -> None:
+    for manifest in list_harness_manifests():
+        doc_path = SKILLS_DIR / f"{manifest.manifest_id}.md"
+        assert doc_path.exists(), f"Missing CLI skill doc for manifest '{manifest.manifest_id}'."
+
+        text = doc_path.read_text(encoding="utf-8")
+
+        assert manifest.display_name in text
+        assert manifest.default_memory_root in text
+        assert f"harnessiq inspect {manifest.manifest_id}" in text
+
+        for runtime_parameter in manifest.runtime_parameters:
+            assert runtime_parameter.key in text
+
+        for custom_parameter in manifest.custom_parameters:
+            assert custom_parameter.key in text
+
+        if manifest.custom_parameters_open_ended:
+            assert "open-ended" in text
+
+        if manifest.cli_command:
+            assert f"harnessiq {manifest.cli_command}" in text
+        else:
+            assert f"harnessiq prepare {manifest.manifest_id}" in text
+            assert f"harnessiq run {manifest.manifest_id}" in text


### PR DESCRIPTION
## Summary
- add a new `harnessiq/cli/skills/` package with a shared CLI overview and one markdown skill file per built-in harness
- wire the markdown files into package data and add a drift-guard test that requires docs for every built-in manifest
- refresh the generated repo docs so the new package and updated test counts are reflected in the top-level README and file index

## Testing
- python -m pytest tests/test_cli_skill_docs.py
- smoke check `harnessiq inspect` across all 10 built-in manifests