### PR TITLE
Harden Instagram browser fingerprinting

### DIFF
--- a/harnessiq/integrations/instagram_playwright.py
+++ b/harnessiq/integrations/instagram_playwright.py
@@ -18,8 +18,13 @@ from harnessiq.providers.playwright import (
 )
 from harnessiq.shared.instagram import (
     DEFAULT_INSTAGRAM_BROWSER_CHANNEL,
+    DEFAULT_INSTAGRAM_BROWSER_COLOR_SCHEME,
+    DEFAULT_INSTAGRAM_BROWSER_EXTRA_HTTP_HEADERS,
     DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,
     DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS,
+    DEFAULT_INSTAGRAM_BROWSER_LOCALE,
+    DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID,
+    DEFAULT_INSTAGRAM_BROWSER_USER_AGENT,
     DEFAULT_INSTAGRAM_BROWSER_VIEWPORT,
     DEFAULT_INSTAGRAM_HEADLESS,
     DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS,
@@ -55,6 +60,7 @@ class PlaywrightInstagramSearchBackend:
         search_interval_seconds: float = _DEFAULT_SEARCH_INTERVAL_SECONDS,
         launch_args: Sequence[str] | None = None,
         init_scripts: Sequence[str] | None = None,
+        context_options: dict[str, Any] | None = None,
     ) -> None:
         self._session_dir = Path(session_dir) if session_dir else None
         self._headless = headless
@@ -71,6 +77,17 @@ class PlaywrightInstagramSearchBackend:
             tuple(str(value) for value in init_scripts if str(value).strip())
             if init_scripts is not None
             else (DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,)
+        )
+        self._context_options = (
+            dict(context_options)
+            if context_options is not None
+            else {
+                "color_scheme": DEFAULT_INSTAGRAM_BROWSER_COLOR_SCHEME,
+                "extra_http_headers": dict(DEFAULT_INSTAGRAM_BROWSER_EXTRA_HTTP_HEADERS),
+                "locale": DEFAULT_INSTAGRAM_BROWSER_LOCALE,
+                "timezone_id": DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID,
+                "user_agent": DEFAULT_INSTAGRAM_BROWSER_USER_AGENT,
+            }
         )
         self._session: PlaywrightBrowserSession | None = None
         self._search_page: Any = None
@@ -135,6 +152,7 @@ class PlaywrightInstagramSearchBackend:
                 import_error_message=_DEFAULT_IMPORT_ERROR_MESSAGE,
                 launch_args=self._launch_args,
                 init_scripts=self._init_scripts,
+                context_options=self._context_options,
             )
             session.start()
             self._session = session
@@ -256,6 +274,17 @@ def create_search_backend() -> InstagramSearchBackend:
         ),
         launch_args=() if hardening_disabled else None,
         init_scripts=() if hardening_disabled else None,
+        context_options=(
+            {}
+            if hardening_disabled
+            else {
+                "color_scheme": DEFAULT_INSTAGRAM_BROWSER_COLOR_SCHEME,
+                "extra_http_headers": dict(DEFAULT_INSTAGRAM_BROWSER_EXTRA_HTTP_HEADERS),
+                "locale": DEFAULT_INSTAGRAM_BROWSER_LOCALE,
+                "timezone_id": DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID,
+                "user_agent": DEFAULT_INSTAGRAM_BROWSER_USER_AGENT,
+            }
+        ),
     )
 
 

--- a/harnessiq/providers/playwright/browser.py
+++ b/harnessiq/providers/playwright/browser.py
@@ -21,6 +21,7 @@ class PlaywrightBrowserSession:
         import_error_message: str,
         launch_args: Sequence[str] = (),
         init_scripts: Sequence[str] = (),
+        context_options: Mapping[str, Any] | None = None,
     ) -> None:
         self._session_dir = Path(session_dir) if session_dir is not None else None
         self._channel = channel
@@ -29,6 +30,7 @@ class PlaywrightBrowserSession:
         self._import_error_message = import_error_message
         self._launch_args = tuple(str(value) for value in launch_args)
         self._init_scripts = tuple(str(value) for value in init_scripts if str(value).strip())
+        self._context_options = dict(context_options or {})
         self._playwright: Any = None
         self._browser: Any = None
         self._context: Any = None
@@ -49,14 +51,15 @@ class PlaywrightBrowserSession:
             raise RuntimeError(self._import_error_message) from exc
 
         self._playwright = sync_playwright().start()
+        context_kwargs = {"viewport": dict(self._viewport), **self._context_options}
         if self._session_dir is not None:
             self._session_dir.mkdir(parents=True, exist_ok=True)
             self._context = self._playwright.chromium.launch_persistent_context(
                 str(self._session_dir),
                 channel=self._channel,
                 headless=self._headless,
-                viewport=dict(self._viewport),
                 args=list(self._launch_args),
+                **context_kwargs,
             )
             self._browser = None
             self._apply_init_scripts()
@@ -66,7 +69,7 @@ class PlaywrightBrowserSession:
             headless=self._headless,
             args=list(self._launch_args),
         )
-        self._context = self._browser.new_context(viewport=dict(self._viewport))
+        self._context = self._browser.new_context(**context_kwargs)
         self._apply_init_scripts()
 
     def get_or_create_page(self) -> Any:

--- a/harnessiq/shared/instagram.py
+++ b/harnessiq/shared/instagram.py
@@ -27,13 +27,49 @@ DEFAULT_INSTAGRAM_HEADLESS = False
 DEFAULT_INSTAGRAM_TIMEOUT_MS = 30_000
 DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS = 5_000
 DEFAULT_INSTAGRAM_BROWSER_VIEWPORT = {"width": 1280, "height": 900}
+DEFAULT_INSTAGRAM_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/134.0.0.0 Safari/537.36"
+)
+DEFAULT_INSTAGRAM_BROWSER_LOCALE = "en-US"
+DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID = "America/New_York"
+DEFAULT_INSTAGRAM_BROWSER_COLOR_SCHEME = "light"
+DEFAULT_INSTAGRAM_BROWSER_EXTRA_HTTP_HEADERS = {"Accept-Language": "en-US,en;q=0.9"}
 DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS = ("--disable-blink-features=AutomationControlled",)
 DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT = """
 Object.defineProperty(navigator, 'webdriver', {get: () => undefined});
+Object.defineProperty(navigator, 'language', {get: () => 'en-US'});
 Object.defineProperty(navigator, 'languages', {get: () => ['en-US', 'en']});
 Object.defineProperty(navigator, 'platform', {get: () => 'Win32'});
 Object.defineProperty(navigator, 'plugins', {get: () => [1, 2, 3, 4, 5]});
-window.chrome = window.chrome || { runtime: {} };
+Object.defineProperty(navigator, 'pdfViewerEnabled', {get: () => true});
+Object.defineProperty(navigator, 'hardwareConcurrency', {get: () => 8});
+Object.defineProperty(navigator, 'userAgentData', {
+  get: () => ({
+    brands: [
+      { brand: 'Google Chrome', version: '134' },
+      { brand: 'Chromium', version: '134' },
+      { brand: 'Not.A/Brand', version: '24' }
+    ],
+    mobile: false,
+    platform: 'Windows',
+    getHighEntropyValues: async () => ({
+      architecture: 'x86',
+      bitness: '64',
+      mobile: false,
+      model: '',
+      platform: 'Windows',
+      platformVersion: '10.0.0',
+      uaFullVersion: '134.0.0.0',
+    }),
+  }),
+});
+window.chrome = window.chrome || {
+  app: { isInstalled: false },
+  runtime: {},
+  webstore: {},
+};
 """
 
 DEFAULT_RECENT_SEARCH_WINDOW = 10
@@ -847,8 +883,13 @@ __all__ = [
     "CUSTOM_PARAMETERS_FILENAME",
     "DEFAULT_AGENT_IDENTITY",
     "DEFAULT_INSTAGRAM_BROWSER_CHANNEL",
+    "DEFAULT_INSTAGRAM_BROWSER_COLOR_SCHEME",
+    "DEFAULT_INSTAGRAM_BROWSER_EXTRA_HTTP_HEADERS",
     "DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT",
     "DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS",
+    "DEFAULT_INSTAGRAM_BROWSER_LOCALE",
+    "DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID",
+    "DEFAULT_INSTAGRAM_BROWSER_USER_AGENT",
     "DEFAULT_INSTAGRAM_BROWSER_VIEWPORT",
     "DEFAULT_INSTAGRAM_HEADLESS",
     "DEFAULT_INSTAGRAM_NETWORK_IDLE_TIMEOUT_MS",

--- a/memory/fix-instagram-browser-reuse/clarifications.md
+++ b/memory/fix-instagram-browser-reuse/clarifications.md
@@ -1,0 +1,4 @@
+No blocking clarifications were required after Phase 1.
+
+- The requested behavior is unambiguous enough to implement directly: reuse one persistent browser context and a stable tab during an Instagram run, while hardening the browser surface to reduce automation detection.
+- If live CLI verification exposes a contradictory product expectation, that would be surfaced after reproduction, but it is not a blocker for implementation.

--- a/memory/fix-instagram-browser-reuse/internalization.md
+++ b/memory/fix-instagram-browser-reuse/internalization.md
@@ -1,0 +1,50 @@
+### 1a: Structural Survey
+
+- The authoritative runtime code lives under `harnessiq/`, with tests under `tests/`, generated architecture guidance under `artifacts/`, and durable local engineering/runtime state under `memory/`.
+- The Instagram harness is split across four main layers:
+  - `harnessiq/agents/instagram/agent.py`: the concrete agent loop and lifecycle.
+  - `harnessiq/shared/instagram.py`: constants, runtime parameter specs, and the `InstagramMemoryStore`.
+  - `harnessiq/integrations/instagram_playwright.py`: the deterministic Google-to-Instagram Playwright backend.
+  - `harnessiq/cli/runners/instagram.py` plus `harnessiq/cli/adapters/instagram.py`: CLI wiring that prepares memory, sets the browser session dir, and constructs the backend for a run.
+- Shared Playwright browser lifecycle helpers live in `harnessiq/providers/playwright/browser.py`. The current helper supports a reusable `PlaywrightBrowserSession` with one live context and page reuse through `get_or_create_page()`.
+- The Instagram CLI path already sets `HARNESSIQ_INSTAGRAM_SESSION_DIR` to `memory/<agent>/browser-data`, so the intended architecture is a persistent Chromium user-data directory per Instagram agent memory folder.
+- The current test surface is focused and useful:
+  - `tests/test_instagram_playwright.py` covers query building, URL normalization, fallback behavior, explicit Google block detection, and backend-level session reuse.
+  - `tests/test_instagram_agent.py` covers the Instagram loop and search-tool integration.
+  - `tests/test_instagram_cli.py` and `tests/test_cli_runners.py` cover CLI wiring and environment setup.
+- Relevant adjacent patterns:
+  - `harnessiq/integrations/google_maps_playwright.py` also uses persistent Playwright contexts.
+  - LinkedIn and prospecting runners treat browser session directories as durable per-agent state and expect one browser session per run, not one browser launch per tool call.
+
+### 1b: Task Cross-Reference
+
+- User request: the Instagram agent “keeps using different browsers and not just different tabs.”
+  - This maps to `harnessiq/integrations/instagram_playwright.py` and `harnessiq/providers/playwright/browser.py`, because the backend owns browser/context/page reuse.
+  - It also maps to CLI construction in `harnessiq/cli/runners/instagram.py` and `harnessiq/cli/adapters/instagram.py`, because repeated backend construction would create repeated browser sessions.
+- User request: Google/search results may be detecting the browser as AI/automation and “the search results are not popping up.”
+  - This maps to the Instagram browser hardening constants in `harnessiq/shared/instagram.py` and the page-navigation/result-detection logic in `harnessiq/integrations/instagram_playwright.py`.
+  - The current hardening only applies one launch arg and a small init script. There is no more realistic browser surface, no explicit user-agent override, and no recovery path when a persistent context restores multiple tabs or starts on an unexpected page.
+- User request: use the repo CLI to test with `max_cycles=2` until fixed.
+  - This maps to the dedicated CLI flow in `harnessiq/cli/instagram/commands.py` and `harnessiq/cli/runners/instagram.py`.
+  - Live verification must use `harnessiq instagram run ... --max-cycles 2` or the equivalent module entrypoint.
+- Files most likely in scope:
+  - `harnessiq/integrations/instagram_playwright.py`
+  - `harnessiq/providers/playwright/browser.py`
+  - `harnessiq/shared/instagram.py`
+  - `tests/test_instagram_playwright.py`
+  - potentially `tests/test_cli_runners.py` if runner/session behavior changes.
+- Existing behavior that must be preserved:
+  - The backend should remain reusable within one run.
+  - The CLI should keep defaulting the browser session dir to `memory/<agent>/browser-data`.
+  - Search execution should still produce the same `InstagramSearchExecution` contract and continue surfacing explicit Google block errors.
+
+### 1c: Assumption & Risk Inventory
+
+- Assumption: “different browsers” means multiple Chromium windows/contexts are being created or restored when one persistent session should be reused for the whole run.
+- Assumption: the right UX is one persistent browser context per run and one stable search tab within that context, with reused tabs preferred over opening new windows.
+- Assumption: stronger browser hardening is acceptable as long as it remains opt-out through the existing `HARNESSIQ_INSTAGRAM_DISABLE_BROWSER_HARDENING` path.
+- Risk: persistent contexts can restore multiple tabs from earlier runs; blindly using `context.pages[0]` can select an arbitrary restored tab instead of the dedicated search tab.
+- Risk: changing generic Playwright session behavior too broadly could affect adjacent integrations. The safest change is additive or scoped to the Instagram backend.
+- Risk: live CLI reproduction depends on local model/browser availability and may fail for reasons outside the browser fix. Unit tests must cover the deterministic parts so the behavior is still verifiable offline.
+
+Phase 1 complete

--- a/memory/fix-instagram-browser-reuse/tickets/index.md
+++ b/memory/fix-instagram-browser-reuse/tickets/index.md
@@ -1,0 +1,3 @@
+# Ticket Index
+
+1. `ticket-1.md` — Harden the Instagram Playwright browser context so one reused session/page can reach real search results in CLI runs, including headless mode.

--- a/memory/fix-instagram-browser-reuse/tickets/ticket-1-critique.md
+++ b/memory/fix-instagram-browser-reuse/tickets/ticket-1-critique.md
@@ -1,0 +1,12 @@
+Post-implementation critique:
+
+- The first version of the investigation focused on session reuse, but live CLI logging showed that reuse was already correct. The real bug was browser fingerprinting in headless mode. Keeping the provider-layer change generic while scoping the actual hardening policy to Instagram is the simpler and more defensible fix.
+- The Playwright helper change stays additive: it now accepts `context_options`, but existing callers do not need to change and retain their current behavior.
+- The Instagram hardening defaults are intentionally modest. They fix the concrete `HeadlessChrome`/locale/timezone/header gap without turning the shared provider layer into a broad stealth browser abstraction.
+- The live CLI probe should remain in `memory/` only. It is useful for this ticket’s verification, but it is not product code.
+
+Applied refinements after critique:
+
+- Kept the new browser-context configuration in the generic session helper instead of hardcoding Instagram-only logic in the provider layer.
+- Centralized all Instagram-specific browser hardening constants in `harnessiq/shared/instagram.py` so future tuning stays in one place.
+- Verified the fix with the actual CLI path and a deterministic two-search probe rather than relying only on unit tests.

--- a/memory/fix-instagram-browser-reuse/tickets/ticket-1-quality.md
+++ b/memory/fix-instagram-browser-reuse/tickets/ticket-1-quality.md
@@ -1,0 +1,47 @@
+Stage 1 — Static Analysis
+
+- No project linter is configured.
+- Manually reviewed:
+  - `harnessiq/providers/playwright/browser.py`
+  - `harnessiq/shared/instagram.py`
+  - `harnessiq/integrations/instagram_playwright.py`
+  - `tests/test_instagram_playwright.py`
+- Result: kept the provider-layer change additive and scoped the new hardening policy to Instagram.
+
+Stage 2 — Type Checking
+
+- Ran:
+  - `python -m compileall harnessiq\providers\playwright\browser.py harnessiq\shared\instagram.py harnessiq\integrations\instagram_playwright.py tests\test_instagram_playwright.py`
+- Result: passed.
+
+Stage 3 — Unit Tests
+
+- Ran:
+  - `python -m pytest tests\test_instagram_playwright.py tests\test_instagram_agent.py tests\test_instagram_cli.py tests\test_cli_runners.py -q`
+- Result: `53 passed in 4.01s`.
+
+Stage 4 — Integration & Contract Tests
+
+- No separate browser integration suite exists in the repo.
+- Relied on targeted regression tests plus live CLI smoke verification against the real Playwright backend.
+
+Stage 5 — Smoke & Manual Verification
+
+- Reproduced the pre-fix behavior with the CLI probe:
+  - one reused session/page was already in use,
+  - but both searches hit Google’s `sorry` interstitial in headless mode.
+- Verified the root fingerprint issue separately:
+  - default headless Chromium exposed `HeadlessChrome/...` in `navigator.userAgent`.
+- Re-ran the CLI probe after the fix:
+  - command:
+    - `python -m harnessiq.cli instagram run --agent probe --memory-root memory\fix-instagram-browser-reuse\runtime --model-factory memory.fix_instagram_browser_reuse.cli_probe:create_two_search_model --search-backend-factory memory.fix_instagram_browser_reuse.cli_probe:create_logging_search_backend --max-cycles 2`
+  - environment:
+    - `HARNESSIQ_INSTAGRAM_HEADLESS=true`
+  - observed result:
+    - CLI returned `email_count: 7`
+    - backend log showed one reused session id and one reused page id across both searches
+    - lead persistence succeeded for both `ai educator` and `stem creator`
+
+Confirmation:
+
+- The Instagram backend now keeps one reused browser session/page and can successfully load real search results in the reproduced headless CLI path.

--- a/memory/fix-instagram-browser-reuse/tickets/ticket-1.md
+++ b/memory/fix-instagram-browser-reuse/tickets/ticket-1.md
@@ -1,0 +1,39 @@
+Title: Harden the Instagram Playwright browser context for reused CLI sessions
+
+Intent: Keep the Instagram agent on one reused browser session/page per run while removing the browser fingerprints that caused Google to serve anti-bot interstitials instead of real search results.
+
+Scope:
+- Extend the shared Playwright session helper so integrations can pass explicit browser-context options.
+- Update the Instagram Playwright backend to supply a normal Chrome user agent and a small set of realistic browser-context defaults.
+- Preserve the existing run-scoped session reuse and deterministic search contract.
+- Add regression coverage for the new hardening inputs.
+- Do not redesign the Instagram agent loop or change the durable memory schema.
+
+Relevant Files:
+- `harnessiq/providers/playwright/browser.py`: accept integration-supplied context options and apply them to created browser contexts.
+- `harnessiq/shared/instagram.py`: centralize Instagram browser hardening constants.
+- `harnessiq/integrations/instagram_playwright.py`: pass hardened context options into the reusable Playwright session.
+- `tests/test_instagram_playwright.py`: verify the hardened defaults and explicit overrides.
+
+Approach: The root failure in live CLI reproduction was not session reuse; the backend already reused one session and one page. The actual issue was the browser fingerprint, especially `HeadlessChrome` in the user agent when headless mode was enabled. The fix therefore keeps the existing run-scoped session model and makes the session helper configurable so the Instagram integration can provide a realistic Chrome user agent, locale, timezone, color scheme, and accept-language header. The existing init-script hardening remains in place and is extended slightly to fill obvious browser-surface gaps.
+
+Assumptions:
+- A standard Chrome user agent and realistic browser-context metadata are sufficient to avoid the specific Google anti-bot response seen in the local CLI reproduction.
+- Instagram should continue to own its own browser hardening policy instead of pushing those defaults onto every Playwright-backed integration.
+- The existing `HARNESSIQ_INSTAGRAM_DISABLE_BROWSER_HARDENING` path should still disable both launch-arg/init-script hardening and the new context-option hardening.
+
+Acceptance Criteria:
+- [ ] The shared Playwright session helper accepts browser-context options without breaking existing integrations.
+- [ ] The Instagram Playwright backend passes hardened context options by default.
+- [ ] Instagram Playwright tests cover both the new default hardening and explicit override behavior.
+- [ ] A live `harnessiq instagram run ... --max-cycles 2` probe no longer hits the Google sorry page in the reproduced headless scenario and persists real leads/emails.
+
+Verification Steps:
+- Static analysis: inspect changed files for style and API consistency.
+- Type checking: run `python -m compileall harnessiq\providers\playwright\browser.py harnessiq\shared\instagram.py harnessiq\integrations\instagram_playwright.py tests\test_instagram_playwright.py`.
+- Unit tests: run `python -m pytest tests\test_instagram_playwright.py tests\test_instagram_agent.py tests\test_instagram_cli.py tests\test_cli_runners.py -q`.
+- Smoke verification: run `python -m harnessiq.cli instagram run --agent probe --memory-root memory\fix-instagram-browser-reuse\runtime --model-factory memory.fix_instagram_browser_reuse.cli_probe:create_two_search_model --search-backend-factory memory.fix_instagram_browser_reuse.cli_probe:create_logging_search_backend --max-cycles 2` with `HARNESSIQ_INSTAGRAM_HEADLESS=true`.
+
+Dependencies: None
+
+Drift Guard: This ticket must not broaden Playwright behavior for unrelated agents beyond making context options possible, and it must not redesign Instagram persistence or the agent loop in response to a browser-fingerprinting failure.

--- a/memory/fix_instagram_browser_reuse/__init__.py
+++ b/memory/fix_instagram_browser_reuse/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for the fix-instagram-browser-reuse task."""

--- a/memory/fix_instagram_browser_reuse/cli_probe.py
+++ b/memory/fix_instagram_browser_reuse/cli_probe.py
@@ -1,0 +1,155 @@
+"""Deterministic CLI probe helpers for the Instagram browser-reuse task."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from harnessiq.agents import AgentModelRequest, AgentModelResponse
+from harnessiq.integrations.instagram_playwright import create_search_backend
+from harnessiq.shared.tools import ToolCall
+
+
+class _TwoSearchModel:
+    """Issue two Instagram searches, then stop."""
+
+    def __init__(self) -> None:
+        self._turn_index = 0
+        self._log_path = (
+            Path(__file__).resolve().parents[1]
+            / "fix-instagram-browser-reuse"
+            / "cli-probe-model.jsonl"
+        )
+
+    def generate_turn(self, request: AgentModelRequest) -> AgentModelResponse:
+        self._turn_index += 1
+        self._write_event(
+            {
+                "turn_index": self._turn_index,
+                "tool_keys": [tool.key for tool in request.tools],
+                "parameter_titles": [section.title for section in request.parameter_sections],
+                "transcript": request.render_transcript(),
+            }
+        )
+        if self._turn_index == 1:
+            return AgentModelResponse(
+                assistant_message="Search the first keyword.",
+                tool_calls=(ToolCall(tool_key="instagram.search_keyword", arguments={"keyword": "ai educator"}),),
+                should_continue=True,
+            )
+        if self._turn_index == 2:
+            return AgentModelResponse(
+                assistant_message="Search the second keyword.",
+                tool_calls=(ToolCall(tool_key="instagram.search_keyword", arguments={"keyword": "stem creator"}),),
+                should_continue=True,
+            )
+        return AgentModelResponse(
+            assistant_message="Done.",
+            should_continue=False,
+        )
+
+    def _write_event(self, payload: dict[str, Any]) -> None:
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "payload": payload,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+
+
+def create_two_search_model() -> _TwoSearchModel:
+    """Return a deterministic model factory for CLI probing."""
+    return _TwoSearchModel()
+
+
+class _LoggingSearchBackend:
+    """Wrap the real Instagram Playwright backend and persist debug events."""
+
+    def __init__(self) -> None:
+        self._backend = create_search_backend()
+        self._log_path = (
+            Path(__file__).resolve().parents[1]
+            / "fix-instagram-browser-reuse"
+            / "cli-probe-log.jsonl"
+        )
+
+    def search_keyword(self, *, keyword: str, max_results: int) -> Any:
+        self._write_event(
+            "before_search",
+            {
+                "keyword": keyword,
+                "max_results": max_results,
+                "session_id": id(getattr(self._backend, "_session", None)),
+                "page_id": id(getattr(self._backend, "_search_page", None)),
+            },
+        )
+        try:
+            result = self._backend.search_keyword(keyword=keyword, max_results=max_results)
+        except Exception as exc:
+            self._write_event(
+                "search_error",
+                {
+                    "keyword": keyword,
+                    "error": str(exc),
+                    "session_id": id(getattr(self._backend, "_session", None)),
+                    "page_id": id(getattr(self._backend, "_search_page", None)),
+                    "page_count": self._page_count(),
+                },
+            )
+            raise
+        self._write_event(
+            "after_search",
+            {
+                "keyword": keyword,
+                "lead_count": result.search_record.lead_count,
+                "email_count": result.search_record.email_count,
+                "session_id": id(getattr(self._backend, "_session", None)),
+                "page_id": id(getattr(self._backend, "_search_page", None)),
+                "page_count": self._page_count(),
+            },
+        )
+        return result
+
+    def close(self) -> None:
+        self._write_event(
+            "close",
+            {
+                "session_id": id(getattr(self._backend, "_session", None)),
+                "page_id": id(getattr(self._backend, "_search_page", None)),
+                "page_count": self._page_count(),
+            },
+        )
+        close = getattr(self._backend, "close", None)
+        if callable(close):
+            close()
+
+    def _page_count(self) -> int | None:
+        session = getattr(self._backend, "_session", None)
+        context = getattr(session, "_context", None)
+        pages = getattr(context, "pages", None)
+        if pages is None:
+            return None
+        try:
+            return len(pages)
+        except Exception:
+            return None
+
+    def _write_event(self, event: str, payload: dict[str, Any]) -> None:
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "event": event,
+            "payload": payload,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+
+
+def create_logging_search_backend() -> _LoggingSearchBackend:
+    """Return the real backend wrapped with file logging for CLI repro."""
+    return _LoggingSearchBackend()

--- a/tests/test_instagram_playwright.py
+++ b/tests/test_instagram_playwright.py
@@ -12,6 +12,9 @@ from harnessiq.integrations.instagram_playwright import (
 from harnessiq.shared.instagram import (
     DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,
     DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS,
+    DEFAULT_INSTAGRAM_BROWSER_LOCALE,
+    DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID,
+    DEFAULT_INSTAGRAM_BROWSER_USER_AGENT,
     DEFAULT_INSTAGRAM_HEADLESS,
     build_instagram_google_fallback_query,
     build_instagram_google_query,
@@ -257,6 +260,9 @@ class InstagramPlaywrightTests(unittest.TestCase):
         self.assertEqual(kwargs["headless"], DEFAULT_INSTAGRAM_HEADLESS)
         self.assertEqual(kwargs["launch_args"], DEFAULT_INSTAGRAM_BROWSER_LAUNCH_ARGS)
         self.assertEqual(kwargs["init_scripts"], (DEFAULT_INSTAGRAM_BROWSER_INIT_SCRIPT,))
+        self.assertEqual(kwargs["context_options"]["locale"], DEFAULT_INSTAGRAM_BROWSER_LOCALE)
+        self.assertEqual(kwargs["context_options"]["timezone_id"], DEFAULT_INSTAGRAM_BROWSER_TIMEZONE_ID)
+        self.assertEqual(kwargs["context_options"]["user_agent"], DEFAULT_INSTAGRAM_BROWSER_USER_AGENT)
 
     def test_backend_allows_explicit_session_hardening_overrides(self) -> None:
         search_page = _FakePage(entries=[])
@@ -271,6 +277,7 @@ class InstagramPlaywrightTests(unittest.TestCase):
                 headless=True,
                 launch_args=("--custom-arg",),
                 init_scripts=("window.__custom = true;",),
+                context_options={"locale": "fr-FR", "user_agent": "CustomAgent/1.0"},
             )
             backend._get_session()
 
@@ -278,6 +285,7 @@ class InstagramPlaywrightTests(unittest.TestCase):
         self.assertTrue(kwargs["headless"])
         self.assertEqual(kwargs["launch_args"], ("--custom-arg",))
         self.assertEqual(kwargs["init_scripts"], ("window.__custom = true;",))
+        self.assertEqual(kwargs["context_options"], {"locale": "fr-FR", "user_agent": "CustomAgent/1.0"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harden the Instagram Playwright browser context with realistic user-agent, locale, timezone, and header defaults
- extend the shared Playwright session helper to accept integration-supplied context options
- add regression coverage for the new default hardening and explicit override behavior

## Verification
- python -m compileall harnessiq\providers\playwright\browser.py harnessiq\shared\instagram.py harnessiq\integrations\instagram_playwright.py tests\test_instagram_playwright.py
- python -m pytest tests\test_instagram_playwright.py tests\test_instagram_agent.py tests\test_instagram_cli.py tests\test_cli_runners.py -q
- python -m harnessiq.cli instagram run --agent probe --memory-root memory\fix-instagram-browser-reuse\runtime --model-factory memory.fix_instagram_browser_reuse.cli_probe:create_two_search_model --search-backend-factory memory.fix_instagram_browser_reuse.cli_probe:create_logging_search_backend --max-cycles 2

## Notes
- the only remaining local dirty file is `memory/agent_instances.json`, produced by the CLI verification run, and it is not part of this PR