### PR TITLE
Remove redundant Instagram recent-search transcript context

### DIFF
--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -38,7 +38,7 @@ from harnessiq.shared.agents import (
     merge_agent_runtime_config,
 )
 from harnessiq.shared.dtos import InstagramAgentInstancePayload
-from harnessiq.shared.exceptions import ConfigurationError, ResourceNotFoundError
+from harnessiq.shared.exceptions import ConfigurationError
 from harnessiq.shared.instagram import (
     DEFAULT_AGENT_IDENTITY,
     DEFAULT_RECENT_RESULT_WINDOW,
@@ -520,10 +520,6 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
         result = super()._execute_tool(tool_call)
         if tool_call.tool_key == INSTAGRAM_SEARCH_KEYWORD:
             self.refresh_parameters()
-            self._append_recent_search_context_entry(
-                keyword=tool_call.arguments.get("keyword"),
-                result=result,
-            )
         return result
 
     def _record_assistant_response(self, response: AgentModelResponse) -> None:
@@ -589,33 +585,6 @@ class InstagramKeywordDiscoveryAgent(BaseAgent):
             self._attempted_search_keywords = self._attempted_search_keywords[
                 -self._config.recent_search_window :
             ]
-
-    def _append_recent_search_context_entry(
-        self,
-        *,
-        keyword: Any,
-        result: ToolResult,
-    ) -> None:
-        cleaned_keyword = keyword.strip() if isinstance(keyword, str) else ""
-        recent_searches = self._recent_search_keywords_for_context()
-        if not recent_searches and not cleaned_keyword:
-            return
-        output = result.output if isinstance(result.output, Mapping) else {}
-        payload = {
-            "active_icp": self._current_icp_description(),
-            "keyword": cleaned_keyword,
-            "recent_searches": list(recent_searches),
-            "status": str(output.get("status", "unknown")),
-        }
-        if "error" in output:
-            payload["error"] = str(output["error"])
-        self._transcript.append(
-            AgentTranscriptEntry(
-                entry_type="context",
-                label="Recent Searches",
-                content=json.dumps(payload, indent=2, sort_keys=True),
-            )
-        )
 
     def _activate_icp(self, icp_index: int) -> None:
         self._active_icp_index = icp_index

--- a/tests/test_instagram_agent.py
+++ b/tests/test_instagram_agent.py
@@ -146,7 +146,7 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertEqual(run_state["status"], "completed")
             self.assertEqual(run_state["active_icp_index"], 1)
 
-    def test_search_tool_persists_results_and_refreshes_active_icp_context(self) -> None:
+    def test_search_tool_persists_results_and_refreshes_active_icp_context_without_transcript_duplication(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             model = _FakeModel(
                 [
@@ -172,24 +172,13 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertEqual(backend.calls, [("fitness coach", 5)])
             self.assertEqual(model.requests[1].parameter_sections[0].content, "fitness creators")
             self.assertEqual(model.requests[1].parameter_sections[2].content, "fitness coach")
-            self.assertEqual(len(model.requests[1].transcript), 1)
-            self.assertEqual(model.requests[1].transcript[0].entry_type, "context")
-            self.assertEqual(model.requests[1].transcript[0].label, "Recent Searches")
-            self.assertEqual(
-                json.loads(model.requests[1].transcript[0].content),
-                {
-                    "active_icp": "fitness creators",
-                    "keyword": "fitness coach",
-                    "recent_searches": ["fitness coach"],
-                    "status": "searched",
-                },
-            )
+            self.assertEqual(model.requests[1].transcript, ())
             self.assertFalse(any(entry.entry_type == "tool_call" for entry in agent.transcript))
             self.assertFalse(any(entry.entry_type == "tool_result" for entry in agent.transcript))
             database = json.loads(Path(temp_dir, "lead_database.json").read_text(encoding="utf-8"))
             self.assertEqual(database["emails"], ["creator@example.com"])
 
-    def test_sequential_searches_append_recent_search_context_entries(self) -> None:
+    def test_sequential_searches_refresh_recent_search_parameter_without_transcript_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             model = _FakeModel(
                 [
@@ -219,16 +208,8 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
             self.assertEqual(result.status, "completed")
             self.assertEqual(model.requests[1].parameter_sections[2].content, "fitness coach")
             self.assertEqual(model.requests[2].parameter_sections[2].content, "fitness coach, pilates creator")
-            self.assertEqual(len(model.requests[1].transcript), 1)
-            self.assertEqual(len(model.requests[2].transcript), 2)
-            self.assertEqual(
-                json.loads(model.requests[1].transcript[0].content)["recent_searches"],
-                ["fitness coach"],
-            )
-            self.assertEqual(
-                json.loads(model.requests[2].transcript[-1].content)["recent_searches"],
-                ["fitness coach", "pilates creator"],
-            )
+            self.assertEqual(model.requests[1].transcript, ())
+            self.assertEqual(model.requests[2].transcript, ())
             self.assertFalse(any(entry.entry_type == "tool_call" for entry in model.requests[2].transcript))
             self.assertFalse(any(entry.entry_type == "tool_result" for entry in model.requests[2].transcript))
 
@@ -255,6 +236,7 @@ class InstagramKeywordDiscoveryAgentTests(unittest.TestCase):
 
             self.assertEqual(result.status, "completed")
             self.assertEqual(model.requests[1].parameter_sections[2].content, "fitness coach")
+            self.assertEqual(model.requests[1].transcript, ())
             self.assertEqual(agent.get_search_history(), ())
 
     def test_duplicate_keyword_detection_is_scoped_per_icp(self) -> None:


### PR DESCRIPTION
## Summary
- stop appending redundant \[CONTEXT: Recent Searches]\ transcript entries after \instagram.search_keyword\
- keep recent-search state flowing through the existing \Recent Searches\ parameter section
- update Instagram agent tests to assert the parameter-only behavior on success and failure paths

## Verification
- python -m pytest tests/test_instagram_agent.py