### PR TITLE
Add SDK agent reconstruction and runtime helpers

### DIFF
--- a/harnessiq/agents/__init__.py
+++ b/harnessiq/agents/__init__.py
@@ -8,6 +8,7 @@ from harnessiq.shared.agents import (
     AgentPauseSignal,
     AgentRunResult,
     AgentRunStatus,
+    AgentRuntimeSnapshot,
     AgentRuntimeConfig,
     AgentToolExecutor,
     AgentTranscriptEntry,
@@ -53,11 +54,13 @@ from harnessiq.utils import (
     AgentInstanceRecord,
     AgentInstanceStore,
     build_agent_instance_id,
+    build_output_sinks,
     build_default_instance_name,
     fingerprint_agent_payload,
 )
 
 from .base import BaseAgent
+from .sdk_helpers import build_agent_runtime_config, inspect_harness
 from .provider_base import BaseProviderToolAgent
 from .apollo import BaseApolloAgent
 from harnessiq.shared.apollo_agent import ApolloAgentConfig, DEFAULT_APOLLO_AGENT_IDENTITY
@@ -115,6 +118,7 @@ __all__ = [
     "AgentPauseSignal",
     "AgentRunResult",
     "AgentRunStatus",
+    "AgentRuntimeSnapshot",
     "AgentRuntimeConfig",
     "AgentToolExecutor",
     "AgentTranscriptEntry",
@@ -158,12 +162,15 @@ __all__ = [
     "ScreenshotPersistor",
     "build_linkedin_browser_tool_definitions",
     "build_agent_instance_id",
+    "build_output_sinks",
+    "build_agent_runtime_config",
     "build_default_instance_name",
     "create_linkedin_browser_stub_tools",
     "estimate_text_tokens",
     "fingerprint_agent_payload",
     "json_parameter_section",
     "get_harness_manifest",
+    "inspect_harness",
     "HookContext",
     "HookDefinition",
     "HookHandler",

--- a/harnessiq/agents/base/agent.py
+++ b/harnessiq/agents/base/agent.py
@@ -17,6 +17,7 @@ from harnessiq.shared.agents import (
     AgentPauseSignal,
     AgentRunResult,
     AgentRunStatus,
+    AgentRuntimeSnapshot,
     AgentRuntimeConfig,
     AgentToolExecutor,
     AgentTranscriptEntry,
@@ -296,6 +297,21 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
             parameter_sections=self._parameter_sections,
             transcript=tuple(self._transcript),
             tools=tools,
+        )
+
+    def snapshot(self) -> AgentRuntimeSnapshot:
+        """Return the current assembled runtime state without executing a model turn."""
+        self.prepare()
+        parameter_sections = self.refresh_parameters()
+        return AgentRuntimeSnapshot(
+            system_prompt=self.build_system_prompt(),
+            parameter_sections=parameter_sections,
+            tools=self.available_tools(),
+            hooks=self.available_hooks(),
+            runtime_config=self._runtime_config,
+            memory_path=self.memory_path,
+            instance_id=self.instance_id,
+            instance_name=self.instance_name,
         )
 
     def enable_context_tools(self) -> None:

--- a/harnessiq/agents/email/campaign.py
+++ b/harnessiq/agents/email/campaign.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from harnessiq.agents.base import AgentModel, AgentParameterSection, AgentRuntimeConfig
+from harnessiq.agents.sdk_helpers import merge_profile_parameters, resolve_profile_memory_path
+from harnessiq.config import HarnessProfile
 from harnessiq.shared.agents import json_parameter_section, merge_agent_runtime_config
 from harnessiq.shared.dtos import EmailAgentRequest, EmailCampaignAgentInstancePayload
 from harnessiq.shared.email import DEFAULT_EMAIL_AGENT_IDENTITY
 from harnessiq.shared.email_campaign import (
+    EMAIL_HARNESS_MANIFEST,
     EmailCampaignMemoryStore,
     EmailSendRecord,
     build_resend_batch_payload,
@@ -66,14 +69,19 @@ class EmailCampaignAgent(BaseEmailAgent):
         *,
         model: AgentModel,
         resend_credentials,
-        memory_path: str | Path,
+        memory_path: str | Path | None = None,
         runtime_overrides: Mapping[str, Any] | None = None,
         custom_overrides: Mapping[str, Any] | None = None,
         resend_client=None,
         runtime_config: AgentRuntimeConfig | None = None,
         instance_name: str | None = None,
     ) -> "EmailCampaignAgent":
-        store = EmailCampaignMemoryStore(memory_path=Path(memory_path))
+        resolved_memory_path = (
+            Path(memory_path)
+            if memory_path is not None
+            else Path(EMAIL_HARNESS_MANIFEST.resolved_default_memory_root)
+        )
+        store = EmailCampaignMemoryStore(memory_path=resolved_memory_path)
         store.prepare()
         runtime_parameters = dict(store.read_runtime_parameters())
         if runtime_overrides:
@@ -97,6 +105,41 @@ class EmailCampaignAgent(BaseEmailAgent):
             resend_client=resend_client,
             runtime_config=runtime_config,
             instance_name=instance_name,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        resend_credentials,
+        memory_path: str | Path | None = None,
+        resend_client=None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        instance_name: str | None = None,
+    ) -> "EmailCampaignAgent":
+        resolved_memory_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=EMAIL_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            resend_credentials=resend_credentials,
+            memory_path=resolved_memory_path,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            resend_client=resend_client,
+            runtime_config=runtime_config,
+            instance_name=instance_name or profile.agent_name,
         )
 
     @property

--- a/harnessiq/agents/exa_outreach/agent.py
+++ b/harnessiq/agents/exa_outreach/agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
 from harnessiq.agents.exa_outreach.helpers import (
@@ -16,6 +16,14 @@ from harnessiq.agents.exa_outreach.helpers import (
 )
 from harnessiq.agents.helpers import find_repo_root as _find_repo_root
 from harnessiq.agents.helpers import utc_now_z as _utcnow
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    load_persisted_profile,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
+from harnessiq.cli.common import load_factory
+from harnessiq.config import HarnessProfile
 from harnessiq.shared.agents import (
     DEFAULT_AGENT_MAX_TOKENS,
     DEFAULT_AGENT_RESET_THRESHOLD,
@@ -35,6 +43,7 @@ from harnessiq.shared.exceptions import (
 from harnessiq.shared.exa_outreach import (
     DEFAULT_AGENT_IDENTITY,
     DEFAULT_SEARCH_QUERY,
+    EXA_OUTREACH_HARNESS_MANIFEST,
     EmailSentRecord,
     EmailTemplate,
     ExaOutreachAgentConfig,
@@ -62,6 +71,8 @@ _DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
 class ExaOutreachAgent(BaseAgent):
     """Concrete agent harness for Exa-driven prospect discovery and optional outreach."""
 
+    master_prompt_path = _MASTER_PROMPT_PATH
+
     def __init__(
         self,
         *,
@@ -81,6 +92,8 @@ class ExaOutreachAgent(BaseAgent):
         allowed_exa_operations: tuple[str, ...] | None = None,
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         # Store all params needed by build_instance_payload() before calling super().__init__().
         self._candidate_memory_path = Path(memory_path) if memory_path is not None else None
@@ -95,6 +108,7 @@ class ExaOutreachAgent(BaseAgent):
         self._payload_reset_threshold = reset_threshold
         self._payload_allowed_resend_operations = allowed_resend_operations
         self._payload_allowed_exa_operations = allowed_exa_operations
+        self._master_prompt_override = master_prompt_override
 
         # Current run ID - assigned in prepare() before the loop starts.
         self._current_run_id: str | None = None
@@ -126,6 +140,7 @@ class ExaOutreachAgent(BaseAgent):
             ),
             memory_path=self._candidate_memory_path,
             repo_root=_find_repo_root(self._candidate_memory_path),
+            instance_name=instance_name,
         )
         resolved_memory_path = self.memory_path
         self._memory_store = ExaOutreachMemoryStore(memory_path=resolved_memory_path)
@@ -149,6 +164,127 @@ class ExaOutreachAgent(BaseAgent):
     @property
     def memory_store(self) -> ExaOutreachMemoryStore:
         return self._memory_store
+
+    @classmethod
+    def from_memory(
+        cls,
+        *,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        email_data: Iterable[EmailTemplate | dict[str, Any]] | None = None,
+        search_only: bool | None = None,
+        storage_backend: StorageBackend | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        exa_credentials: Any | None = None,
+        exa_client: Any | None = None,
+        resend_credentials: Any | None = None,
+        resend_client: Any | None = None,
+        allowed_resend_operations: tuple[str, ...] | None = None,
+        allowed_exa_operations: tuple[str, ...] | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "ExaOutreachAgent":
+        resolved_path = Path(memory_path) if memory_path is not None else _DEFAULT_MEMORY_PATH
+        store = ExaOutreachMemoryStore(memory_path=resolved_path)
+        store.prepare()
+        profile = load_persisted_profile(
+            manifest_id=EXA_OUTREACH_HARNESS_MANIFEST.manifest_id,
+            memory_path=resolved_path,
+        )
+        profile_runtime, _ = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        query_config = store.read_query_config()
+        runtime_parameters = dict(query_config)
+        runtime_parameters.update(profile_runtime)
+        resolved_email_data = list(email_data or ())
+        resolved_search_only = bool(search_only) if search_only is not None else not resolved_email_data
+        return cls(
+            model=model,
+            email_data=resolved_email_data,
+            search_query=str(query_config.get("search_query", DEFAULT_SEARCH_QUERY)).strip() or DEFAULT_SEARCH_QUERY,
+            search_only=resolved_search_only,
+            memory_path=resolved_path,
+            storage_backend=storage_backend,
+            max_tokens=int(runtime_parameters.get("max_tokens", DEFAULT_AGENT_MAX_TOKENS)),
+            reset_threshold=float(runtime_parameters.get("reset_threshold", DEFAULT_AGENT_RESET_THRESHOLD)),
+            exa_credentials=exa_credentials,
+            exa_client=exa_client,
+            resend_credentials=resend_credentials,
+            resend_client=resend_client,
+            allowed_resend_operations=allowed_resend_operations,
+            allowed_exa_operations=allowed_exa_operations,
+            tools=tools,
+            runtime_config=runtime_config,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        email_data: Iterable[EmailTemplate | dict[str, Any]] | None = None,
+        search_only: bool | None = None,
+        storage_backend: StorageBackend | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        exa_credentials: Any | None = None,
+        exa_client: Any | None = None,
+        resend_credentials: Any | None = None,
+        resend_client: Any | None = None,
+        allowed_resend_operations: tuple[str, ...] | None = None,
+        allowed_exa_operations: tuple[str, ...] | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "ExaOutreachAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=EXA_OUTREACH_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        adapter_arguments = profile.last_run.adapter_arguments if profile.last_run is not None else {}
+        resolved_email_data = email_data
+        if resolved_email_data is None and adapter_arguments.get("email_data_factory"):
+            raw_email_data = load_factory(str(adapter_arguments["email_data_factory"]))()
+            resolved_email_data = [
+                EmailTemplate.from_dict(dict(payload))
+                for payload in raw_email_data
+            ]
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            email_data=resolved_email_data,
+            search_only=search_only if search_only is not None else bool(adapter_arguments.get("search_only", False)),
+            storage_backend=storage_backend,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            exa_credentials=exa_credentials,
+            exa_client=exa_client,
+            resend_credentials=resend_credentials,
+            resend_client=resend_client,
+            allowed_resend_operations=allowed_resend_operations,
+            allowed_exa_operations=allowed_exa_operations,
+            tools=tools,
+            runtime_config=runtime_config,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
+        )
 
     # ------------------------------------------------------------------
     # BaseAgent overrides
@@ -180,17 +316,19 @@ class ExaOutreachAgent(BaseAgent):
 
     def build_system_prompt(self) -> str:
         """Load and return the master prompt from the prompts directory."""
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(
-                f"ExaOutreach master prompt not found at '{_MASTER_PROMPT_PATH}'. "
-                "Ensure harnessiq/agents/exa_outreach/prompts/master_prompt.md exists."
-            )
         identity = (
             self._memory_store.read_agent_identity()
             if self._memory_store.agent_identity_path.exists()
             else DEFAULT_AGENT_IDENTITY
         )
-        prompt = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+        prompt = load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=(
+                f"ExaOutreach master prompt not found at '{_MASTER_PROMPT_PATH}'. "
+                "Ensure harnessiq/agents/exa_outreach/prompts/master_prompt.md exists."
+            ),
+        )
         if identity and identity not in {DEFAULT_AGENT_IDENTITY, *LEGACY_DEFAULT_AGENT_IDENTITIES}:
             prompt = prompt.replace(
                 "[IDENTITY]\nYou are ExaOutreachAgent.",

--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -13,6 +13,11 @@ from harnessiq.agents.helpers import (
     resolve_memory_path as _resolve_memory_path,
     utc_now_z as _utcnow,
 )
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
 from harnessiq.agents.instagram.helpers import (
     build_instagram_instance_payload as _build_instagram_instance_payload,
     is_search_only_response as _is_search_only_response,
@@ -39,6 +44,7 @@ from harnessiq.shared.instagram import (
     DEFAULT_RECENT_RESULT_WINDOW,
     DEFAULT_RECENT_SEARCH_WINDOW,
     DEFAULT_SEARCH_RESULT_LIMIT,
+    INSTAGRAM_HARNESS_MANIFEST,
     InstagramICP,
     InstagramKeywordAgentConfig,
     InstagramMemoryStore,
@@ -48,9 +54,12 @@ from harnessiq.shared.instagram import (
     resolve_instagram_icp_profiles,
 )
 from harnessiq.shared.tools import INSTAGRAM_SEARCH_KEYWORD, RegisteredTool, ToolCall, ToolResult
+from harnessiq.config import HarnessProfile
 from harnessiq.toolset import get_tool
 from harnessiq.tools.instagram import create_instagram_tools
 from harnessiq.tools.registry import create_tool_registry
+from harnessiq.utils.ledger import new_run_id
+
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _MASTER_PROMPT_PATH = _PROMPTS_DIR / "master_prompt.md"
 _DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
@@ -58,6 +67,8 @@ _DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
 
 class InstagramKeywordDiscoveryAgent(BaseAgent):
     """Concrete harness for ICP-driven Instagram keyword discovery."""
+
+    master_prompt_path = _MASTER_PROMPT_PATH
 
     def __init__(
         self,
@@ -75,6 +86,8 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         persist_icp_descriptions: bool = True,
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         if search_backend is None:
             raise ConfigurationError("InstagramKeywordDiscoveryAgent requires a search_backend.")
@@ -90,6 +103,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         self._payload_recent_search_window = recent_search_window
         self._payload_recent_result_window = recent_result_window
         self._payload_search_result_limit = search_result_limit
+        self._master_prompt_override = master_prompt_override
         self._run_id: str | None = None
         self._active_icp_index = 0
         self._icps: tuple[InstagramICP, ...] = tuple(InstagramICP(description=value) for value in normalized_icps)
@@ -138,6 +152,7 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             ),
             memory_path=candidate_memory_path,
             repo_root=_find_repo_root(candidate_memory_path),
+            instance_name=instance_name,
         )
 
     @property
@@ -159,6 +174,8 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         custom_overrides: Mapping[str, Any] | None = None,
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> "InstagramKeywordDiscoveryAgent":
         resolved_path = _resolve_memory_path(memory_path, default_path=_DEFAULT_MEMORY_PATH)
         store = InstagramMemoryStore(memory_path=resolved_path)
@@ -182,7 +199,46 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             persist_icp_descriptions=False,
             tools=tools,
             runtime_config=runtime_config,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
             **normalized,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        search_backend: InstagramSearchBackend,
+        memory_path: str | Path | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "InstagramKeywordDiscoveryAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=INSTAGRAM_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            search_backend=search_backend,
+            memory_path=resolved_path,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            tools=tools,
+            runtime_config=runtime_config,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
         )
 
     def prepare(self) -> None:
@@ -231,12 +287,14 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             self.close()
 
     def build_system_prompt(self) -> str:
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(
+        prompt_template = load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=(
                 f"Instagram master prompt not found at '{_MASTER_PROMPT_PATH}'. "
                 "Ensure the prompt file exists."
-            )
-        prompt_template = _MASTER_PROMPT_PATH.read_text(encoding="utf-8").strip()
+            ),
+        ).strip()
         identity = (
             self._memory_store.read_agent_identity()
             if self._memory_store.agent_identity_path.exists()
@@ -462,6 +520,10 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         result = super()._execute_tool(tool_call)
         if tool_call.tool_key == INSTAGRAM_SEARCH_KEYWORD:
             self.refresh_parameters()
+            self._append_recent_search_context_entry(
+                keyword=tool_call.arguments.get("keyword"),
+                result=result,
+            )
         return result
 
     def _record_assistant_response(self, response: AgentModelResponse) -> None:
@@ -527,6 +589,33 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             self._attempted_search_keywords = self._attempted_search_keywords[
                 -self._config.recent_search_window :
             ]
+
+    def _append_recent_search_context_entry(
+        self,
+        *,
+        keyword: Any,
+        result: ToolResult,
+    ) -> None:
+        cleaned_keyword = keyword.strip() if isinstance(keyword, str) else ""
+        recent_searches = self._recent_search_keywords_for_context()
+        if not recent_searches and not cleaned_keyword:
+            return
+        output = result.output if isinstance(result.output, Mapping) else {}
+        payload = {
+            "active_icp": self._current_icp_description(),
+            "keyword": cleaned_keyword,
+            "recent_searches": list(recent_searches),
+            "status": str(output.get("status", "unknown")),
+        }
+        if "error" in output:
+            payload["error"] = str(output["error"])
+        self._transcript.append(
+            AgentTranscriptEntry(
+                entry_type="context",
+                label="Recent Searches",
+                content=json.dumps(payload, indent=2, sort_keys=True),
+            )
+        )
 
     def _activate_icp(self, icp_index: int) -> None:
         self._active_icp_index = icp_index

--- a/harnessiq/agents/knowt/agent.py
+++ b/harnessiq/agents/knowt/agent.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
 from harnessiq.agents.helpers import find_repo_root as _find_repo_root
+from harnessiq.agents.helpers import resolve_memory_path as _resolve_memory_path
 from harnessiq.agents.knowt.helpers import build_knowt_instance_payload as _build_knowt_instance_payload
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    load_persisted_profile,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
+from harnessiq.config import HarnessProfile
 from harnessiq.shared.agents import (
     DEFAULT_AGENT_MAX_TOKENS,
     DEFAULT_AGENT_RESET_THRESHOLD,
@@ -20,6 +28,7 @@ from harnessiq.shared.dtos import KnowtAgentInstancePayload
 from harnessiq.shared.exceptions import ResourceNotFoundError
 from harnessiq.shared.knowt import (
     KnowtAgentConfig,
+    KNOWT_HARNESS_MANIFEST,
     KnowtMemoryStore,
     MASTER_PROMPT_FILENAME,
     PROMPTS_DIRNAME,
@@ -46,6 +55,8 @@ class KnowtAgent(BaseAgent):
     be updated without touching Python source.
     """
 
+    master_prompt_path = _MASTER_PROMPT_PATH
+
     def __init__(
         self,
         *,
@@ -58,6 +69,8 @@ class KnowtAgent(BaseAgent):
         config: KnowtAgentConfig | None = None,
         tools: "Sequence[RegisteredTool] | None" = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         # Store all params needed by build_instance_payload() before calling super().__init__().
         initial_config = config or KnowtAgentConfig(
@@ -65,6 +78,7 @@ class KnowtAgent(BaseAgent):
             max_tokens=max_tokens,
             reset_threshold=reset_threshold,
         )
+        self._master_prompt_override = master_prompt_override
         self._config = initial_config
         self._memory_store = KnowtMemoryStore(memory_path=self._config.memory_path)
         self._memory_store.prepare()
@@ -89,6 +103,7 @@ class KnowtAgent(BaseAgent):
             ),
             memory_path=self._config.memory_path,
             repo_root=_find_repo_root(Path(self._config.memory_path)),
+            instance_name=instance_name,
         )
         resolved_memory_path = self.memory_path
         self._config = KnowtAgentConfig(
@@ -114,17 +129,99 @@ class KnowtAgent(BaseAgent):
     def memory_store(self) -> KnowtMemoryStore:
         return self._memory_store
 
+    @classmethod
+    def from_memory(
+        cls,
+        *,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        creatify_client: "CreatifyClient | None" = None,
+        creatify_credentials: "CreatifyCredentials | None" = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        tools: "Sequence[RegisteredTool] | None" = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "KnowtAgent":
+        resolved_memory_path = _resolve_memory_path(
+            memory_path,
+            default_path=Path(KNOWT_HARNESS_MANIFEST.resolved_default_memory_root),
+        )
+        profile = load_persisted_profile(
+            manifest_id=KNOWT_HARNESS_MANIFEST.manifest_id,
+            memory_path=resolved_memory_path,
+        )
+        runtime_parameters, _ = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls(
+            model=model,
+            memory_path=resolved_memory_path,
+            creatify_client=creatify_client,
+            creatify_credentials=creatify_credentials,
+            max_tokens=int(runtime_parameters.get("max_tokens", DEFAULT_AGENT_MAX_TOKENS)),
+            reset_threshold=float(runtime_parameters.get("reset_threshold", DEFAULT_AGENT_RESET_THRESHOLD)),
+            tools=tools,
+            runtime_config=runtime_config,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        creatify_client: "CreatifyClient | None" = None,
+        creatify_credentials: "CreatifyCredentials | None" = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        tools: "Sequence[RegisteredTool] | None" = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "KnowtAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=KNOWT_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            creatify_client=creatify_client,
+            creatify_credentials=creatify_credentials,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            tools=tools,
+            runtime_config=runtime_config,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
+        )
+
     def prepare(self) -> None:
         self._memory_store.prepare()
 
     def build_system_prompt(self) -> str:
         """Load and return the master prompt from the prompts directory."""
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(
+        return load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=(
                 f"Knowt master prompt not found at '{_MASTER_PROMPT_PATH}'. "
                 "Ensure harnessiq/agents/knowt/prompts/master_prompt.md exists."
-            )
-        return _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+            ),
+        )
 
     def load_parameter_sections(self) -> Sequence[AgentParameterSection]:
         """Return current script and avatar description as durable parameter sections."""

--- a/harnessiq/agents/leads/agent.py
+++ b/harnessiq/agents/leads/agent.py
@@ -7,6 +7,14 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
+from harnessiq.agents.helpers import find_repo_root as _find_repo_root
+from harnessiq.agents.helpers import resolve_memory_path as _resolve_memory_path
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    load_persisted_profile,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
 from harnessiq.interfaces.tool_selection import DynamicToolSelector
 from harnessiq.agents.leads.helpers import (
     build_leads_instance_payload as _build_leads_instance_payload,
@@ -35,9 +43,11 @@ from harnessiq.shared.leads import (
     LeadICPState,
     LeadsAgentConfig,
     LeadRunState,
+    LEADS_HARNESS_MANIFEST,
     LeadsMemoryStore,
     LeadsStorageBackend,
 )
+from harnessiq.config import HarnessProfile
 from harnessiq.shared.tools import (
     LEADS_CHECK_SEEN,
     LEADS_COMPACT_SEARCH_HISTORY,
@@ -54,6 +64,8 @@ _DEFAULT_MEMORY_PATH = Path(__file__).parent / "memory"
 
 class LeadsAgent(BaseAgent):
     """Concrete leads harness that rotates one agent instance across multiple ICPs."""
+
+    master_prompt_path = _MASTER_PROMPT_PATH
 
     def __init__(
         self,
@@ -77,7 +89,10 @@ class LeadsAgent(BaseAgent):
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
         dynamic_tool_selector: DynamicToolSelector | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
+        self._master_prompt_override = master_prompt_override
         self._config = LeadsAgentConfig.from_inputs(
             company_background=company_background,
             icps=icps,
@@ -122,6 +137,8 @@ class LeadsAgent(BaseAgent):
             ),
             dynamic_tool_selector=dynamic_tool_selector,
             memory_path=self._config.memory_path,
+            repo_root=_find_repo_root(self._config.memory_path),
+            instance_name=instance_name,
         )
 
     @property
@@ -131,6 +148,117 @@ class LeadsAgent(BaseAgent):
     @property
     def memory_store(self) -> LeadsMemoryStore:
         return self._memory_store
+
+    @classmethod
+    def from_memory(
+        cls,
+        *,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        storage_backend: LeadsStorageBackend | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        provider_credentials: Mapping[str, Any] | None = None,
+        provider_clients: Mapping[str, Any] | None = None,
+        allowed_provider_operations: Mapping[str, Sequence[str] | None] | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        dynamic_tool_selector: DynamicToolSelector | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "LeadsAgent":
+        resolved_path = _resolve_memory_path(memory_path, default_path=_DEFAULT_MEMORY_PATH)
+        store = LeadsMemoryStore(memory_path=resolved_path)
+        store.prepare()
+        profile = load_persisted_profile(
+            manifest_id=LEADS_HARNESS_MANIFEST.manifest_id,
+            memory_path=resolved_path,
+        )
+        profile_runtime, _ = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        runtime_parameters = store.read_runtime_parameters()
+        runtime_parameters.update(profile_runtime)
+        run_config = store.read_run_config()
+        return cls(
+            model=model,
+            company_background=run_config.company_background,
+            icps=run_config.icps,
+            platforms=run_config.platforms,
+            memory_path=resolved_path,
+            storage_backend=storage_backend,
+            max_tokens=int(runtime_parameters.get("max_tokens", DEFAULT_AGENT_MAX_TOKENS)),
+            reset_threshold=float(runtime_parameters.get("reset_threshold", DEFAULT_AGENT_RESET_THRESHOLD)),
+            prune_search_interval=(
+                int(runtime_parameters["prune_search_interval"])
+                if runtime_parameters.get("prune_search_interval") is not None
+                else None
+            ),
+            prune_token_limit=(
+                int(runtime_parameters["prune_token_limit"])
+                if runtime_parameters.get("prune_token_limit") is not None
+                else None
+            ),
+            search_summary_every=int(
+                runtime_parameters.get("search_summary_every", run_config.search_summary_every)
+            ),
+            search_tail_size=int(runtime_parameters.get("search_tail_size", run_config.search_tail_size)),
+            max_leads_per_icp=(
+                int(runtime_parameters["max_leads_per_icp"])
+                if runtime_parameters.get("max_leads_per_icp") is not None
+                else run_config.max_leads_per_icp
+            ),
+            provider_credentials=provider_credentials,
+            provider_clients=provider_clients,
+            allowed_provider_operations=allowed_provider_operations,
+            tools=tools,
+            runtime_config=runtime_config,
+            dynamic_tool_selector=dynamic_tool_selector,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        storage_backend: LeadsStorageBackend | None = None,
+        provider_credentials: Mapping[str, Any] | None = None,
+        provider_clients: Mapping[str, Any] | None = None,
+        allowed_provider_operations: Mapping[str, Sequence[str] | None] | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        dynamic_tool_selector: DynamicToolSelector | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "LeadsAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=LEADS_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            storage_backend=storage_backend,
+            runtime_overrides=profile.runtime_parameters | dict(runtime_overrides or {}),
+            custom_overrides=profile.custom_parameters | dict(custom_overrides or {}),
+            provider_credentials=provider_credentials,
+            provider_clients=provider_clients,
+            allowed_provider_operations=allowed_provider_operations,
+            tools=tools,
+            runtime_config=runtime_config,
+            dynamic_tool_selector=dynamic_tool_selector,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
+        )
 
     def build_instance_payload(self) -> LeadsAgentInstancePayload:
         return _build_leads_instance_payload(config=self._config)
@@ -170,12 +298,14 @@ class LeadsAgent(BaseAgent):
         )
 
     def build_system_prompt(self) -> str:
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(
+        template = load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=(
                 f"Leads master prompt not found at '{_MASTER_PROMPT_PATH}'. "
                 "Ensure harnessiq/agents/leads/prompts/master_prompt.md exists."
-            )
-        template = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+            ),
+        )
         tool_lines = "\n".join(f"- {tool.name}: {tool.description}" for tool in self.available_tools())
         return (
             template.replace("{{TOOL_LIST}}", tool_lines)

--- a/harnessiq/agents/linkedin/agent.py
+++ b/harnessiq/agents/linkedin/agent.py
@@ -14,6 +14,12 @@ from harnessiq.agents.helpers import (
     utc_now_z as _utcnow,
     utc_timestamp_for_filename as _timestamp_for_filename,
 )
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
+from harnessiq.config import HarnessProfile
 from harnessiq.agents.linkedin.helpers import (
     build_linkedin_instance_payload as _build_linkedin_instance_payload,
     or_placeholder as _or_placeholder,
@@ -39,6 +45,7 @@ from harnessiq.shared.linkedin import (
     DEFAULT_LINKEDIN_ACTION_LOG_WINDOW,
     DEFAULT_LINKEDIN_NOTIFY_ON_PAUSE,
     DEFAULT_LINKEDIN_START_URL,
+    LINKEDIN_HARNESS_MANIFEST,
     LinkedInMemoryStore,
     SUPPORTED_LINKEDIN_RUNTIME_PARAMETERS,
     ActionLogEntry,
@@ -62,6 +69,8 @@ _MASTER_PROMPT_PATH = Path(__file__).parent / "prompts" / "master_prompt.md"
 class LinkedInJobApplierAgent(BaseAgent):
     """Concrete agent harness matching the LinkedIn job application specification."""
 
+    master_prompt_path = _MASTER_PROMPT_PATH
+
     def __init__(
         self,
         *,
@@ -77,6 +86,8 @@ class LinkedInJobApplierAgent(BaseAgent):
         notify_on_pause: bool = DEFAULT_LINKEDIN_NOTIFY_ON_PAUSE,
         pause_webhook: str | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         # Store all params needed by build_instance_payload() before calling super().__init__().
         self._candidate_memory_path = Path(memory_path) if memory_path is not None else None
@@ -87,6 +98,7 @@ class LinkedInJobApplierAgent(BaseAgent):
         self._payload_notify_on_pause = notify_on_pause
         self._payload_pause_webhook = pause_webhook
         self._screenshot_persistor = screenshot_persistor
+        self._master_prompt_override = master_prompt_override
 
         super().__init__(
             name="linkedin_job_applier",
@@ -99,6 +111,7 @@ class LinkedInJobApplierAgent(BaseAgent):
             ),
             memory_path=self._candidate_memory_path,
             repo_root=_find_repo_root(self._candidate_memory_path),
+            instance_name=instance_name,
         )
         resolved_memory_path = self.memory_path
         self._config = LinkedInAgentConfig(
@@ -150,7 +163,10 @@ class LinkedInJobApplierAgent(BaseAgent):
         tools: Sequence[RegisteredTool] | None = None,
         screenshot_persistor: ScreenshotPersistor | None = None,
         runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> "LinkedInJobApplierAgent":
         resolved_path = _resolve_memory_path(memory_path, default_path=_DEFAULT_MEMORY_PATH)
         memory_store = LinkedInMemoryStore(memory_path=resolved_path)
@@ -158,6 +174,10 @@ class LinkedInJobApplierAgent(BaseAgent):
         runtime_parameters = memory_store.read_runtime_parameters()
         if runtime_overrides:
             runtime_parameters.update(runtime_overrides)
+        if custom_overrides:
+            merged_custom = memory_store.read_custom_parameters()
+            merged_custom.update(custom_overrides)
+            memory_store.write_custom_parameters(merged_custom)
         return cls(
             model=model,
             memory_path=resolved_path,
@@ -165,14 +185,62 @@ class LinkedInJobApplierAgent(BaseAgent):
             tools=tools,
             screenshot_persistor=screenshot_persistor,
             runtime_config=runtime_config,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
             **normalize_linkedin_runtime_parameters(runtime_parameters),
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        browser_tools: Iterable[RegisteredTool] = (),
+        tools: Sequence[RegisteredTool] | None = None,
+        screenshot_persistor: ScreenshotPersistor | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "LinkedInJobApplierAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=LINKEDIN_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            browser_tools=browser_tools,
+            tools=tools,
+            screenshot_persistor=screenshot_persistor,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            runtime_config=runtime_config,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
         )
 
     def prepare(self) -> None:
         self._memory_store.prepare()
 
     def build_system_prompt(self) -> str:
-        template = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+        template = load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=(
+                f"LinkedIn master prompt not found at '{_MASTER_PROMPT_PATH}'. "
+                "Ensure harnessiq/agents/linkedin/prompts/master_prompt.md exists."
+            ),
+        )
         identity = self._memory_store.read_agent_identity() or DEFAULT_AGENT_IDENTITY
         tool_lines = "\n".join(f"- {tool.name}: {tool.description}" for tool in self.available_tools())
         return (

--- a/harnessiq/agents/mission_driven/agent.py
+++ b/harnessiq/agents/mission_driven/agent.py
@@ -7,12 +7,14 @@ from typing import Any, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
 from harnessiq.agents.helpers import resolve_memory_path, utc_now_z
+from harnessiq.agents.sdk_helpers import merge_profile_parameters, resolve_profile_memory_path
 from harnessiq.agents.mission_driven.stages import (
     MissionDefinitionStage,
     MissionNarrativeStage,
     MissionStatusStage,
     MissionTaskPlanStage,
 )
+from harnessiq.config import HarnessProfile
 from harnessiq.agents.subcalls import JsonSubcallRunner
 from harnessiq.shared.agents import (
     AgentModel,
@@ -175,6 +177,41 @@ class MissionDrivenAgent(BaseAgent):
             json_subcall_runner=json_subcall_runner,
             instance_name=instance_name,
             **normalized_runtime,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        json_subcall_runner: JsonSubcallRunner | None = None,
+        instance_name: str | None = None,
+    ) -> "MissionDrivenAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=MISSION_DRIVEN_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            tools=tools,
+            runtime_config=runtime_config,
+            json_subcall_runner=json_subcall_runner,
+            instance_name=instance_name or profile.agent_name,
         )
 
     def build_instance_payload(self) -> dict[str, Any]:

--- a/harnessiq/agents/prospecting/agent.py
+++ b/harnessiq/agents/prospecting/agent.py
@@ -11,6 +11,11 @@ from harnessiq.agents.helpers import (
     find_repo_root as _find_repo_root,
     resolve_memory_path as _resolve_memory_path,
 )
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
 from harnessiq.agents.prospecting.helpers import (
     build_instance_payload as _build_instance_payload,
     create_browser_stub_tools as _create_browser_stub_tools,
@@ -40,6 +45,7 @@ from harnessiq.shared.prospecting import (
     DEFAULT_SINK_RECORD_TYPE,
     DEFAULT_SUMMARIZE_AT_X,
     DEFAULT_WEBSITE_INSPECT_ENABLED,
+    PROSPECTING_HARNESS_MANIFEST,
     NEXT_QUERY_SYSTEM_PROMPT,
     ProspectingAgentConfig,
     ProspectingMemoryStore,
@@ -55,6 +61,7 @@ from harnessiq.shared.prospecting import (
     utcnow,
 )
 from harnessiq.shared.tools import RegisteredTool, SEARCH_OR_SUMMARIZE, ToolResult
+from harnessiq.config import HarnessProfile
 from harnessiq.tools import create_evaluate_company_tool, create_search_or_summarize_tool
 from harnessiq.tools.registry import create_tool_registry
 
@@ -67,6 +74,8 @@ JsonSubcallRunner = Callable[[str, Sequence[AgentParameterSection], str], dict[s
 
 class GoogleMapsProspectingAgent(BaseAgent):
     """Concrete harness for Google Maps prospecting."""
+
+    master_prompt_path = _MASTER_PROMPT_PATH
 
     _RESET_SAFE_TOOL_KEYS = frozenset(
         {
@@ -97,6 +106,8 @@ class GoogleMapsProspectingAgent(BaseAgent):
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
         json_subcall_runner: JsonSubcallRunner | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         # Store all params needed by build_instance_payload() before calling super().__init__().
         self._candidate_memory_path = Path(memory_path) if memory_path is not None else None
@@ -110,6 +121,7 @@ class GoogleMapsProspectingAgent(BaseAgent):
         self._payload_website_inspect_enabled = website_inspect_enabled
         self._payload_sink_record_type = sink_record_type
         self._payload_eval_system_prompt = eval_system_prompt
+        self._master_prompt_override = master_prompt_override
 
         self._config = ProspectingAgentConfig(
             memory_path=Path("."),
@@ -144,6 +156,7 @@ class GoogleMapsProspectingAgent(BaseAgent):
             ),
             memory_path=self._candidate_memory_path,
             repo_root=_find_repo_root(self._candidate_memory_path),
+            instance_name=instance_name,
         )
         resolved_memory_path = self.memory_path or _DEFAULT_MEMORY_PATH
         self._memory_store = ProspectingMemoryStore(memory_path=resolved_memory_path)
@@ -180,6 +193,8 @@ class GoogleMapsProspectingAgent(BaseAgent):
         tools: Sequence[RegisteredTool] | None = None,
         runtime_config: AgentRuntimeConfig | None = None,
         json_subcall_runner: JsonSubcallRunner | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> "GoogleMapsProspectingAgent":
         resolved_path = _resolve_memory_path(memory_path, default_path=_DEFAULT_MEMORY_PATH)
         store = ProspectingMemoryStore(memory_path=resolved_path)
@@ -200,8 +215,49 @@ class GoogleMapsProspectingAgent(BaseAgent):
             tools=tools,
             runtime_config=runtime_config,
             json_subcall_runner=json_subcall_runner,
+            instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
             **normalized_runtime,
             **normalized_custom,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        browser_tools: Iterable[RegisteredTool] = (),
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        json_subcall_runner: JsonSubcallRunner | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "GoogleMapsProspectingAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=PROSPECTING_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            browser_tools=browser_tools,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            tools=tools,
+            runtime_config=runtime_config,
+            json_subcall_runner=json_subcall_runner,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
         )
 
     def prepare(self) -> None:
@@ -254,9 +310,11 @@ class GoogleMapsProspectingAgent(BaseAgent):
         self.refresh_parameters()
 
     def build_system_prompt(self) -> str:
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(f"Prospecting master prompt not found at '{_MASTER_PROMPT_PATH}'.")
-        prompt = _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+        prompt = load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=f"Prospecting master prompt not found at '{_MASTER_PROMPT_PATH}'.",
+        )
         company_description = self._memory_store.read_company_description() or DEFAULT_COMPANY_DESCRIPTION
         identity = self._memory_store.read_agent_identity() or DEFAULT_AGENT_IDENTITY
         tool_lines = "\n".join(f"- {tool.key}: {tool.description}" for tool in self.available_tools())

--- a/harnessiq/agents/research_sweep/agent.py
+++ b/harnessiq/agents/research_sweep/agent.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
+from harnessiq.agents.sdk_helpers import (
+    load_master_prompt_text,
+    merge_profile_parameters,
+    resolve_profile_memory_path,
+)
+from harnessiq.config import HarnessProfile
 from harnessiq.agents.research_sweep.helpers import (
     append_transcript_entry as _append_transcript_entry,
     utc_today as _utc_today,
@@ -67,6 +73,8 @@ _MASTER_PROMPT_PATH = _PROMPTS_DIR / "master_prompt.md"
 class ResearchSweepAgent(BaseAgent):
     """Run a fixed-order nine-site academic research sweep with durable reset-safe memory."""
 
+    master_prompt_path = _MASTER_PROMPT_PATH
+
     _allowed_context_tool_keys = frozenset(
         {
             CONTEXT_PARAM_WRITE_ONCE_MEMORY_FIELD,
@@ -94,6 +102,7 @@ class ResearchSweepAgent(BaseAgent):
         runtime_config: AgentRuntimeConfig | None = None,
         tools: Sequence[RegisteredTool] | None = None,
         instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> None:
         candidate_memory_path = (
             Path(memory_path)
@@ -107,6 +116,7 @@ class ResearchSweepAgent(BaseAgent):
         )
         self._payload_max_tokens = max_tokens
         self._payload_reset_threshold = reset_threshold
+        self._master_prompt_override = master_prompt_override
         self._memory_store = ResearchSweepMemoryStore(memory_path=candidate_memory_path)
         self._memory_store.prepare()
         self._write_native_config_files(
@@ -193,6 +203,7 @@ class ResearchSweepAgent(BaseAgent):
         runtime_config: AgentRuntimeConfig | None = None,
         tools: Sequence[RegisteredTool] | None = None,
         instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
     ) -> "ResearchSweepAgent":
         resolved_memory_path = (
             Path(memory_path)
@@ -228,6 +239,46 @@ class ResearchSweepAgent(BaseAgent):
             runtime_config=runtime_config,
             tools=tools,
             instance_name=instance_name,
+            master_prompt_override=master_prompt_override,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        serper_client: "SerperClient | None" = None,
+        serper_credentials: "SerperCredentials | None" = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        instance_name: str | None = None,
+        master_prompt_override: str | Path | None = None,
+    ) -> "ResearchSweepAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=RESEARCH_SWEEP_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            serper_client=serper_client,
+            serper_credentials=serper_credentials,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            runtime_config=runtime_config,
+            tools=tools,
+            instance_name=instance_name or profile.agent_name,
+            master_prompt_override=master_prompt_override,
         )
 
     def build_instance_payload(self) -> ResearchSweepAgentInstancePayload:
@@ -413,11 +464,11 @@ class ResearchSweepAgent(BaseAgent):
         return RegisteredTool(definition=definition, handler=handler)
 
     def _load_master_prompt(self) -> str:
-        if not _MASTER_PROMPT_PATH.exists():
-            raise ResourceNotFoundError(
-                f"Research sweep master prompt not found at '{_MASTER_PROMPT_PATH}'."
-            )
-        return _MASTER_PROMPT_PATH.read_text(encoding="utf-8")
+        return load_master_prompt_text(
+            default_path=_MASTER_PROMPT_PATH,
+            override=self._master_prompt_override,
+            missing_message=f"Research sweep master prompt not found at '{_MASTER_PROMPT_PATH}'.",
+        )
 
     def _render_research_memory_payload(self) -> dict[str, Any]:
         raw_memory_fields = self._context_runtime_state.memory_fields

--- a/harnessiq/agents/sdk_helpers.py
+++ b/harnessiq/agents/sdk_helpers.py
@@ -1,0 +1,230 @@
+"""Public SDK helpers and shared agent-construction utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from harnessiq.config.harness_profiles import HarnessProfile, HarnessProfileStore
+from harnessiq.config.provider_credentials.api import get_provider_credential_spec
+from harnessiq.shared.agents import (
+    DEFAULT_AGENT_MAX_TOKENS,
+    DEFAULT_AGENT_RESET_THRESHOLD,
+    AgentRuntimeConfig,
+)
+from harnessiq.shared.exceptions import ResourceNotFoundError
+from harnessiq.shared.harness_manifest import HarnessManifest
+from harnessiq.shared.harness_manifests import get_harness_manifest
+from harnessiq.shared.hooks import DEFAULT_APPROVAL_POLICY
+from harnessiq.shared.tool_selection import ToolSelectionConfig
+from harnessiq.utils import ConnectionsConfigStore, build_output_sinks
+
+
+def build_agent_runtime_config(
+    *,
+    sink_specs: Sequence[str] = (),
+    use_persisted_connections: bool = True,
+    approval_policy: str | None = None,
+    allowed_tools: Sequence[str] = (),
+    dynamic_tools_enabled: bool = False,
+    dynamic_tool_top_k: int = 5,
+    dynamic_tool_candidates: Sequence[str] = (),
+    dynamic_tool_embedding_model: str | None = None,
+    max_tokens: int = DEFAULT_AGENT_MAX_TOKENS,
+    reset_threshold: float = DEFAULT_AGENT_RESET_THRESHOLD,
+    langsmith_tracing_enabled: bool = True,
+    session_id: str | None = None,
+) -> AgentRuntimeConfig:
+    """Build an ``AgentRuntimeConfig`` from high-level SDK parameters."""
+    output_sinks = ()
+    if sink_specs:
+        connections = ()
+        if use_persisted_connections:
+            connections = ConnectionsConfigStore().load().enabled_connections()
+        output_sinks = build_output_sinks(connections=connections, sink_specs=sink_specs)
+    tool_selection = ToolSelectionConfig(
+        enabled=dynamic_tools_enabled,
+        embedding_model=dynamic_tool_embedding_model,
+        top_k=dynamic_tool_top_k,
+        candidate_tool_keys=_parse_allowed_tool_values(dynamic_tool_candidates),
+    )
+    return AgentRuntimeConfig(
+        max_tokens=max_tokens,
+        reset_threshold=reset_threshold,
+        approval_policy=approval_policy or DEFAULT_APPROVAL_POLICY,
+        allowed_tools=_parse_allowed_tool_values(allowed_tools),
+        tool_selection=tool_selection,
+        output_sinks=output_sinks,
+        langsmith_tracing_enabled=langsmith_tracing_enabled,
+        session_id=session_id,
+    )
+
+
+def inspect_harness(manifest_id: str | HarnessManifest) -> dict[str, Any]:
+    """Return the structured inspection payload for one harness manifest."""
+    manifest = manifest_id if isinstance(manifest_id, HarnessManifest) else get_harness_manifest(manifest_id)
+    return {
+        "harness": manifest.manifest_id,
+        "display_name": manifest.display_name,
+        "import_path": manifest.import_path,
+        "cli_command": manifest.cli_command,
+        "cli_adapter_path": manifest.cli_adapter_path,
+        "default_memory_root": manifest.resolved_default_memory_root,
+        "runtime_parameters": [_render_parameter_spec(spec) for spec in manifest.runtime_parameters],
+        "custom_parameters": [_render_parameter_spec(spec) for spec in manifest.custom_parameters],
+        "runtime_parameters_open_ended": manifest.runtime_parameters_open_ended,
+        "custom_parameters_open_ended": manifest.custom_parameters_open_ended,
+        "memory_files": [
+            {
+                "key": entry.key,
+                "relative_path": entry.relative_path,
+                "description": entry.description,
+                "kind": entry.kind,
+                "format": entry.format,
+            }
+            for entry in manifest.memory_files
+        ],
+        "provider_families": list(manifest.provider_families),
+        "provider_credential_fields": _build_provider_credential_fields(manifest),
+        "output_schema": manifest.output_schema,
+    }
+
+
+def load_persisted_profile(
+    *,
+    manifest_id: str,
+    memory_path: str | Path,
+) -> HarnessProfile | None:
+    """Load a persisted profile from ``memory_path`` when one exists."""
+    store = HarnessProfileStore(memory_path=Path(memory_path))
+    if not store.profile_path.exists():
+        return None
+    payload = json.loads(store.profile_path.read_text(encoding="utf-8"))
+    profile = HarnessProfile.from_dict(payload)
+    if profile.manifest_id != manifest_id:
+        return None
+    return profile
+
+
+def merge_profile_parameters(
+    *,
+    profile: HarnessProfile | None,
+    runtime_overrides: Mapping[str, Any] | None = None,
+    custom_overrides: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Overlay explicit overrides on top of persisted profile parameters."""
+    runtime_parameters = dict(profile.runtime_parameters if profile is not None else {})
+    if runtime_overrides:
+        runtime_parameters.update(runtime_overrides)
+    custom_parameters = dict(profile.custom_parameters if profile is not None else {})
+    if custom_overrides:
+        custom_parameters.update(custom_overrides)
+    return runtime_parameters, custom_parameters
+
+
+def resolve_profile_memory_path(
+    *,
+    profile: HarnessProfile,
+    manifest: HarnessManifest,
+    memory_path: str | Path | None = None,
+) -> Path:
+    """Resolve the profile memory path, defaulting to the manifest root plus agent name."""
+    if memory_path is not None:
+        return Path(memory_path)
+    return _resolve_memory_path(
+        profile.agent_name,
+        manifest.resolved_default_memory_root,
+        slugifier=_slugify_agent_name,
+    )
+
+
+def load_master_prompt_text(
+    *,
+    default_path: Path,
+    override: str | Path | None = None,
+    missing_message: str,
+) -> str:
+    """Return prompt text from ``override`` or ``default_path``."""
+    if override is not None:
+        if isinstance(override, Path):
+            if not override.exists():
+                raise ResourceNotFoundError(missing_message)
+            return override.read_text(encoding="utf-8")
+        override_text = str(override)
+        candidate_path = Path(override_text)
+        if "\n" not in override_text and candidate_path.exists() and candidate_path.is_file():
+            return candidate_path.read_text(encoding="utf-8")
+        return override_text
+    if not default_path.exists():
+        raise ResourceNotFoundError(missing_message)
+    return default_path.read_text(encoding="utf-8")
+
+
+def _parse_allowed_tool_values(values: Sequence[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        for part in str(raw_value).split(","):
+            candidate = part.strip()
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            normalized.append(candidate)
+    return tuple(normalized)
+
+
+def _slugify_agent_name(agent_name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", agent_name.strip()).strip("-")
+    if not cleaned:
+        raise ValueError("Agent names must contain at least one alphanumeric character.")
+    return cleaned
+
+
+def _resolve_memory_path(
+    agent_name: str,
+    memory_root: str,
+    *,
+    slugifier=_slugify_agent_name,
+) -> Path:
+    return Path(memory_root).expanduser() / slugifier(agent_name)
+
+
+def _render_parameter_spec(spec) -> dict[str, Any]:
+    return {
+        "key": spec.key,
+        "type": spec.value_type,
+        "description": spec.description,
+        "nullable": spec.nullable,
+        "default": spec.default,
+        "choices": list(spec.choices),
+    }
+
+
+def _build_provider_credential_fields(manifest: HarnessManifest) -> dict[str, list[dict[str, str]]]:
+    credential_fields: dict[str, list[dict[str, str]]] = {}
+    for family in manifest.provider_families:
+        try:
+            spec = get_provider_credential_spec(family)
+        except KeyError:
+            credential_fields[family] = []
+            continue
+        credential_fields[family] = [
+            {
+                "name": field.name,
+                "description": field.description,
+            }
+            for field in spec.fields
+        ]
+    return credential_fields
+
+
+__all__ = [
+    "build_agent_runtime_config",
+    "inspect_harness",
+    "load_master_prompt_text",
+    "load_persisted_profile",
+    "merge_profile_parameters",
+    "resolve_profile_memory_path",
+]

--- a/harnessiq/agents/spawn_specialized_subagents/agent.py
+++ b/harnessiq/agents/spawn_specialized_subagents/agent.py
@@ -7,11 +7,13 @@ from typing import Any, Mapping, Sequence
 
 from harnessiq.agents.base import BaseAgent
 from harnessiq.agents.helpers import resolve_memory_path, utc_now_z
+from harnessiq.agents.sdk_helpers import merge_profile_parameters, resolve_profile_memory_path
 from harnessiq.agents.spawn_specialized_subagents.stages import (
     DelegationPlannerStage,
     IntegrationStage,
     WorkerExecutionStage,
 )
+from harnessiq.config import HarnessProfile
 from harnessiq.agents.subcalls import JsonSubcallRunner
 from harnessiq.shared.agents import (
     AgentModel,
@@ -161,6 +163,41 @@ class SpawnSpecializedSubagentsAgent(BaseAgent):
             json_subcall_runner=json_subcall_runner,
             instance_name=instance_name,
             **normalized_runtime,
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        *,
+        profile: HarnessProfile,
+        model: AgentModel,
+        memory_path: str | Path | None = None,
+        tools: Sequence[RegisteredTool] | None = None,
+        runtime_config: AgentRuntimeConfig | None = None,
+        runtime_overrides: Mapping[str, Any] | None = None,
+        custom_overrides: Mapping[str, Any] | None = None,
+        json_subcall_runner: JsonSubcallRunner | None = None,
+        instance_name: str | None = None,
+    ) -> "SpawnSpecializedSubagentsAgent":
+        resolved_path = resolve_profile_memory_path(
+            profile=profile,
+            manifest=SPAWN_SPECIALIZED_SUBAGENTS_HARNESS_MANIFEST,
+            memory_path=memory_path,
+        )
+        resolved_runtime, resolved_custom = merge_profile_parameters(
+            profile=profile,
+            runtime_overrides=runtime_overrides,
+            custom_overrides=custom_overrides,
+        )
+        return cls.from_memory(
+            model=model,
+            memory_path=resolved_path,
+            runtime_overrides=resolved_runtime,
+            custom_overrides=resolved_custom,
+            tools=tools,
+            runtime_config=runtime_config,
+            json_subcall_runner=json_subcall_runner,
+            instance_name=instance_name or profile.agent_name,
         )
 
     def build_instance_payload(self) -> dict[str, Any]:

--- a/harnessiq/config/__init__.py
+++ b/harnessiq/config/__init__.py
@@ -40,6 +40,7 @@ from .model_profiles import (
 )
 from .loader import CredentialLoader
 from .models import ProviderCredentialConfig
+from .sdk import resolve_harness_credentials, seed_environment
 
 __all__ = [
     "AgentCredentialBinding",
@@ -76,6 +77,8 @@ __all__ = [
     "get_provider_credential_spec",
     "list_provider_credential_specs",
     "parse_dotenv_file",
+    "resolve_harness_credentials",
+    "seed_environment",
 ]
 
 _LAZY_PROVIDER_CREDENTIAL_EXPORTS = {

--- a/harnessiq/config/sdk.py
+++ b/harnessiq/config/sdk.py
@@ -1,0 +1,103 @@
+"""Public SDK wrappers over persisted config and environment lifecycle helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from harnessiq.config.credentials import DotEnvFileNotFoundError, parse_dotenv_file
+from harnessiq.config.credentials import CredentialsConfigStore, AgentCredentialsNotConfiguredError
+from harnessiq.config.harness_profiles import build_harness_credential_binding_name
+from harnessiq.shared.langsmith import LANGSMITH_ENV_ALIAS_GROUPS
+from harnessiq.shared.harness_manifest import HarnessManifest
+
+
+def seed_environment(repo_root: str | Path = ".") -> dict[str, str]:
+    """Seed repo-local environment variables and LangSmith aliases."""
+    parsed = _load_repo_environment_values(repo_root)
+    if not parsed:
+        return {}
+    applied = _seed_environment_variables(parsed)
+    applied.update(_seed_langsmith_aliases(parsed))
+    return applied
+
+
+def resolve_harness_credentials(
+    manifest: HarnessManifest,
+    *,
+    agent_name: str,
+    repo_root: str | Path = ".",
+) -> dict[str, object]:
+    """Resolve persisted credential bindings for one harness profile."""
+    store = CredentialsConfigStore(repo_root=Path(repo_root))
+    binding_name = build_harness_credential_binding_name(
+        manifest_id=manifest.manifest_id,
+        agent_name=agent_name,
+    )
+    try:
+        binding = store.load().binding_for(binding_name)
+    except AgentCredentialsNotConfiguredError:
+        return {}
+    resolved = store.resolve_binding(binding)
+    resolved_by_family: dict[str, dict[str, str]] = {}
+    for field_name, value in resolved.as_dict().items():
+        family, _, credential_field = field_name.partition(".")
+        if not credential_field:
+            continue
+        resolved_by_family.setdefault(family, {})[credential_field] = value
+    credential_objects: dict[str, object] = {}
+    for family, values in resolved_by_family.items():
+        from harnessiq.config.provider_credentials.api import get_provider_credential_spec
+
+        credential_objects[family] = get_provider_credential_spec(family).build_credentials(values)
+    return credential_objects
+
+
+def _load_repo_environment_values(repo_root: str | Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for env_path in _find_env_paths(repo_root):
+        try:
+            parsed.update(parse_dotenv_file(env_path))
+        except DotEnvFileNotFoundError:
+            continue
+    return parsed
+
+
+def _find_env_paths(repo_root: str | Path) -> tuple[Path, ...]:
+    resolved_root = Path(repo_root).expanduser().resolve()
+    for candidate in (resolved_root, *resolved_root.parents):
+        env_paths = tuple(
+            path
+            for path in (candidate / filename for filename in (".env", "local.env"))
+            if path.exists() and path.is_file()
+        )
+        if env_paths:
+            return env_paths
+    return ()
+
+
+def _seed_environment_variables(parsed: dict[str, str]) -> dict[str, str]:
+    applied: dict[str, str] = {}
+    for env_name, value in parsed.items():
+        if env_name in os.environ:
+            continue
+        os.environ[env_name] = value
+        applied[env_name] = value
+    return applied
+
+
+def _seed_langsmith_aliases(parsed: dict[str, str]) -> dict[str, str]:
+    applied: dict[str, str] = {}
+    for canonical_name, legacy_name in LANGSMITH_ENV_ALIAS_GROUPS:
+        resolved_value = parsed.get(canonical_name) or parsed.get(legacy_name)
+        if resolved_value is None:
+            continue
+        for env_name in (canonical_name, legacy_name):
+            if env_name in os.environ:
+                continue
+            os.environ[env_name] = resolved_value
+            applied[env_name] = resolved_value
+    return applied
+
+
+__all__ = ["resolve_harness_credentials", "seed_environment"]

--- a/harnessiq/shared/agents.py
+++ b/harnessiq/shared/agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Sequence, TypedDict
 
 from harnessiq.shared.hooks import (
@@ -15,7 +16,7 @@ from harnessiq.shared.tool_selection import ToolSelectionConfig
 from harnessiq.shared.tools import ToolCall, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
-    from harnessiq.shared.hooks import RegisteredHook
+    from harnessiq.shared.hooks import HookDefinition, RegisteredHook
     from harnessiq.utils.ledger import OutputSink
 
 DEFAULT_AGENT_MAX_TOKENS = 80_000
@@ -149,6 +150,20 @@ class AgentRuntimeConfig:
     def reset_token_limit(self) -> int:
         """Return the token estimate that should trigger a transcript reset."""
         return max(1, int(self.max_tokens * self.reset_threshold))
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRuntimeSnapshot:
+    """Assembled pre-run runtime state for one agent instance."""
+
+    system_prompt: str
+    parameter_sections: tuple["AgentParameterSection", ...]
+    tools: tuple[ToolDefinition, ...]
+    hooks: tuple["HookDefinition", ...]
+    runtime_config: AgentRuntimeConfig
+    memory_path: Path
+    instance_id: str
+    instance_name: str
 
 
 def merge_agent_runtime_config(
@@ -545,6 +560,7 @@ __all__ = [
     "AgentRunResult",
     "AgentRunStatus",
     "AgentRuntimeConfig",
+    "AgentRuntimeSnapshot",
     "AgentToolExecutor",
     "AgentTranscriptEntry",
     "AgentTranscriptEntryType",

--- a/harnessiq/shared/leads.py
+++ b/harnessiq/shared/leads.py
@@ -602,9 +602,15 @@ class LeadsMemoryStore:
     def run_state_path(self) -> Path:
         return self.memory_path / RUN_STATE_FILENAME
 
+    @property
+    def runtime_parameters_path(self) -> Path:
+        return self.memory_path / RUNTIME_PARAMETERS_FILENAME
+
     def prepare(self) -> None:
         self.memory_path.mkdir(parents=True, exist_ok=True)
         self.icps_dir.mkdir(parents=True, exist_ok=True)
+        if not self.runtime_parameters_path.exists():
+            _write_json(self.runtime_parameters_path, {})
 
     def write_run_config(self, config: LeadRunConfig) -> None:
         self.prepare()
@@ -621,6 +627,13 @@ class LeadsMemoryStore:
     def read_run_state(self) -> LeadRunState:
         data = _read_json_file(self.run_state_path, expected_type=dict)
         return LeadRunState.from_dict(data)
+
+    def write_runtime_parameters(self, parameters: dict[str, Any]) -> None:
+        self.prepare()
+        _write_json(self.runtime_parameters_path, dict(parameters))
+
+    def read_runtime_parameters(self) -> dict[str, Any]:
+        return _read_json_file(self.runtime_parameters_path, expected_type=dict)
 
     def initialize_icp_states(self, icps: Sequence[LeadICP]) -> None:
         self.prepare()

--- a/tests/test_agents_base.py
+++ b/tests/test_agents_base.py
@@ -234,6 +234,24 @@ class BaseAgentTests(unittest.TestCase):
         assert agent.last_tool_selection_result is not None
         self.assertEqual(agent.last_tool_selection_result.selected_keys, ("session.write", "filesystem.read"))
 
+    def test_snapshot_prepares_and_returns_assembled_runtime_state(self) -> None:
+        registry = ToolRegistry([_constant_tool("session.echo", "echo", _echo_handler)])
+        agent = _InspectableAgent(
+            model=_FakeModel([AgentModelResponse(assistant_message="done", should_continue=False)]),
+            tool_executor=registry,
+            parameter_versions=["snapshot-state"],
+        )
+
+        snapshot = agent.snapshot()
+
+        self.assertEqual(snapshot.system_prompt, "System prompt")
+        self.assertEqual(snapshot.parameter_sections[0].title, "State")
+        self.assertEqual(snapshot.parameter_sections[0].content, "snapshot-state")
+        self.assertEqual([tool.key for tool in snapshot.tools], ["session.echo"])
+        self.assertEqual(snapshot.memory_path, agent.memory_path)
+        self.assertEqual(snapshot.instance_id, agent.instance_id)
+        self.assertEqual(snapshot.instance_name, agent.instance_name)
+
     def test_run_records_tool_results_and_passes_transcript_to_next_turn(self) -> None:
         registry = ToolRegistry(
             [

--- a/tests/test_sdk_agent_helpers.py
+++ b/tests/test_sdk_agent_helpers.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from harnessiq.agents import (
+    build_agent_runtime_config,
+    build_output_sinks,
+    inspect_harness,
+)
+from harnessiq.agents import KnowtAgent, LeadsAgent
+from harnessiq.config import (
+    AgentCredentialBinding,
+    CredentialEnvReference,
+    CredentialsConfigStore,
+    HarnessProfile,
+    resolve_harness_credentials,
+    seed_environment,
+)
+from harnessiq.shared.harness_manifests import get_harness_manifest
+from harnessiq.shared.leads import LeadICP, LeadRunConfig, LeadsMemoryStore
+from harnessiq.utils import ConnectionsConfigStore, JSONLLedgerSink, SinkConnection, SlackSink
+
+
+def _mock_model() -> MagicMock:
+    model = MagicMock()
+    model.generate_turn.return_value = MagicMock()
+    return model
+
+
+def test_build_agent_runtime_config_resolves_connections_and_sink_specs(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HARNESSIQ_HOME", str(tmp_path / "home"))
+    ConnectionsConfigStore().upsert(
+        SinkConnection(
+            name="team-slack",
+            sink_type="slack",
+            config={"webhook_url": "https://example.test/webhook"},
+        )
+    )
+
+    config = build_agent_runtime_config(
+        sink_specs=("jsonl:logs/runs.jsonl",),
+        approval_policy="always",
+        allowed_tools=("filesystem.read_text_file", "context.*"),
+        dynamic_tools_enabled=True,
+        dynamic_tool_candidates=("filesystem.read_text_file,context.*",),
+        dynamic_tool_top_k=2,
+        max_tokens=2048,
+        reset_threshold=0.8,
+        session_id="sdk-session",
+    )
+
+    assert config.max_tokens == 2048
+    assert config.reset_threshold == 0.8
+    assert config.allowed_tools == ("filesystem.read_text_file", "context.*")
+    assert config.tool_selection.enabled is True
+    assert config.tool_selection.candidate_tool_keys == ("filesystem.read_text_file", "context.*")
+    assert config.session_id == "sdk-session"
+    assert any(isinstance(sink, SlackSink) for sink in config.output_sinks)
+    assert any(isinstance(sink, JSONLLedgerSink) for sink in config.output_sinks)
+
+
+def test_inspect_harness_returns_manifest_backed_payload() -> None:
+    payload = inspect_harness("research_sweep")
+
+    assert payload["harness"] == "research_sweep"
+    assert payload["default_memory_root"] == "memory/research_sweep"
+    assert "serper" in payload["provider_credential_fields"]
+    assert "type" in payload["runtime_parameters"][0]
+
+
+def test_build_output_sinks_is_promoted_via_agents_namespace() -> None:
+    sinks = build_output_sinks(sink_specs=("jsonl:logs/runs.jsonl",))
+
+    assert len(sinks) == 1
+    assert isinstance(sinks[0], JSONLLedgerSink)
+
+
+def test_seed_environment_public_wrapper_reads_env_files(tmp_path, monkeypatch) -> None:
+    (tmp_path / ".env").write_text("XAI_API_KEY=base-key\n", encoding="utf-8")
+    (tmp_path / "local.env").write_text("LANGCHAIN_API_KEY=langsmith-key\n", encoding="utf-8")
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+
+    applied = seed_environment(tmp_path)
+
+    assert applied["XAI_API_KEY"] == "base-key"
+    assert applied["LANGSMITH_API_KEY"] == "langsmith-key"
+
+
+def test_resolve_harness_credentials_returns_provider_objects(tmp_path) -> None:
+    manifest = get_harness_manifest("knowt")
+    CredentialsConfigStore(repo_root=tmp_path).upsert(
+        AgentCredentialBinding(
+            agent_name="harness::knowt::channel-a",
+            references=(
+                CredentialEnvReference(field_name="creatify.api_id", env_var="CREATIFY_API_ID"),
+                CredentialEnvReference(field_name="creatify.api_key", env_var="CREATIFY_API_KEY"),
+            ),
+        )
+    )
+    (tmp_path / ".env").write_text(
+        "CREATIFY_API_ID=cid_123\nCREATIFY_API_KEY=key_456\n",
+        encoding="utf-8",
+    )
+
+    resolved = resolve_harness_credentials(manifest, agent_name="channel-a", repo_root=tmp_path)
+
+    assert "creatify" in resolved
+    assert resolved["creatify"].api_id == "cid_123"
+
+
+def test_leads_from_memory_uses_run_config_and_runtime_parameters(tmp_path) -> None:
+    store = LeadsMemoryStore(memory_path=tmp_path / "leads")
+    store.prepare()
+    store.write_run_config(
+        LeadRunConfig(
+            company_background="We sell workflow tooling.",
+            icps=(LeadICP(label="Operations leaders"),),
+            platforms=("apollo",),
+        )
+    )
+    store.write_runtime_parameters(
+        {
+            "max_tokens": 4096,
+            "reset_threshold": 0.75,
+            "search_summary_every": 7,
+            "search_tail_size": 3,
+        }
+    )
+
+    agent = LeadsAgent.from_memory(
+        model=_mock_model(),
+        memory_path=store.memory_path,
+        tools=(),
+        instance_name="ops",
+    )
+
+    assert agent.config.max_tokens == 4096
+    assert agent.config.reset_threshold == 0.75
+    assert agent.config.run_config.search_summary_every == 7
+    assert agent.config.run_config.search_tail_size == 3
+    assert agent.instance_name == "ops"
+
+
+def test_knowt_from_profile_uses_profile_runtime_parameters(tmp_path) -> None:
+    profile = HarnessProfile(
+        manifest_id="knowt",
+        agent_name="channel-a",
+        runtime_parameters={"max_tokens": 3210, "reset_threshold": 0.7},
+    )
+
+    agent = KnowtAgent.from_profile(
+        profile=profile,
+        model=_mock_model(),
+        memory_path=tmp_path / "knowt" / "channel-a",
+    )
+
+    assert agent.config.max_tokens == 3210
+    assert agent.config.reset_threshold == 0.7


### PR DESCRIPTION
﻿## Summary
- add public SDK helpers for agent runtime config construction, harness inspection, environment seeding, and persisted credential resolution
- add `BaseAgent.snapshot()` and `AgentRuntimeSnapshot` plus `from_memory()` / `from_profile()` reconstruction paths across the runnable agent surface touched by this design
- add focused SDK tests covering the new helper APIs and reconstruction flows

## Testing
- `python -m pytest tests/test_sdk_agent_helpers.py tests/test_cli_environment.py tests/test_cli_builders.py tests/test_leads_agent.py tests/test_knowt_agent.py tests/test_exa_outreach_agent.py tests/test_agents_base.py -k "not test_run_pauses_when_builtin_pause_tool_is_invoked" -q`

## Notes
- The excluded `tests/test_agents_base.py::test_run_pauses_when_builtin_pause_tool_is_invoked` is a pre-existing unrelated failure on the branch line I started from.
