### PR TITLE
Document runtime agents, tools, and formalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Harnessiq ships a dedicated Google Cloud deployment surface for running manifest
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 10 |
-| Test modules | 132 |
+| Test modules | 135 |
 
 ## Agent Matrix
 

--- a/artifacts/file_index.md
+++ b/artifacts/file_index.md
@@ -15,7 +15,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | Service provider packages | 27 |
 | Tool-only external service surfaces | 1 |
 | Built-in sink types | 10 |
-| Test modules | 132 |
+| Test modules | 135 |
 
 ## Codebase Standards
 
@@ -33,11 +33,16 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 
 | Path | Kind | Responsibility |
 | --- | --- | --- |
+| `.harnessiq/` | generated/cache | Fallback local HarnessIQ home used by the ledger/output-sink runtime when the preferred home path is not writable. |
+| `.worktrees/` | local state | Git worktree checkouts used for isolated implementation branches; local-only and not part of the shipped package. |
 | `artifacts/` | repo docs | Generated and curated repository reference artifacts. |
+| `build/` | generated/cache | Setuptools build output; generated, not part of the live source tree. |
 | `docs/` | repo docs | Focused usage and architecture notes for the package. |
 | `harnessiq/` | source | Live SDK package source. |
+| `harnessiq.egg-info/` | generated/cache | Packaging metadata emitted by local builds. |
 | `memory/` | local state | Task artifacts plus durable agent runtime state; not part of the shipped package. |
 | `scripts/` | repo tooling | Repository maintenance and generation scripts. |
+| `src/` | generated/cache | Legacy or generated residue in this checkout; not the authoritative package source. |
 | `tests/` | source | unittest coverage for runtime, CLI, providers, and tools. |
 
 ## Package Layout
@@ -47,7 +52,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | `harnessiq/agents/` | apollo, base, email, exa, exa_outreach, instagram, instantly, knowt, leads, linkedin, mission_driven, outreach, prospecting, provider_base, research_sweep, spawn_specialized_subagents | Shared runtime bases plus the concrete harness packages exported by the SDK. |
 | `harnessiq/cli/` | adapters, agents, builders, commands, email, exa_outreach, gcloud, instagram, leads, ledger, linkedin, master_prompts, models, prospecting, providers, research_sweep, runners, skills, stats, tools | Argparse entrypoints and command-family modules for harness management plus ledger/output-sink operations. |
 | `harnessiq/config/` | provider_credentials | Environment loading, credential binding, and provider-credential spec models. |
-| `harnessiq/evaluations/` | - | Pytest-first evaluation helpers, lightweight scoring helpers, and plugin support for tagged eval runs. |
+| `harnessiq/evaluations/` | correctness, efficiency, output, tool_use | Pytest-first evaluation helpers, lightweight scoring helpers, and plugin support for tagged eval runs. |
 | `harnessiq/integrations/` | - | Concrete external runtime adapters such as Playwright backends and model factories. |
 | `harnessiq/interfaces/` | formalization | Public runtime dependency seams and injectable formalization abstractions used by the SDK surface. |
 | `harnessiq/master_prompts/` | prompts | Packaged prompt assets and prompt registry helpers. |
@@ -198,7 +203,7 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 
 ## Test Surface
 
-`tests/` currently contains 132 test modules. The table below groups them by dominant responsibility.
+`tests/` currently contains 135 test modules. The table below groups them by dominant responsibility.
 
 | Area | Count | Examples |
 | --- | --- | --- |
@@ -206,5 +211,5 @@ It is intentionally high-signal rather than exhaustive: the goal is to explain t
 | cli | 15 | `tests/test_agents_cli.py`, `tests/test_email_cli.py`, `tests/test_exa_outreach_cli.py` |
 | ledger | 1 | `tests/test_output_sinks.py` |
 | providers | 32 | `tests/test_anthropic_provider.py`, `tests/test_apollo_provider.py`, `tests/test_arcads_provider.py` |
-| support | 46 | `tests/test_cli_builders.py`, `tests/test_cli_common.py`, `tests/test_cli_environment.py` |
-| tools | 16 | `tests/test_context_compaction_tools.py`, `tests/test_context_window_tools.py`, `tests/test_general_tools.py` |
+| support | 48 | `tests/test_cli_builders.py`, `tests/test_cli_common.py`, `tests/test_cli_environment.py` |
+| tools | 17 | `tests/test_context_compaction_tools.py`, `tests/test_context_window_tools.py`, `tests/test_formalization_behaviors_tool_pace.py` |

--- a/harnessiq/agents/__init__.py
+++ b/harnessiq/agents/__init__.py
@@ -1,4 +1,28 @@
-"""Agent runtime primitives and concrete agent implementations."""
+"""
+===============================================================================
+File: harnessiq/agents/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents` within the
+  HarnessIQ runtime.
+- Agent runtime primitives and concrete agent implementations.
+
+Use cases:
+- Import ActionLogEntry, AgentInstanceCatalog, AgentInstanceRecord,
+  AgentInstanceStore, AgentModel, AgentModelRequest from one stable package
+  entry point.
+- Read this module to understand what `harnessiq/agents` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/agents` when you want the supported facade instead of
+  reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents` explicit, discoverable, and
+  easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.shared.agents import (
     AgentModel,

--- a/harnessiq/agents/apollo/__init__.py
+++ b/harnessiq/agents/apollo/__init__.py
@@ -1,4 +1,27 @@
-"""Apollo-backed reusable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/apollo/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/apollo` within
+  the HarnessIQ runtime.
+- Apollo-backed reusable agent harnesses.
+
+Use cases:
+- Import ApolloAgentRequest, ApolloAgentConfig, BaseApolloAgent,
+  DEFAULT_APOLLO_AGENT_IDENTITY from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/apollo` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/apollo` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/apollo` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.apollo.agent import BaseApolloAgent
 from harnessiq.shared.dtos import ApolloAgentRequest

--- a/harnessiq/agents/apollo/agent.py
+++ b/harnessiq/agents/apollo/agent.py
@@ -1,4 +1,29 @@
-"""Reusable Apollo-backed agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/apollo/agent.py
+
+What this file does:
+- Implements the concrete `BaseApolloAgent` runtime for the `apollo` agent
+  package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable Apollo-backed agent harnesses.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseApolloAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `apollo` workflow packaged as one reusable HarnessIQ harness instead
+  of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/apollo/helpers.py
+++ b/harnessiq/agents/apollo/helpers.py
@@ -1,3 +1,23 @@
-"""Apollo agent helper module."""
+"""
+===============================================================================
+File: harnessiq/agents/apollo/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `apollo` package.
+- Apollo agent helper module.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/apollo` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `apollo` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 __all__: list[str] = []

--- a/harnessiq/agents/base/__init__.py
+++ b/harnessiq/agents/base/__init__.py
@@ -1,4 +1,28 @@
-"""Base agent runtime abstractions."""
+"""
+===============================================================================
+File: harnessiq/agents/base/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/base` within
+  the HarnessIQ runtime.
+- Base agent runtime abstractions.
+
+Use cases:
+- Import AgentModel, AgentModelRequest, AgentModelResponse,
+  AgentParameterSection, AgentPauseSignal, AgentRunResult from one stable
+  package entry point.
+- Read this module to understand what `harnessiq/agents/base` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/agents/base` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/base` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.shared.hooks import (
     ApprovalPolicy,

--- a/harnessiq/agents/base/agent.py
+++ b/harnessiq/agents/base/agent.py
@@ -1,4 +1,34 @@
-"""Reusable agent runtime abstractions and loop orchestration."""
+"""
+===============================================================================
+File: harnessiq/agents/base/agent.py
+
+What this file does:
+- Implements the shared HarnessIQ agent runtime that every long-running
+  tool-using harness builds on.
+- Owns model-request assembly, transcript management, tool execution, context
+  resets, and formalization integration.
+- Reusable agent runtime abstractions and loop orchestration.
+
+Use cases:
+- Subclass it when building a new durable agent with provider-backed tools.
+- Inspect it when you need to understand how the main run loop decides to
+  continue, pause, reset, or complete.
+- Use it as the reference point for how stages, artifacts, hooks, and dynamic
+  tool selection plug into the SDK.
+
+How to use it:
+- Implement `build_instance_payload()`, `build_system_prompt()`, and
+  `load_parameter_sections()` in a subclass.
+- Pass tool registries, runtime config, and optional formalization layers into
+  the constructor.
+- Call `run()` for the managed loop or `snapshot()` when you need the assembled
+  runtime state without execution.
+
+Intent:
+- Keep every agent on one deterministic runtime contract so business workflows
+  can vary without each package reinventing loop orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -437,6 +467,9 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
 
     def _run_loop(self, *, max_cycles: int | None = None) -> AgentRunResult:
         """Run the agent loop until it pauses, completes, or hits ``max_cycles``."""
+        # This reset establishes one clean runtime window for the current run.
+        # Durable state remains on disk, but transcript-local state is rebuilt so
+        # every run starts from the same deterministic baseline.
         self.prepare()
         self._reset_count = 0
         self._cycle_index = 0
@@ -462,6 +495,10 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
         cycles_completed = 0
         try:
             while max_cycles is None or cycles_completed < max_cycles:
+                # Each cycle follows the same contract: build the provider-agnostic
+                # request, ask the model for the next turn, then reconcile every
+                # requested tool call back through hooks, formalization, and
+                # transcript bookkeeping before the next cycle begins.
                 self._cycle_index = cycles_completed + 1
                 request = self.build_model_request()
                 total_estimated_request_tokens += request.estimated_tokens()
@@ -485,6 +522,10 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
                 reset_after_tool_result = False
                 last_recorded_tool_result: ToolResult | None = None
                 for requested_tool_call in response.tool_calls:
+                    # Tool execution is intentionally multi-stage. Hooks can pause
+                    # or rewrite the call, formalization layers can intercept it,
+                    # and only then does the raw tool executor run. That ordering
+                    # keeps policy and workflow rules outside the tool code itself.
                     tool_call, result, pause_signal = self._prepare_tool_call(requested_tool_call)
                     if pause_signal is not None:
                         break
@@ -513,6 +554,10 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
                         break
                     if not self._allow_auto_reset_after_tool_result(result):
                         continue
+                    # Resets are evaluated immediately after meaningful tool
+                    # results so the next model turn sees an updated context
+                    # window. Formalization-driven resets take priority because
+                    # they encode workflow semantics rather than token hygiene.
                     if self._formalization_requires_reset():
                         self.reset_context()
                         self._last_prune_progress = self.pruning_progress_value()
@@ -638,6 +683,9 @@ class BaseAgent(BaseAgentHelpersMixin, ABC):
         )
 
     def _resolve_active_tool_keys(self) -> tuple[str, ...]:
+        # Dynamic tool selection only narrows the already-available runtime
+        # surface. It never invents tools; it filters the definitions that
+        # survived formalization and explicit allow-list checks.
         available_definitions = self.available_tools(None)
         if self._dynamic_tool_selector is None or not self._runtime_config.tool_selection.enabled:
             self._last_tool_selection_result = None

--- a/harnessiq/agents/base/agent_helpers.py
+++ b/harnessiq/agents/base/agent_helpers.py
@@ -1,4 +1,29 @@
-"""Private helper methods and utilities for the base agent runtime."""
+"""
+===============================================================================
+File: harnessiq/agents/base/agent_helpers.py
+
+What this file does:
+- Provides the shared helper mixin used by `BaseAgent` to reconcile
+  formalization layers, hook tools, context mutation, and ledger behavior.
+- Private helper methods and utilities for the base agent runtime.
+
+Use cases:
+- Read this module when debugging how a tool call is filtered, transformed, or
+  finalized before it reaches the transcript.
+- Extend these helpers when adding cross-cutting runtime behavior that should
+  apply to every agent.
+
+How to use it:
+- Treat the helpers here as internal runtime infrastructure rather than public
+  agent APIs.
+- Compose new agent behavior by extending `BaseAgent` and letting the mixin
+  methods keep orchestration consistent.
+
+Intent:
+- Centralize the non-domain-specific runtime rules so agent packages stay
+  focused on business behavior instead of SDK plumbing.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -242,6 +267,9 @@ class BaseAgentHelpersMixin:
 
     def _collect_formalization_tools(self) -> tuple[RegisteredTool, ...]:
         """Return all registered tools contributed by formalization layers."""
+        # Formalization tools are merged as a late overlay so the layer that owns
+        # a workflow constraint can also expose the deterministic tools that make
+        # the constraint operable during the run.
         collected: list[tuple[RegisteredTool, ...]] = []
         for layer in self._formalization_layers:
             layer_tools = tuple(layer.get_formalization_tools())
@@ -281,6 +309,10 @@ class BaseAgentHelpersMixin:
         base_sections: Sequence[AgentParameterSection],
     ) -> tuple[AgentParameterSection, ...]:
         """Merge durable sections, overrides, and context memory into one block."""
+        # Parameter composition is the final place where durable configuration,
+        # formalization-owned context, and runtime-injected reminders converge.
+        # The order matters because downstream context tools depend on a stable
+        # layout when they rebuild or compact the context window.
         state = self._context_runtime_state
         injected_first: list[AgentParameterSection] = []
         injected_before_memory: list[AgentParameterSection] = []
@@ -686,6 +718,9 @@ class BaseAgentHelpersMixin:
         tool_call: ToolCall,
     ) -> tuple[ToolCall | None, ToolResult | None, AgentPauseSignal | None]:
         """Run pre-tool hooks and return the executable tool call payload."""
+        # Checkpoint hooks run before general tool hooks because they protect a
+        # durable handoff boundary. The generic before-tool phase then sees the
+        # already-normalized arguments and can still pause or override execution.
         tool_definition = self._resolve_tool_definition(tool_call.tool_key)
         tool_name = tool_definition.name if tool_definition is not None else tool_call.tool_key
         context = self._make_hook_context(
@@ -746,6 +781,9 @@ class BaseAgentHelpersMixin:
         context: HookContext,
     ) -> tuple[HookContext, ToolResult | None, AgentPauseSignal | None]:
         """Execute matching hooks for one phase until one alters control flow."""
+        # Hooks are short-circuiting by design. The first hook that pauses or
+        # returns a synthetic tool result becomes the controlling policy decision
+        # for that phase, which keeps approval and safety behavior deterministic.
         current_context = context
         for hook in self._resolved_hook_tools():
             if not hook.applies_to(phase):
@@ -903,6 +941,9 @@ class BaseAgentHelpersMixin:
 
     def _is_reset_helpful(self, token_limit: int) -> bool:
         """Estimate whether clearing transcript state meaningfully reduces tokens."""
+        # The runtime only resets when dropping transcript history materially
+        # improves the next request. This avoids churn where a reset would clear
+        # history but still leave the request above the configured token budget.
         request = self.build_model_request()
         if request.estimated_tokens() < token_limit:
             return False
@@ -930,6 +971,9 @@ class BaseAgentHelpersMixin:
 
     def _apply_context_window(self, context_window: list[dict[str, Any]]) -> None:
         """Replace the active transcript and parameters from a context snapshot."""
+        # Context-compaction tools speak in a normalized context-window shape.
+        # Rehydrating that shape back into transcript and parameter objects keeps
+        # manual transcript surgery out of individual tool implementations.
         parameter_sections: list[AgentParameterSection] = []
         transcript: list[AgentTranscriptEntry] = []
         for entry in context_window:

--- a/harnessiq/agents/base/helpers.py
+++ b/harnessiq/agents/base/helpers.py
@@ -1,4 +1,24 @@
-"""Compatibility wrapper for base-agent helper utilities."""
+"""
+===============================================================================
+File: harnessiq/agents/base/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `base` package.
+- Compatibility wrapper for base-agent helper utilities.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/base` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `base` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from .agent_helpers import BaseAgentHelpersMixin, _resolve_repo_root, _utcnow
 

--- a/harnessiq/agents/email/__init__.py
+++ b/harnessiq/agents/email/__init__.py
@@ -1,4 +1,27 @@
-"""Email-capable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/email/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/email` within
+  the HarnessIQ runtime.
+- Email-capable agent harnesses.
+
+Use cases:
+- Import BaseEmailAgent, DEFAULT_EMAIL_AGENT_IDENTITY, EmailCampaignAgent,
+  EmailAgentRequest, EmailAgentConfig from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/email` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/email` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/email` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.email.agent import BaseEmailAgent
 from harnessiq.agents.email.campaign import EmailCampaignAgent

--- a/harnessiq/agents/email/agent.py
+++ b/harnessiq/agents/email/agent.py
@@ -1,4 +1,29 @@
-"""Reusable email-capable agent harnesses built on the generic runtime."""
+"""
+===============================================================================
+File: harnessiq/agents/email/agent.py
+
+What this file does:
+- Implements the concrete `BaseEmailAgent` runtime for the `email` agent
+  package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable email-capable agent harnesses built on the generic runtime.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseEmailAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `email` workflow packaged as one reusable HarnessIQ harness instead
+  of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/email/campaign.py
+++ b/harnessiq/agents/email/campaign.py
@@ -1,4 +1,25 @@
-"""Concrete durable-memory email campaign agent."""
+"""
+===============================================================================
+File: harnessiq/agents/email/campaign.py
+
+What this file does:
+- Defines the `EmailCampaignAgent` type and the supporting logic it needs in
+  the `harnessiq/agents/email` module.
+- Concrete durable-memory email campaign agent.
+
+Use cases:
+- Import `EmailCampaignAgent` when composing higher-level HarnessIQ runtime
+  behavior from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/email/helpers.py
+++ b/harnessiq/agents/email/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for email-capable agents."""
+"""
+===============================================================================
+File: harnessiq/agents/email/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `email` package.
+- Helper functions for email-capable agents.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/email` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `email` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/exa/__init__.py
+++ b/harnessiq/agents/exa/__init__.py
@@ -1,4 +1,27 @@
-"""Exa-backed reusable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/exa/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/exa` within
+  the HarnessIQ runtime.
+- Exa-backed reusable agent harnesses.
+
+Use cases:
+- Import BaseExaAgent, DEFAULT_EXA_AGENT_IDENTITY, ExaAgentRequest,
+  ExaAgentConfig from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/exa` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/agents/exa` when you want the supported facade instead
+  of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/exa` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.exa.agent import BaseExaAgent
 from harnessiq.shared.dtos import ExaAgentRequest

--- a/harnessiq/agents/exa/agent.py
+++ b/harnessiq/agents/exa/agent.py
@@ -1,4 +1,28 @@
-"""Reusable Exa-backed agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/exa/agent.py
+
+What this file does:
+- Implements the concrete `BaseExaAgent` runtime for the `exa` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable Exa-backed agent harnesses.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseExaAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `exa` workflow packaged as one reusable HarnessIQ harness instead of
+  scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/exa/helpers.py
+++ b/harnessiq/agents/exa/helpers.py
@@ -1,3 +1,23 @@
-"""Exa agent helper module."""
+"""
+===============================================================================
+File: harnessiq/agents/exa/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `exa` package.
+- Exa agent helper module.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/exa` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `exa` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 __all__: list[str] = []

--- a/harnessiq/agents/exa_outreach/__init__.py
+++ b/harnessiq/agents/exa_outreach/__init__.py
@@ -1,4 +1,27 @@
-"""ExaOutreach agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/exa_outreach/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/exa_outreach`
+  within the HarnessIQ runtime.
+- ExaOutreach agent harness.
+
+Use cases:
+- Import EXA_OUTREACH_HARNESS_MANIFEST, ExaOutreachAgent from one stable
+  package entry point.
+- Read this module to understand what `harnessiq/agents/exa_outreach` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/exa_outreach` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/exa_outreach` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import ExaOutreachAgent
 from harnessiq.shared.exa_outreach import EXA_OUTREACH_HARNESS_MANIFEST

--- a/harnessiq/agents/exa_outreach/agent.py
+++ b/harnessiq/agents/exa_outreach/agent.py
@@ -1,4 +1,29 @@
-"""ExaOutreach agent harness for prospect discovery and optional email outreach."""
+"""
+===============================================================================
+File: harnessiq/agents/exa_outreach/agent.py
+
+What this file does:
+- Implements the concrete `ExaOutreachAgent` runtime for the `exa_outreach`
+  agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- ExaOutreach agent harness for prospect discovery and optional email outreach.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `ExaOutreachAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `exa_outreach` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/exa_outreach/helpers.py
+++ b/harnessiq/agents/exa_outreach/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the ExaOutreach agent."""
+"""
+===============================================================================
+File: harnessiq/agents/exa_outreach/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `exa_outreach` package.
+- Helper functions for the ExaOutreach agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/exa_outreach` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `exa_outreach` support logic centralized so business modules
+  stay focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/helpers.py
+++ b/harnessiq/agents/helpers.py
@@ -1,4 +1,24 @@
-"""Shared helper utilities reused across agent packages."""
+"""
+===============================================================================
+File: harnessiq/agents/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `agents` package.
+- Shared helper utilities reused across agent packages.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `agents` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/instagram/__init__.py
+++ b/harnessiq/agents/instagram/__init__.py
@@ -1,4 +1,27 @@
-"""Instagram keyword discovery agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/instagram/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/instagram`
+  within the HarnessIQ runtime.
+- Instagram keyword discovery agent harness.
+
+Use cases:
+- Import INSTAGRAM_HARNESS_MANIFEST, InstagramKeywordDiscoveryAgent from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/agents/instagram` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/instagram` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/instagram` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import InstagramKeywordDiscoveryAgent
 from harnessiq.shared.instagram import INSTAGRAM_HARNESS_MANIFEST

--- a/harnessiq/agents/instagram/agent.py
+++ b/harnessiq/agents/instagram/agent.py
@@ -1,4 +1,29 @@
-"""Instagram keyword discovery agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/instagram/agent.py
+
+What this file does:
+- Implements the concrete `InstagramKeywordDiscoveryAgent` runtime for the
+  `instagram` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Instagram keyword discovery agent harness.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `InstagramKeywordDiscoveryAgent` or use its factory helpers, then
+  call `run()` or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `instagram` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/instagram/helpers.py
+++ b/harnessiq/agents/instagram/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the Instagram keyword discovery agent."""
+"""
+===============================================================================
+File: harnessiq/agents/instagram/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `instagram` package.
+- Helper functions for the Instagram keyword discovery agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/instagram` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `instagram` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/instantly/__init__.py
+++ b/harnessiq/agents/instantly/__init__.py
@@ -1,4 +1,28 @@
-"""Instantly-backed reusable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/instantly/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/instantly`
+  within the HarnessIQ runtime.
+- Instantly-backed reusable agent harnesses.
+
+Use cases:
+- Import BaseInstantlyAgent, DEFAULT_INSTANTLY_AGENT_IDENTITY,
+  InstantlyAgentRequest, InstantlyAgentConfig from one stable package entry
+  point.
+- Read this module to understand what `harnessiq/agents/instantly` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/instantly` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/instantly` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.instantly.agent import BaseInstantlyAgent
 from harnessiq.shared.dtos import InstantlyAgentRequest

--- a/harnessiq/agents/instantly/agent.py
+++ b/harnessiq/agents/instantly/agent.py
@@ -1,4 +1,29 @@
-"""Reusable Instantly-backed agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/instantly/agent.py
+
+What this file does:
+- Implements the concrete `BaseInstantlyAgent` runtime for the `instantly`
+  agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable Instantly-backed agent harnesses.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseInstantlyAgent` or use its factory helpers, then call `run()`
+  or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `instantly` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/instantly/helpers.py
+++ b/harnessiq/agents/instantly/helpers.py
@@ -1,3 +1,23 @@
-"""Instantly agent helper module."""
+"""
+===============================================================================
+File: harnessiq/agents/instantly/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `instantly` package.
+- Instantly agent helper module.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/instantly` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `instantly` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 __all__: list[str] = []

--- a/harnessiq/agents/knowt/__init__.py
+++ b/harnessiq/agents/knowt/__init__.py
@@ -1,4 +1,27 @@
-"""Knowt TikTok content creation agent."""
+"""
+===============================================================================
+File: harnessiq/agents/knowt/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/knowt` within
+  the HarnessIQ runtime.
+- Knowt TikTok content creation agent.
+
+Use cases:
+- Import KNOWT_HARNESS_MANIFEST, KnowtAgent from one stable package entry
+  point.
+- Read this module to understand what `harnessiq/agents/knowt` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/knowt` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/knowt` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .agent import KnowtAgent
 from harnessiq.shared.knowt import KNOWT_HARNESS_MANIFEST

--- a/harnessiq/agents/knowt/agent.py
+++ b/harnessiq/agents/knowt/agent.py
@@ -1,4 +1,28 @@
-"""Knowt TikTok content creation agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/knowt/agent.py
+
+What this file does:
+- Implements the concrete `KnowtAgent` runtime for the `knowt` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Knowt TikTok content creation agent harness.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `KnowtAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `knowt` workflow packaged as one reusable HarnessIQ harness instead
+  of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/knowt/helpers.py
+++ b/harnessiq/agents/knowt/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the Knowt agent."""
+"""
+===============================================================================
+File: harnessiq/agents/knowt/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `knowt` package.
+- Helper functions for the Knowt agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/knowt` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `knowt` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/leads/__init__.py
+++ b/harnessiq/agents/leads/__init__.py
@@ -1,4 +1,28 @@
-"""Leads discovery agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/leads/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/leads` within
+  the HarnessIQ runtime.
+- Leads discovery agent harness.
+
+Use cases:
+- Import LEADS_CHECK_SEEN, LEADS_COMPACT_SEARCH_HISTORY, LEADS_LOG_SEARCH,
+  LEADS_SAVE_LEADS, LEADS_HARNESS_MANIFEST, LeadsAgent from one stable package
+  entry point.
+- Read this module to understand what `harnessiq/agents/leads` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/leads` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/leads` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .agent import (
     LEADS_CHECK_SEEN,

--- a/harnessiq/agents/leads/agent.py
+++ b/harnessiq/agents/leads/agent.py
@@ -1,4 +1,28 @@
-"""Multi-ICP leads discovery agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/leads/agent.py
+
+What this file does:
+- Implements the concrete `LeadsAgent` runtime for the `leads` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Multi-ICP leads discovery agent harness.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `LeadsAgent` or use its factory helpers, then call `run()` or
+  `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `leads` workflow packaged as one reusable HarnessIQ harness instead
+  of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/leads/helpers.py
+++ b/harnessiq/agents/leads/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the Leads agent."""
+"""
+===============================================================================
+File: harnessiq/agents/leads/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `leads` package.
+- Helper functions for the Leads agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/leads` rather than
+  duplicating package-specific support code.
+
+Intent:
+- Keep reusable `leads` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/linkedin/__init__.py
+++ b/harnessiq/agents/linkedin/__init__.py
@@ -1,4 +1,28 @@
-"""LinkedIn job application agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/linkedin/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/linkedin`
+  within the HarnessIQ runtime.
+- LinkedIn job application agent harness.
+
+Use cases:
+- Import ActionLogEntry, JobApplicationRecord, LINKEDIN_HARNESS_MANIFEST,
+  LinkedInAgentConfig, LinkedInManagedFile, LinkedInJobApplierAgent from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/agents/linkedin` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/linkedin` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/linkedin` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.linkedin.agent import (
     LinkedInJobApplierAgent,

--- a/harnessiq/agents/linkedin/agent.py
+++ b/harnessiq/agents/linkedin/agent.py
@@ -1,4 +1,29 @@
-"""LinkedIn-specific agent harness and durable memory helpers."""
+"""
+===============================================================================
+File: harnessiq/agents/linkedin/agent.py
+
+What this file does:
+- Implements the concrete `LinkedInJobApplierAgent` runtime for the `linkedin`
+  agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- LinkedIn-specific agent harness and durable memory helpers.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `LinkedInJobApplierAgent` or use its factory helpers, then call
+  `run()` or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `linkedin` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/linkedin/helpers.py
+++ b/harnessiq/agents/linkedin/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the LinkedIn agent."""
+"""
+===============================================================================
+File: harnessiq/agents/linkedin/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `linkedin` package.
+- Helper functions for the LinkedIn agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/linkedin` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `linkedin` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/linkedin/prompts/__init__.py
+++ b/harnessiq/agents/linkedin/prompts/__init__.py
@@ -1,0 +1,23 @@
+"""
+===============================================================================
+File: harnessiq/agents/linkedin/prompts/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/agents/linkedin/prompts` within the HarnessIQ runtime.
+
+Use cases:
+- Import the package-level symbols from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/linkedin/prompts`
+  intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/linkedin/prompts` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/linkedin/prompts` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
+

--- a/harnessiq/agents/mission_driven/__init__.py
+++ b/harnessiq/agents/mission_driven/__init__.py
@@ -1,4 +1,26 @@
-"""Mission-driven harness package."""
+"""
+===============================================================================
+File: harnessiq/agents/mission_driven/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/agents/mission_driven` within the HarnessIQ runtime.
+- Mission-driven harness package.
+
+Use cases:
+- Import MissionDrivenAgent from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/mission_driven` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/mission_driven` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/mission_driven` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import MissionDrivenAgent
 

--- a/harnessiq/agents/mission_driven/agent.py
+++ b/harnessiq/agents/mission_driven/agent.py
@@ -1,4 +1,31 @@
-"""Concrete mission-driven harness implementation."""
+"""
+===============================================================================
+File: harnessiq/agents/mission_driven/agent.py
+
+What this file does:
+- Implements the mission-driven harness that keeps a durable mission artifact
+  synchronized with the agent loop.
+- It coordinates staged subcalls, mission memory files, and mission-specific
+  tools so planning and execution state survive resets.
+- Concrete mission-driven harness implementation.
+
+Use cases:
+- Run long-lived work that needs a mission definition, task plan, progress log,
+  checkpoints, and artifact tracking.
+- Inspect it when debugging how mission updates are normalized into the durable
+  artifact.
+
+How to use it:
+- Construct `MissionDrivenAgent` directly or load it from persisted
+  memory/profile helpers.
+- Interact with the mission through the mission tools rather than treating the
+  transcript as durable state.
+
+Intent:
+- Make durable mission execution a first-class SDK pattern instead of ad hoc
+  prompt-driven bookkeeping.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -290,6 +317,9 @@ class MissionDrivenAgent(BaseAgent):
         }
 
     def _initialize_artifact(self) -> dict[str, Any]:
+        # Artifact initialization is front-loaded into deterministic stages so
+        # the durable mission starts with a definition, plan, status, and human-
+        # readable narrative before the open-ended run loop begins.
         definition = self._definition_stage.run(
             mission_goal=self._config.mission_goal,
             mission_type=self._config.mission_type,
@@ -344,6 +374,10 @@ class MissionDrivenAgent(BaseAgent):
         return snapshot
 
     def _handle_record_updates(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        # This handler is the heart of the mission-driven harness. It reconciles
+        # partial updates from the agent back into the durable artifact, then
+        # recomputes mission status and the README summary from the new source of
+        # truth so every surface stays synchronized after a tool call.
         task_updates = self._coerce_mapping_list(arguments.get("task_updates", []))
         progress_events = self._coerce_mapping_list(arguments.get("progress_events", []))
         memory_facts = self._coerce_mapping_list(arguments.get("memory_facts", []))
@@ -481,6 +515,10 @@ class MissionDrivenAgent(BaseAgent):
         return snapshot
 
     def _apply_task_updates(self, current_plan: MissionTaskPlan, updates: list[Mapping[str, Any]]) -> MissionTaskPlan:
+        # Task updates are merge-style rather than replace-all so the model can
+        # incrementally refine the plan without resending the full task graph on
+        # every call. Existing fields survive unless the update explicitly
+        # changes them.
         task_index = {task.task_id: task for task in current_plan.tasks}
         for update in updates:
             task_id = str(update.get("id", "")).strip()
@@ -506,6 +544,9 @@ class MissionDrivenAgent(BaseAgent):
         )
 
     def _sync_file_manifest(self) -> None:
+        # The file manifest is derived from the harness manifest instead of being
+        # hand-maintained so the durable artifact can always explain which files
+        # it owns and whether each expected memory entry currently exists.
         records: list[dict[str, Any]] = []
         for entry in MISSION_DRIVEN_HARNESS_MANIFEST.memory_files:
             path = self.memory_path / entry.relative_path

--- a/harnessiq/agents/mission_driven/stages.py
+++ b/harnessiq/agents/mission_driven/stages.py
@@ -1,4 +1,24 @@
-"""Typed model stages for the mission-driven harness."""
+"""
+===============================================================================
+File: harnessiq/agents/mission_driven/stages.py
+
+What this file does:
+- Defines the staged sub-workflows used by the `mission_driven` agent package.
+- Typed model stages for the mission-driven harness.
+
+Use cases:
+- Use these stage helpers when the agent needs explicit subcalls or
+  deterministic planning steps before or after the main loop.
+
+How to use it:
+- Instantiate the stage objects from the sibling agent runtime and feed them
+  the domain payloads they expect.
+
+Intent:
+- Separate reusable stage logic from the top-level agent class so multi-step
+  workflows stay testable and easier to reason about.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/outreach/__init__.py
+++ b/harnessiq/agents/outreach/__init__.py
@@ -1,4 +1,28 @@
-"""Outreach-backed reusable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/outreach/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/outreach`
+  within the HarnessIQ runtime.
+- Outreach-backed reusable agent harnesses.
+
+Use cases:
+- Import BaseOutreachAgent, DEFAULT_OUTREACH_AGENT_IDENTITY,
+  OutreachAgentRequest, OutreachAgentConfig from one stable package entry
+  point.
+- Read this module to understand what `harnessiq/agents/outreach` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/outreach` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/outreach` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.outreach.agent import BaseOutreachAgent
 from harnessiq.shared.dtos import OutreachAgentRequest

--- a/harnessiq/agents/outreach/agent.py
+++ b/harnessiq/agents/outreach/agent.py
@@ -1,4 +1,29 @@
-"""Reusable Outreach-backed agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/outreach/agent.py
+
+What this file does:
+- Implements the concrete `BaseOutreachAgent` runtime for the `outreach` agent
+  package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable Outreach-backed agent harnesses.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseOutreachAgent` or use its factory helpers, then call `run()`
+  or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `outreach` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/outreach/helpers.py
+++ b/harnessiq/agents/outreach/helpers.py
@@ -1,3 +1,23 @@
-"""Outreach agent helper module."""
+"""
+===============================================================================
+File: harnessiq/agents/outreach/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `outreach` package.
+- Outreach agent helper module.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/outreach` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `outreach` support logic centralized so business modules stay
+  focused on orchestration.
+===============================================================================
+"""
 
 __all__: list[str] = []

--- a/harnessiq/agents/prospecting/__init__.py
+++ b/harnessiq/agents/prospecting/__init__.py
@@ -1,4 +1,28 @@
-"""Google Maps prospecting agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/prospecting/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/prospecting`
+  within the HarnessIQ runtime.
+- Google Maps prospecting agent harness.
+
+Use cases:
+- Import GoogleMapsProspectingAgent, ProspectingAgentConfig,
+  ProspectingMemoryStore, PROSPECTING_HARNESS_MANIFEST, QualifiedLeadRecord,
+  SUPPORTED_PROSPECTING_CUSTOM_PARAMETERS from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/prospecting` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/prospecting` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/prospecting` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import GoogleMapsProspectingAgent
 from harnessiq.shared.prospecting import (

--- a/harnessiq/agents/prospecting/agent.py
+++ b/harnessiq/agents/prospecting/agent.py
@@ -1,4 +1,29 @@
-"""Google Maps prospecting agent harness."""
+"""
+===============================================================================
+File: harnessiq/agents/prospecting/agent.py
+
+What this file does:
+- Implements the concrete `GoogleMapsProspectingAgent` runtime for the
+  `prospecting` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Google Maps prospecting agent harness.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `GoogleMapsProspectingAgent` or use its factory helpers, then call
+  `run()` or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `prospecting` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/prospecting/helpers.py
+++ b/harnessiq/agents/prospecting/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the Google Maps prospecting agent."""
+"""
+===============================================================================
+File: harnessiq/agents/prospecting/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `prospecting` package.
+- Helper functions for the Google Maps prospecting agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/prospecting` rather
+  than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `prospecting` support logic centralized so business modules
+  stay focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/provider_base/__init__.py
+++ b/harnessiq/agents/provider_base/__init__.py
@@ -1,4 +1,26 @@
-"""Provider-backed reusable agent harnesses."""
+"""
+===============================================================================
+File: harnessiq/agents/provider_base/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/agents/provider_base`
+  within the HarnessIQ runtime.
+- Provider-backed reusable agent harnesses.
+
+Use cases:
+- Import BaseProviderToolAgent from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/provider_base` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/provider_base` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/provider_base` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.agents.provider_base.agent import BaseProviderToolAgent
 

--- a/harnessiq/agents/provider_base/agent.py
+++ b/harnessiq/agents/provider_base/agent.py
@@ -1,4 +1,29 @@
-"""Reusable provider-backed agent harness scaffolding."""
+"""
+===============================================================================
+File: harnessiq/agents/provider_base/agent.py
+
+What this file does:
+- Implements the concrete `BaseProviderToolAgent` runtime for the
+  `provider_base` agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Reusable provider-backed agent harness scaffolding.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `BaseProviderToolAgent` or use its factory helpers, then call
+  `run()` or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `provider_base` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/provider_base/helpers.py
+++ b/harnessiq/agents/provider_base/helpers.py
@@ -1,3 +1,23 @@
-"""Provider-base agent helper module."""
+"""
+===============================================================================
+File: harnessiq/agents/provider_base/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `provider_base` package.
+- Provider-base agent helper module.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/provider_base`
+  rather than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `provider_base` support logic centralized so business modules
+  stay focused on orchestration.
+===============================================================================
+"""
 
 __all__: list[str] = []

--- a/harnessiq/agents/research_sweep/__init__.py
+++ b/harnessiq/agents/research_sweep/__init__.py
@@ -1,4 +1,26 @@
-"""Research sweep agent package."""
+"""
+===============================================================================
+File: harnessiq/agents/research_sweep/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/agents/research_sweep` within the HarnessIQ runtime.
+- Research sweep agent package.
+
+Use cases:
+- Import ResearchSweepAgent from one stable package entry point.
+- Read this module to understand what `harnessiq/agents/research_sweep` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/research_sweep` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/research_sweep` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import ResearchSweepAgent
 

--- a/harnessiq/agents/research_sweep/agent.py
+++ b/harnessiq/agents/research_sweep/agent.py
@@ -1,4 +1,29 @@
-"""Deterministic academic research sweep harness."""
+"""
+===============================================================================
+File: harnessiq/agents/research_sweep/agent.py
+
+What this file does:
+- Implements the concrete `ResearchSweepAgent` runtime for the `research_sweep`
+  agent package.
+- The module owns the package-specific memory loading, prompt assembly, and
+  tool wiring needed by that agent.
+- Deterministic academic research sweep harness.
+
+Use cases:
+- Instantiate the agent directly when you already have the required runtime
+  parameters.
+- Load the agent from persisted memory or profile helpers when resuming a
+  previous run.
+
+How to use it:
+- Construct `ResearchSweepAgent` or use its factory helpers, then call `run()`
+  or `snapshot()` through the shared base runtime.
+
+Intent:
+- Keep the `research_sweep` workflow packaged as one reusable HarnessIQ harness
+  instead of scattering its durable behavior across scripts.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/research_sweep/helpers.py
+++ b/harnessiq/agents/research_sweep/helpers.py
@@ -1,4 +1,24 @@
-"""Helper functions for the Research Sweep agent."""
+"""
+===============================================================================
+File: harnessiq/agents/research_sweep/helpers.py
+
+What this file does:
+- Collects shared helper functions for the `research_sweep` package.
+- Helper functions for the Research Sweep agent.
+
+Use cases:
+- Use these helpers when sibling runtime modules need the same normalization,
+  path resolution, or payload-shaping logic.
+
+How to use it:
+- Import the narrow helper you need from `harnessiq/agents/research_sweep`
+  rather than duplicating package-specific support code.
+
+Intent:
+- Keep reusable `research_sweep` support logic centralized so business modules
+  stay focused on orchestration.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/sdk_helpers.py
+++ b/harnessiq/agents/sdk_helpers.py
@@ -1,4 +1,24 @@
-"""Public SDK helpers and shared agent-construction utilities."""
+"""
+===============================================================================
+File: harnessiq/agents/sdk_helpers.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/agents`.
+- Public SDK helpers and shared agent-construction utilities.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `build_agent_runtime_config` and the other exported symbols here through
+  their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/spawn_specialized_subagents/__init__.py
+++ b/harnessiq/agents/spawn_specialized_subagents/__init__.py
@@ -1,4 +1,26 @@
-"""Spawn-specialized-subagents harness package."""
+"""
+===============================================================================
+File: harnessiq/agents/spawn_specialized_subagents/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/agents/spawn_specialized_subagents` within the HarnessIQ runtime.
+- Spawn-specialized-subagents harness package.
+
+Use cases:
+- Import SpawnSpecializedSubagentsAgent from one stable package entry point.
+- Read this module to understand what
+  `harnessiq/agents/spawn_specialized_subagents` intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/agents/spawn_specialized_subagents` when you want the
+  supported facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/agents/spawn_specialized_subagents`
+  explicit, discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .agent import SpawnSpecializedSubagentsAgent
 

--- a/harnessiq/agents/spawn_specialized_subagents/agent.py
+++ b/harnessiq/agents/spawn_specialized_subagents/agent.py
@@ -1,4 +1,31 @@
-"""Concrete spawn-specialized-subagents harness implementation."""
+"""
+===============================================================================
+File: harnessiq/agents/spawn_specialized_subagents/agent.py
+
+What this file does:
+- Implements the delegation harness that plans assignments, records worker
+  outputs, and integrates the final result.
+- The module owns the durable orchestration state that lets subagent planning
+  survive resets and resume coherently.
+- Concrete spawn-specialized-subagents harness implementation.
+
+Use cases:
+- Use it when one agent needs to break work into bounded assignments before
+  integrating results.
+- Inspect it when debugging how assignments are planned, executed, or
+  reconciled back into one response.
+
+How to use it:
+- Construct `SpawnSpecializedSubagentsAgent` directly or hydrate it from
+  memory/profile helpers.
+- Drive assignment planning, worker execution, and result integration through
+  the tool handlers defined here.
+
+Intent:
+- Keep delegation explicit, auditable, and restart-safe instead of relying on
+  one large free-form prompt.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -267,6 +294,8 @@ class SpawnSpecializedSubagentsAgent(BaseAgent):
         store.write_current_context(self._config.current_context)
 
     def _plan_assignments(self) -> dict[str, Any]:
+        # Planning is persisted before any worker executes so delegation becomes
+        # a restart-safe artifact, not an ephemeral one-turn model suggestion.
         payload = self._planner_stage.run(
             objective=self._memory_store.read_objective(),
             available_agent_types=self._config.available_agent_types,
@@ -297,6 +326,9 @@ class SpawnSpecializedSubagentsAgent(BaseAgent):
         return payload
 
     def _handle_run_assignment(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        # Assignment execution is deliberately single-assignment-at-a-time. That
+        # keeps ownership, execution logs, and durable worker outputs aligned
+        # with one bounded unit of delegated work.
         assignment_id = str(arguments["assignment_id"]).strip()
         if not assignment_id:
             raise ValidationError("assignment_id must not be blank.")
@@ -323,6 +355,9 @@ class SpawnSpecializedSubagentsAgent(BaseAgent):
 
     def _handle_integrate_results(self, arguments: dict[str, Any]) -> dict[str, Any]:
         del arguments
+        # Integration is blocked until there is at least one durable worker
+        # output. That guard prevents the agent from fabricating a synthesized
+        # result before the delegated work has actually been recorded.
         plan = self._memory_store.read_plan()
         worker_outputs = self._memory_store.read_worker_outputs()
         if not worker_outputs:
@@ -345,6 +380,9 @@ class SpawnSpecializedSubagentsAgent(BaseAgent):
         return payload
 
     def _find_assignment(self, plan: Mapping[str, Any], assignment_id: str) -> SubAgentAssignmentDTO:
+        # Plans are stored as plain JSON-compatible mappings. Rehydrating the
+        # selected assignment into a typed DTO gives the worker stage one stable
+        # contract even though the durable store is schema-light JSON.
         raw_assignments = plan.get("assignments", [])
         if not isinstance(raw_assignments, list):
             raise ValidationError("Current plan does not contain assignments.")

--- a/harnessiq/agents/spawn_specialized_subagents/stages.py
+++ b/harnessiq/agents/spawn_specialized_subagents/stages.py
@@ -1,4 +1,25 @@
-"""Typed model stages for the spawn-specialized-subagents harness."""
+"""
+===============================================================================
+File: harnessiq/agents/spawn_specialized_subagents/stages.py
+
+What this file does:
+- Defines the staged sub-workflows used by the `spawn_specialized_subagents`
+  agent package.
+- Typed model stages for the spawn-specialized-subagents harness.
+
+Use cases:
+- Use these stage helpers when the agent needs explicit subcalls or
+  deterministic planning steps before or after the main loop.
+
+How to use it:
+- Instantiate the stage objects from the sibling agent runtime and feed them
+  the domain payloads they expect.
+
+Intent:
+- Separate reusable stage logic from the top-level agent class so multi-step
+  workflows stay testable and easier to reason about.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/agents/subcalls.py
+++ b/harnessiq/agents/subcalls.py
@@ -1,4 +1,24 @@
-"""Shared helpers for deterministic JSON-returning model subcalls."""
+"""
+===============================================================================
+File: harnessiq/agents/subcalls.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/agents`.
+- Shared helpers for deterministic JSON-returning model subcalls.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `parse_json_object` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/formalization/__init__.py
+++ b/harnessiq/formalization/__init__.py
@@ -1,4 +1,28 @@
-"""Public formalization-layer contracts and runtime building blocks."""
+"""
+===============================================================================
+File: harnessiq/formalization/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/formalization` within
+  the HarnessIQ runtime.
+- Public formalization-layer contracts and runtime building blocks.
+
+Use cases:
+- Import ArtifactSpec, ArtifactNotFoundError, BaseArtifactLayer,
+  BaseBehaviorLayer, BaseExecutionPaceLayer, BaseErrorRecoveryLayer from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/formalization` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/formalization` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/formalization` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .artifacts import (
     ArtifactNotFoundError,

--- a/harnessiq/formalization/artifacts/__init__.py
+++ b/harnessiq/formalization/artifacts/__init__.py
@@ -1,4 +1,28 @@
-"""Artifact-formalization runtime specs, helpers, and exceptions."""
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/formalization/artifacts` within the HarnessIQ runtime.
+- Artifact-formalization runtime specs, helpers, and exceptions.
+
+Use cases:
+- Import ArtifactNotFoundError, CompletionRequirement, FORMAT_EXTENSION_MAP,
+  FORMAT_TOOL_MAP, InjectionPolicy, InputArtifactLayer from one stable package
+  entry point.
+- Read this module to understand what `harnessiq/formalization/artifacts`
+  intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/formalization/artifacts` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/formalization/artifacts` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .exceptions import ArtifactNotFoundError, OutputArtifactMissingError
 from .format_map import (

--- a/harnessiq/formalization/artifacts/exceptions.py
+++ b/harnessiq/formalization/artifacts/exceptions.py
@@ -1,4 +1,25 @@
-"""Artifact-formalization runtime exception types."""
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/exceptions.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+- Artifact-formalization runtime exception types.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
 
 
 class ArtifactNotFoundError(FileNotFoundError):

--- a/harnessiq/formalization/artifacts/format_map.py
+++ b/harnessiq/formalization/artifacts/format_map.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/format_map.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/harnessiq/formalization/artifacts/input_layer.py
+++ b/harnessiq/formalization/artifacts/input_layer.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/input_layer.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 import json

--- a/harnessiq/formalization/artifacts/input_spec.py
+++ b/harnessiq/formalization/artifacts/input_spec.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/input_spec.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence

--- a/harnessiq/formalization/artifacts/output_layer.py
+++ b/harnessiq/formalization/artifacts/output_layer.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/output_layer.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/harnessiq/formalization/artifacts/output_spec.py
+++ b/harnessiq/formalization/artifacts/output_spec.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/artifacts/output_spec.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/harnessiq/formalization/base.py
+++ b/harnessiq/formalization/base.py
@@ -1,4 +1,25 @@
-"""Self-documenting formalization layer contracts for harness composition."""
+"""
+===============================================================================
+File: harnessiq/formalization/base.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+- Self-documenting formalization layer contracts for harness composition.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/formalization/behaviors/__init__.py
+++ b/harnessiq/formalization/behaviors/__init__.py
@@ -1,4 +1,28 @@
-"""Legacy-compatible behavior formalization exports."""
+"""
+===============================================================================
+File: harnessiq/formalization/behaviors/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/formalization/behaviors` within the HarnessIQ runtime.
+- Legacy-compatible behavior formalization exports.
+
+Use cases:
+- Import BaseBehaviorLayer, BaseExecutionPaceLayer, BaseErrorRecoveryLayer,
+  BaseQualityBehaviorLayer, BaseReasoningBehaviorLayer, BaseSafetyBehaviorLayer
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/formalization/behaviors`
+  intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/formalization/behaviors` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/formalization/behaviors` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .base import (
     BaseBehaviorLayer,

--- a/harnessiq/formalization/behaviors/base.py
+++ b/harnessiq/formalization/behaviors/base.py
@@ -1,4 +1,25 @@
-"""Legacy-compatible exports for behavior-layer base types."""
+"""
+===============================================================================
+File: harnessiq/formalization/behaviors/base.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+- Legacy-compatible exports for behavior-layer base types.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
 
 from harnessiq.interfaces.formalization.behaviors import (
     BaseBehaviorLayer,

--- a/harnessiq/formalization/stages/__init__.py
+++ b/harnessiq/formalization/stages/__init__.py
@@ -1,4 +1,28 @@
-"""Executable stage-runtime primitives for staged formalization flows."""
+"""
+===============================================================================
+File: harnessiq/formalization/stages/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/formalization/stages`
+  within the HarnessIQ runtime.
+- Executable stage-runtime primitives for staged formalization flows.
+
+Use cases:
+- Import SimpleStageSpec, STAGE_COMPLETE_TOOL, StageAdvancementError,
+  StageAwareToolExecutor, StageLayer, StageCompletionError from one stable
+  package entry point.
+- Read this module to understand what `harnessiq/formalization/stages` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/formalization/stages` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/formalization/stages` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .context import StageContext
 from .exceptions import StageAdvancementError, StageCompletionError

--- a/harnessiq/formalization/stages/context.py
+++ b/harnessiq/formalization/stages/context.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/context.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/harnessiq/formalization/stages/exceptions.py
+++ b/harnessiq/formalization/stages/exceptions.py
@@ -1,4 +1,25 @@
-"""Stage-runtime exception types."""
+"""
+===============================================================================
+File: harnessiq/formalization/stages/exceptions.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+- Stage-runtime exception types.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
 
 
 class StageAdvancementError(RuntimeError):

--- a/harnessiq/formalization/stages/executor.py
+++ b/harnessiq/formalization/stages/executor.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/executor.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/harnessiq/formalization/stages/layer.py
+++ b/harnessiq/formalization/stages/layer.py
@@ -1,3 +1,31 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/layer.py
+
+What this file does:
+- Implements the runtime stage manager that advances a harness through a
+  deterministic ordered sequence of stages.
+- This module ties stage descriptions to actual runtime behavior such as tool
+  swapping, output persistence, and stage completion checks.
+
+Use cases:
+- Use it when a harness must progress through named stages instead of free-form
+  tool use.
+- Inspect it when debugging why a stage advanced, failed to advance, or changed
+  the visible tool surface.
+
+How to use it:
+- Instantiate `StageLayer` with a non-empty ordered list of `StageSpec` objects
+  and pass it into the agent runtime.
+- Call `formalization.stage_complete` from the model loop when a stage is done
+  and required outputs are ready.
+
+Intent:
+- Enforce stage sequencing in Python so a staged workflow stays auditable and
+  does not rely on prompt discipline alone.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 import json
@@ -131,6 +159,9 @@ class StageLayer(BaseFormalizationLayer):
         }
 
     def get_parameter_sections(self) -> Sequence[AgentParameterSection]:
+        # Stage metadata is surfaced both as formalization docs and as a live
+        # "current stage" parameter block so the model always sees what phase it
+        # is in, what counts as done, and what prior stage outputs still matter.
         static_sections = super().get_parameter_sections()
         stage = self._current_stage
         index = self._current_index
@@ -195,6 +226,9 @@ class StageLayer(BaseFormalizationLayer):
         if not patterns:
             return tuple(tool_keys)
 
+        # Stage-owned tools are always preserved even if they do not match the
+        # generic allow patterns, because they are the concrete operations the
+        # active stage needs to complete its contract.
         stage_tool_keys: set[str] = set()
         if self._stage_executor is not None and getattr(self._stage_executor, "_stage_registry", None) is not None:
             stage_tool_keys = set(self._stage_executor._stage_registry.keys())
@@ -220,6 +254,9 @@ class StageLayer(BaseFormalizationLayer):
         if result.tool_key != STAGE_COMPLETE_TOOL.key:
             return result
 
+        # `stage_complete` is advisory until the runtime validates both the
+        # required outputs and the stage's own completion predicate. Only then
+        # does the layer mark advancement as pending for the next reset.
         stage = self._current_stage
         payload = result.output if isinstance(result.output, dict) else {}
         outputs = dict(payload.get("outputs", {}))
@@ -274,6 +311,9 @@ class StageLayer(BaseFormalizationLayer):
         if not self._completion_pending:
             return
 
+        # Advancement happens after the reset, not inside `stage_complete`, so
+        # the next model turn always starts in a clean context already aligned
+        # with the new stage and its freshly swapped tool surface.
         current_stage = self._current_stage
         next_name = current_stage.get_next_stage(self._pending_outputs)
         terminal_completion = next_name is None and self._is_final_stage
@@ -346,6 +386,9 @@ class StageLayer(BaseFormalizationLayer):
     def _persist_stage_outputs(self, stage_name: str, outputs: dict[str, Any]) -> None:
         if self._memory_path is None:
             return
+        # Prior stage outputs are durably stored by stage name so later stages
+        # can reference them after resets or restarts without depending on the
+        # transcript to preserve those artifacts.
         path = self._memory_path / _STAGE_OUTPUTS_FILENAME
         path.parent.mkdir(parents=True, exist_ok=True)
         existing: dict[str, Any] = {}
@@ -383,6 +426,9 @@ class StageLayer(BaseFormalizationLayer):
         path = self._memory_path / _STAGE_INDEX_FILENAME
         if not path.exists():
             return
+        # Stage restoration is name-based instead of trusting a raw numeric
+        # index alone, which makes persisted state more robust if stage order
+        # changes while the registered names remain stable.
         payload = json.loads(path.read_text(encoding="utf-8"))
         stage_name = payload.get("current_stage")
         if stage_name in self._index_map:

--- a/harnessiq/formalization/stages/prebuilt.py
+++ b/harnessiq/formalization/stages/prebuilt.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/prebuilt.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/harnessiq/formalization/stages/spec.py
+++ b/harnessiq/formalization/stages/spec.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/spec.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/harnessiq/formalization/stages/tools.py
+++ b/harnessiq/formalization/stages/tools.py
@@ -1,3 +1,25 @@
+"""
+===============================================================================
+File: harnessiq/formalization/stages/tools.py
+
+What this file does:
+- Implements part of the runtime formalization layer that turns declarative
+  contracts into executable HarnessIQ behavior.
+
+Use cases:
+- Use this module when wiring staged execution, artifacts, or reusable
+  formalization runtime helpers into an agent.
+
+How to use it:
+- Import the runtime classes or helpers from this module through the
+  formalization package and compose them into the agent runtime.
+
+Intent:
+- Make formalization rules operational in Python so important workflow
+  constraints are enforced deterministically.
+===============================================================================
+"""
+
 from __future__ import annotations
 
 from typing import Any

--- a/harnessiq/interfaces/formalization.py
+++ b/harnessiq/interfaces/formalization.py
@@ -1,4 +1,25 @@
-"""Compatibility exports for formalization-layer contracts."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization.py
+
+What this file does:
+- Provides the public import facade for the formalization interface and runtime
+  surface exposed by the SDK.
+- Compatibility exports for formalization-layer contracts.
+
+Use cases:
+- Import formalization contracts and implementations from one stable top-level
+  module.
+
+How to use it:
+- Prefer importing shared formalization symbols from
+  `harnessiq.interfaces.formalization` when you want the packaged facade
+  instead of deep module paths.
+
+Intent:
+- Keep the formalization surface discoverable and stable for SDK consumers.
+===============================================================================
+"""
 
 from harnessiq.formalization.base import (
     ArtifactSpec,

--- a/harnessiq/interfaces/formalization/__init__.py
+++ b/harnessiq/interfaces/formalization/__init__.py
@@ -1,15 +1,34 @@
-"""Public formalization interfaces for injectable harness structure.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/__init__.py
 
-The classes exported from this package define the SDK-facing abstraction layer
-for formalization. A harness can depend on none of them, some of them, or many
-of them. The common pattern is:
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization` within the HarnessIQ runtime.
+- Public formalization interfaces for injectable harness structure. The classes
+  exported from this package define the SDK-facing abstraction layer for
+  formalization. A harness can depend on none of them, some of them, or many of
+  them. The common pattern is: 1. shared formalization records live in
+  ``harnessiq.shared.formalization`` 2. abstract behavioral contracts live here
+  under ``harnessiq.interfaces`` 3. concrete runtime implementations can later
+  plug these layers into a harness Each class lives in its own module so the
+  package stays navigable as the formalization surface grows.
 
-1. shared formalization records live in ``harnessiq.shared.formalization``
-2. abstract behavioral contracts live here under ``harnessiq.interfaces``
-3. concrete runtime implementations can later plug these layers into a harness
+Use cases:
+- Import ArtifactSpec, ArtifactNotFoundError, BaseArtifactLayer,
+  BaseBehaviorLayer, BaseExecutionPaceLayer, BaseErrorRecoveryLayer from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/interfaces/formalization`
+  intends to expose publicly.
 
-Each class lives in its own module so the package stays navigable as the
-formalization surface grows.
+How to use it:
+- Import from `harnessiq/interfaces/formalization` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/interfaces/formalization` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/artifact.py
+++ b/harnessiq/interfaces/formalization/artifact.py
@@ -1,9 +1,28 @@
-"""Abstract artifact-production layer for formalized output materialization.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/artifact.py
 
-Artifact layers let a harness declare which durable files or structured outputs
-matter as first-class deliverables. The interface is intentionally narrow:
-subclasses only declare artifact specs, while the base class turns those specs
-into default self-documentation and auditable rules.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract artifact-production layer for formalized output materialization.
+  Artifact layers let a harness declare which durable files or structured
+  outputs matter as first-class deliverables. The interface is intentionally
+  narrow: subclasses only declare artifact specs, while the base class turns
+  those specs into default self-documentation and auditable rules.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/artifacts.py
+++ b/harnessiq/interfaces/formalization/artifacts.py
@@ -1,4 +1,25 @@
-"""Compatibility re-exports for artifact-formalization runtime types."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/artifacts.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Compatibility re-exports for artifact-formalization runtime types.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from harnessiq.formalization.artifacts import (
     ArtifactNotFoundError,

--- a/harnessiq/interfaces/formalization/base.py
+++ b/harnessiq/interfaces/formalization/base.py
@@ -1,16 +1,28 @@
-"""Universal base contract for all formalization layer interfaces.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/base.py
 
-This module defines the one abstraction every formalization layer shares. The
-design goal is to make formalization layers optional, composable, and
-self-documenting:
+What this file does:
+- Defines the universal abstract base contract for self-documenting
+  formalization layers.
+- Explains the runtime hook surface a layer can participate in and provides the
+  default description pipeline that turns declarations into structured docs.
 
-- optional, because a harness should still work without any formalization layer
-- composable, because multiple layers can participate without tightly coupling
-- self-documenting, because the interface itself should explain what it is doing
+Use cases:
+- Subclass it when creating a new formalization layer family.
+- Read it to understand which runtime seams a harness can expose to declarative
+  formalization logic.
 
-The base class deliberately provides no-op runtime hooks and a default
-documentation pipeline. Concrete layer families only override the specific
-runtime seams and description methods they care about.
+How to use it:
+- Override the description methods and only the runtime hooks your layer
+  actually needs.
+- Let the default helper methods render developer-facing and agent-facing
+  descriptions from those declarations.
+
+Intent:
+- Make formalization optional, composable, and inspectable instead of hiding
+  control rules inside prompts or scattered runtime checks.
+===============================================================================
 """
 
 from __future__ import annotations
@@ -52,6 +64,9 @@ class BaseFormalizationLayer(ABC):
 
     def describe(self) -> FormalizationDescription:
         """Return the structured self-description for this layer."""
+        # `describe()` is the canonical translation point from Python layer
+        # implementation to portable metadata. Other SDK surfaces rely on this
+        # object instead of inspecting concrete subclasses ad hoc.
         return FormalizationDescription(
             layer_id=self.layer_id,
             identity=self._describe_identity(),
@@ -62,6 +77,9 @@ class BaseFormalizationLayer(ABC):
 
     def get_parameter_sections(self) -> tuple[AgentParameterSection, ...]:
         """Return formalization-owned context sections for the model window."""
+        # The same formalization metadata shown to developers is also injected
+        # into the model context so the runtime and the prompt describe the same
+        # rules instead of drifting apart.
         return (
             AgentParameterSection(
                 title=f"Formalization: {self.layer_id}",
@@ -109,6 +127,10 @@ class BaseFormalizationLayer(ABC):
 
     def _describe_identity(self) -> str:
         """Return default identity prose for a generic formalization layer."""
+        # Identity text answers the top-level question, "what layer is active
+        # right now and why should the harness care?" Concrete layer families
+        # can sharpen that message, but this default keeps even generic layers
+        # self-explanatory.
         rules = tuple(self._describe_rules())
         declared_hooks = sorted({rule.enforced_at for rule in rules})
         hook_summary = ", ".join(declared_hooks) if declared_hooks else "no explicit hooks"
@@ -161,6 +183,8 @@ class BaseFormalizationLayer(ABC):
     @staticmethod
     def _format_budget(budget: BudgetSpec | None) -> str:
         """Render a human-readable execution budget summary."""
+        # Budget formatting is intentionally shared so every contract layer
+        # renders limits in the same language across docs, prompts, and tests.
         if budget is None:
             return "No explicit execution budget declared."
         parts: list[str] = []
@@ -178,6 +202,9 @@ class BaseFormalizationLayer(ABC):
         patterns: Sequence[str],
     ) -> tuple[str, ...]:
         """Apply fnmatch patterns to a visible tool-key surface."""
+        # Pattern-based filtering gives formalization layers a declarative way to
+        # narrow tool visibility without forcing each layer to reimplement the
+        # same matching loop.
         if not patterns:
             return tuple(tool_keys)
         return tuple(

--- a/harnessiq/interfaces/formalization/behaviors/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/__init__.py
@@ -1,4 +1,28 @@
-"""Behavior-layer formalization interfaces."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors` within the HarnessIQ runtime.
+- Behavior-layer formalization interfaces.
+
+Use cases:
+- Import BaseBehaviorLayer, BaseExecutionPaceLayer, BaseErrorRecoveryLayer,
+  BaseQualityBehaviorLayer, BaseReasoningBehaviorLayer, BaseSafetyBehaviorLayer
+  from one stable package entry point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors` intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors` when you want the
+  supported facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/interfaces/formalization/behaviors`
+  explicit, discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .base import (
     BaseBehaviorLayer,

--- a/harnessiq/interfaces/formalization/behaviors/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/base.py
@@ -1,4 +1,25 @@
-"""Shared abstractions for behavior-oriented formalization layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Shared abstractions for behavior-oriented formalization layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/pace/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/pace/__init__.py
@@ -1,4 +1,31 @@
-"""Execution-pace formalization layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/pace/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/pace` within the HarnessIQ
+  runtime.
+- Execution-pace formalization layers.
+
+Use cases:
+- Import BaseExecutionPaceLayer, PaceRuleSpec, ProgressCheckpointBehavior,
+  ReflectionCadenceBehavior, VerificationBehavior from one stable package entry
+  point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/pace` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/pace` when you want
+  the supported facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/pace` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseExecutionPaceLayer, PaceRuleSpec
 from .checkpoint import ProgressCheckpointBehavior

--- a/harnessiq/interfaces/formalization/behaviors/pace/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/pace/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for execution-pace behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/pace/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for execution-pace behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/pace/checkpoint.py
+++ b/harnessiq/interfaces/formalization/behaviors/pace/checkpoint.py
@@ -1,4 +1,25 @@
-"""Concrete progress-checkpoint cadence behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/pace/checkpoint.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete progress-checkpoint cadence behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/pace/reflection.py
+++ b/harnessiq/interfaces/formalization/behaviors/pace/reflection.py
@@ -1,4 +1,25 @@
-"""Concrete reflection-cadence behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/pace/reflection.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete reflection-cadence behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/pace/verification.py
+++ b/harnessiq/interfaces/formalization/behaviors/pace/verification.py
@@ -1,4 +1,25 @@
-"""Concrete post-write verification behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/pace/verification.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete post-write verification behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/quality/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/quality/__init__.py
@@ -1,4 +1,32 @@
-"""Quality-behavior formalization layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/quality/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/quality` within the HarnessIQ
+  runtime.
+- Quality-behavior formalization layers.
+
+Use cases:
+- Import BaseQualityBehaviorLayer, QualityCriterionSpec,
+  CitationRequirementBehavior, QualityGateBehavior, ScopeEnforcementBehavior
+  from one stable package entry point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/quality` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/quality` when you
+  want the supported facade instead of reaching through deeper internal
+  modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/quality` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseQualityBehaviorLayer, QualityCriterionSpec
 from .citation import CitationRequirementBehavior

--- a/harnessiq/interfaces/formalization/behaviors/quality/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/quality/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for quality behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/quality/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for quality behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/quality/citation.py
+++ b/harnessiq/interfaces/formalization/behaviors/quality/citation.py
@@ -1,4 +1,25 @@
-"""Concrete citation-requirement behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/quality/citation.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete citation-requirement behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/quality/gate.py
+++ b/harnessiq/interfaces/formalization/behaviors/quality/gate.py
@@ -1,4 +1,25 @@
-"""Concrete generic quality-gate behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/quality/gate.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete generic quality-gate behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/quality/scope.py
+++ b/harnessiq/interfaces/formalization/behaviors/quality/scope.py
@@ -1,4 +1,25 @@
-"""Concrete scope-enforcement behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/quality/scope.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete scope-enforcement behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/reasoning/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/reasoning/__init__.py
@@ -1,4 +1,32 @@
-"""Reasoning-behavior formalization layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/reasoning/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/reasoning` within the HarnessIQ
+  runtime.
+- Reasoning-behavior formalization layers.
+
+Use cases:
+- Import BaseReasoningBehaviorLayer, ReasoningRequirementSpec,
+  PreActionReasoningBehavior, SelfCritiqueBehavior, HypothesisTestingBehavior
+  from one stable package entry point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/reasoning` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/reasoning` when you
+  want the supported facade instead of reaching through deeper internal
+  modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/reasoning` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseReasoningBehaviorLayer, ReasoningRequirementSpec
 from .hypothesis import HypothesisTestingBehavior

--- a/harnessiq/interfaces/formalization/behaviors/reasoning/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/reasoning/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for reasoning behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/reasoning/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for reasoning behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/reasoning/hypothesis.py
+++ b/harnessiq/interfaces/formalization/behaviors/reasoning/hypothesis.py
@@ -1,4 +1,25 @@
-"""Concrete competing-hypothesis behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/reasoning/hypothesis.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete competing-hypothesis behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/reasoning/pre_action.py
+++ b/harnessiq/interfaces/formalization/behaviors/reasoning/pre_action.py
@@ -1,4 +1,25 @@
-"""Concrete pre-action reasoning behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/reasoning/pre_action.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete pre-action reasoning behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/reasoning/self_critique.py
+++ b/harnessiq/interfaces/formalization/behaviors/reasoning/self_critique.py
@@ -1,4 +1,25 @@
-"""Concrete self-critique reasoning behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/reasoning/self_critique.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete self-critique reasoning behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/recovery/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/recovery/__init__.py
@@ -1,4 +1,32 @@
-"""Recovery behavior formalization interfaces."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/recovery/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/recovery` within the HarnessIQ
+  runtime.
+- Recovery behavior formalization interfaces.
+
+Use cases:
+- Import BaseErrorRecoveryLayer, ErrorEscalationBehavior, RecoveryStrategySpec,
+  RetryStrategyBehavior, StuckDetectionBehavior from one stable package entry
+  point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/recovery` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/recovery` when you
+  want the supported facade instead of reaching through deeper internal
+  modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/recovery` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseErrorRecoveryLayer, RecoveryStrategySpec
 from .escalation import ErrorEscalationBehavior

--- a/harnessiq/interfaces/formalization/behaviors/recovery/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/recovery/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for error-recovery behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/recovery/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for error-recovery behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/recovery/escalation.py
+++ b/harnessiq/interfaces/formalization/behaviors/recovery/escalation.py
@@ -1,4 +1,25 @@
-"""Concrete error-escalation behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/recovery/escalation.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete error-escalation behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/recovery/retry.py
+++ b/harnessiq/interfaces/formalization/behaviors/recovery/retry.py
@@ -1,4 +1,25 @@
-"""Concrete retry-strategy behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/recovery/retry.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete retry-strategy behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/recovery/stuck.py
+++ b/harnessiq/interfaces/formalization/behaviors/recovery/stuck.py
@@ -1,4 +1,25 @@
-"""Concrete stuck-detection behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/recovery/stuck.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete stuck-detection behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/safety/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/safety/__init__.py
@@ -1,4 +1,32 @@
-"""Safety behavior formalization interfaces."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/safety/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/safety` within the HarnessIQ
+  runtime.
+- Safety behavior formalization interfaces.
+
+Use cases:
+- Import BaseSafetyBehaviorLayer, GuardrailSpec,
+  IrreversibleActionGateBehavior, RateLimitBehavior, ScopeGuardBehavior from
+  one stable package entry point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/safety` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/safety` when you
+  want the supported facade instead of reaching through deeper internal
+  modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/safety` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseSafetyBehaviorLayer, GuardrailSpec
 from .irreversible import IrreversibleActionGateBehavior

--- a/harnessiq/interfaces/formalization/behaviors/safety/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/safety/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for safety behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/safety/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for safety behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/safety/irreversible.py
+++ b/harnessiq/interfaces/formalization/behaviors/safety/irreversible.py
@@ -1,4 +1,25 @@
-"""Concrete irreversible-action gate behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/safety/irreversible.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete irreversible-action gate behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/safety/rate_limit.py
+++ b/harnessiq/interfaces/formalization/behaviors/safety/rate_limit.py
@@ -1,4 +1,25 @@
-"""Concrete rate-limit behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/safety/rate_limit.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete rate-limit behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/safety/scope_guard.py
+++ b/harnessiq/interfaces/formalization/behaviors/safety/scope_guard.py
@@ -1,4 +1,25 @@
-"""Concrete scope-guard behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/safety/scope_guard.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete scope-guard behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/tool/__init__.py
+++ b/harnessiq/interfaces/formalization/behaviors/tool/__init__.py
@@ -1,4 +1,31 @@
-"""Tool-behavior formalization layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/tool/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/interfaces/formalization/behaviors/tool` within the HarnessIQ
+  runtime.
+- Tool-behavior formalization layers.
+
+Use cases:
+- Import BaseToolBehaviorLayer, ToolConstraintSpec, ToolCallLimitBehavior,
+  ToolCooldownBehavior, ToolSequencingBehavior from one stable package entry
+  point.
+- Read this module to understand what
+  `harnessiq/interfaces/formalization/behaviors/tool` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/interfaces/formalization/behaviors/tool` when you want
+  the supported facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for
+  `harnessiq/interfaces/formalization/behaviors/tool` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .base import BaseToolBehaviorLayer, ToolConstraintSpec
 from .cooldown import ToolCooldownBehavior

--- a/harnessiq/interfaces/formalization/behaviors/tool/base.py
+++ b/harnessiq/interfaces/formalization/behaviors/tool/base.py
@@ -1,4 +1,25 @@
-"""Typed base classes for tool-calling behavior layers."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/tool/base.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Typed base classes for tool-calling behavior layers.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/tool/cooldown.py
+++ b/harnessiq/interfaces/formalization/behaviors/tool/cooldown.py
@@ -1,4 +1,25 @@
-"""Concrete tool cooldown behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/tool/cooldown.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete tool cooldown behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/tool/limit.py
+++ b/harnessiq/interfaces/formalization/behaviors/tool/limit.py
@@ -1,4 +1,25 @@
-"""Concrete tool-call budget behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/tool/limit.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete tool-call budget behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/behaviors/tool/sequencing.py
+++ b/harnessiq/interfaces/formalization/behaviors/tool/sequencing.py
@@ -1,4 +1,25 @@
-"""Concrete prerequisite-ordering behavior."""
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/behaviors/tool/sequencing.py
+
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Concrete prerequisite-ordering behavior.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/interfaces/formalization/contract.py
+++ b/harnessiq/interfaces/formalization/contract.py
@@ -1,9 +1,29 @@
-"""Abstract execution-contract layer for formalized harness inputs and outputs.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/contract.py
 
-Contract layers answer the most basic formalization question: what must be
-available before work begins, what must exist before the task is complete, and
-what execution budget bounds the run. The class in this module keeps those
-requirements declarative so the runtime can later validate them deterministically.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract execution-contract layer for formalized harness inputs and outputs.
+  Contract layers answer the most basic formalization question: what must be
+  available before work begins, what must exist before the task is complete,
+  and what execution budget bounds the run. The class in this module keeps
+  those requirements declarative so the runtime can later validate them
+  deterministically.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/hook_layer.py
+++ b/harnessiq/interfaces/formalization/hook_layer.py
@@ -1,8 +1,27 @@
-"""Abstract hook-behavior layer for stateful runtime interception.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/hook_layer.py
 
-The existing runtime already has hook concepts, but a formalization hook layer
-captures a different concern: behaviors that belong to a self-documenting
-formalization object and may carry their own state or rule declarations.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract hook-behavior layer for stateful runtime interception. The existing
+  runtime already has hook concepts, but a formalization hook layer captures a
+  different concern: behaviors that belong to a self-documenting formalization
+  object and may carry their own state or rule declarations.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/role.py
+++ b/harnessiq/interfaces/formalization/role.py
@@ -1,9 +1,28 @@
-"""Abstract role-selection layer for multi-role harness formalization.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/role.py
 
-Role layers formalize agent identity switching without forcing that logic into
-the harness itself. A role can inject prompt fragments and narrow the visible
-tool surface, while the harness stays responsible for deciding which role is
-currently active.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract role-selection layer for multi-role harness formalization. Role
+  layers formalize agent identity switching without forcing that logic into the
+  harness itself. A role can inject prompt fragments and narrow the visible
+  tool surface, while the harness stays responsible for deciding which role is
+  currently active.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/stage.py
+++ b/harnessiq/interfaces/formalization/stage.py
@@ -1,9 +1,28 @@
-"""Abstract staged-execution layer for deterministic multi-phase harnesses.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/stage.py
 
-Stage layers describe ordered execution phases. They are responsible for
-projecting stage-specific prompt fragments, narrowing visible tools, and
-declaring the outputs that make a stage complete. The runtime can later wire
-those declarations into reset-driven advancement or other deterministic flow.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract staged-execution layer for deterministic multi-phase harnesses.
+  Stage layers describe ordered execution phases. They are responsible for
+  projecting stage-specific prompt fragments, narrowing visible tools, and
+  declaring the outputs that make a stage complete. The runtime can later wire
+  those declarations into reset-driven advancement or other deterministic flow.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/state.py
+++ b/harnessiq/interfaces/formalization/state.py
@@ -1,9 +1,28 @@
-"""Abstract durable-state layer for formalized reset continuity.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/state.py
 
-State layers define typed fields that survive resets and restarts. The point is
-not only persistence. The state schema also explains to the harness and the
-agent which values matter across context boundaries and how they are allowed to
-change over time.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract durable-state layer for formalized reset continuity. State layers
+  define typed fields that survive resets and restarts. The point is not only
+  persistence. The state schema also explains to the harness and the agent
+  which values matter across context boundaries and how they are allowed to
+  change over time.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/interfaces/formalization/tool_contribution.py
+++ b/harnessiq/interfaces/formalization/tool_contribution.py
@@ -1,8 +1,27 @@
-"""Abstract tool-contribution layer for formalization-owned tool surfaces.
+"""
+===============================================================================
+File: harnessiq/interfaces/formalization/tool_contribution.py
 
-Some formalization layers do not just document behavior; they also contribute
-tools that should become part of the harness runtime surface. This interface
-keeps that responsibility explicit and self-documenting.
+What this file does:
+- Defines part of the abstract formalization interface surface used to describe
+  harness behavior declaratively.
+- Abstract tool-contribution layer for formalization-owned tool surfaces. Some
+  formalization layers do not just document behavior; they also contribute
+  tools that should become part of the harness runtime surface. This interface
+  keeps that responsibility explicit and self-documenting.
+
+Use cases:
+- Subclass or import these interfaces when building a new formalization layer
+  family or behavior.
+
+How to use it:
+- Use the abstractions here to declare behavior, rules, and configuration in a
+  form the runtime can later inspect or enforce.
+
+Intent:
+- Keep formalization contracts explicit and composable so harness rules are
+  visible in code and docs.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/shared/formalization.py
+++ b/harnessiq/shared/formalization.py
@@ -1,19 +1,40 @@
-"""Shared formalization records used by the public interface layer package.
+"""
+===============================================================================
+File: harnessiq/shared/formalization.py
 
-This module intentionally holds the durable, dependency-light data structures
-that describe a formalization layer. The interface package builds abstract
-behavior on top of these records, but the records themselves live in
-``harnessiq.shared`` so they can be reused by runtime code, tests, generators,
-and SDK consumers without importing the higher-level interface package.
+What this file does:
+- Defines the shared, dependency-light record types that describe formalization
+  layers across the SDK.
+- These records are the stable vocabulary used by abstract interfaces, runtime
+  implementations, tests, and generators.
+- Shared formalization records used by the public interface layer package. This
+  module intentionally holds the durable, dependency-light data structures that
+  describe a formalization layer. The interface package builds abstract
+  behavior on top of these records, but the records themselves live in
+  ``harnessiq.shared`` so they can be reused by runtime code, tests,
+  generators, and SDK consumers without importing the higher-level interface
+  package. The separation matters for two reasons: 1. These records are the
+  stable vocabulary for formalization layers. They are not specific to any one
+  abstract base class. 2. The formalization interfaces are expected to be
+  injectable into different harness compositions. Keeping the records in
+  ``shared`` lets both the interface layer and the eventual runtime
+  implementation depend on the same source of truth.
 
-The separation matters for two reasons:
+Use cases:
+- Use these dataclasses when you need a portable description of a layer
+  contract or rule set.
+- Read this module first when you are learning the data model that powers
+  formalization documentation and enforcement.
 
-1. These records are the stable vocabulary for formalization layers. They are
-   not specific to any one abstract base class.
-2. The formalization interfaces are expected to be injectable into different
-   harness compositions. Keeping the records in ``shared`` lets both the
-   interface layer and the eventual runtime implementation depend on the same
-   source of truth.
+How to use it:
+- Import the record types directly from `harnessiq.shared.formalization` when
+  you need schema-like formalization metadata without higher-level runtime
+  dependencies.
+
+Intent:
+- Keep the language of formalization stable and reusable so higher layers can
+  share one source of truth.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/tools/__init__.py
+++ b/harnessiq/tools/__init__.py
@@ -1,4 +1,28 @@
-"""Canonical tool primitives for Harnessiq."""
+"""
+===============================================================================
+File: harnessiq/tools/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools` within the
+  HarnessIQ runtime.
+- Canonical tool primitives for Harnessiq.
+
+Use cases:
+- Import ADD_NUMBERS, ApprovalPolicy, BROWSER_CLICK, BROWSER_EXTRACT_CONTENT,
+  BROWSER_FIND_ELEMENT, BROWSER_GET_CURRENT_URL from one stable package entry
+  point.
+- Read this module to understand what `harnessiq/tools` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools` when you want the supported facade instead of
+  reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools` explicit, discoverable, and
+  easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.shared.tools import (
     ADD_NUMBERS,

--- a/harnessiq/tools/apollo/__init__.py
+++ b/harnessiq/tools/apollo/__init__.py
@@ -1,4 +1,27 @@
-"""Apollo MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/apollo/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/apollo` within
+  the HarnessIQ runtime.
+- Apollo MCP-style tool factory.
+
+Use cases:
+- Import build_apollo_request_tool_definition, create_apollo_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/apollo` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/apollo` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/apollo` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.apollo.operations import (
     build_apollo_request_tool_definition,

--- a/harnessiq/tools/apollo/operations.py
+++ b/harnessiq/tools/apollo/operations.py
@@ -1,4 +1,27 @@
-"""Apollo MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/apollo/operations.py
+
+What this file does:
+- Exposes the `apollo` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Apollo MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `apollo` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/apollo` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `apollo` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from harnessiq.providers.apollo.operations import (
     build_apollo_request_tool_definition,

--- a/harnessiq/tools/arcads/__init__.py
+++ b/harnessiq/tools/arcads/__init__.py
@@ -1,4 +1,27 @@
-"""Arcads tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/arcads/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/arcads` within
+  the HarnessIQ runtime.
+- Arcads tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_arcads_request_tool_definition, create_arcads_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/arcads` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/arcads` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/arcads` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.arcads.operations import (
     build_arcads_request_tool_definition,

--- a/harnessiq/tools/arcads/operations.py
+++ b/harnessiq/tools/arcads/operations.py
@@ -1,4 +1,27 @@
-"""Arcads MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/arcads/operations.py
+
+What this file does:
+- Exposes the `arcads` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Arcads MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `arcads` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/arcads` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `arcads` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/artifact.py
+++ b/harnessiq/tools/artifact.py
@@ -1,4 +1,25 @@
-"""Artifact writing and inspection tools."""
+"""
+===============================================================================
+File: harnessiq/tools/artifact.py
+
+What this file does:
+- Defines the `ArtifactToolRuntime` type and the supporting logic it needs in
+  the `harnessiq/tools` module.
+- Artifact writing and inspection tools.
+
+Use cases:
+- Import `ArtifactToolRuntime` when composing higher-level HarnessIQ runtime
+  behavior from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/arxiv/__init__.py
+++ b/harnessiq/tools/arxiv/__init__.py
@@ -1,4 +1,27 @@
-"""arXiv MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/arxiv/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/arxiv` within
+  the HarnessIQ runtime.
+- arXiv MCP-style tool factory.
+
+Use cases:
+- Import build_arxiv_request_tool_definition, create_arxiv_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/arxiv` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/arxiv` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/arxiv` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .operations import build_arxiv_request_tool_definition, create_arxiv_tools
 

--- a/harnessiq/tools/arxiv/operations.py
+++ b/harnessiq/tools/arxiv/operations.py
@@ -1,4 +1,27 @@
-"""arXiv MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/arxiv/operations.py
+
+What this file does:
+- Exposes the `arxiv` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- arXiv MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `arxiv` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/arxiv` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `arxiv` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/attio/__init__.py
+++ b/harnessiq/tools/attio/__init__.py
@@ -1,4 +1,27 @@
-"""Attio tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/attio/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/attio` within
+  the HarnessIQ runtime.
+- Attio tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_attio_request_tool_definition, create_attio_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/attio` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/attio` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/attio` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.attio.operations import (
     build_attio_request_tool_definition,

--- a/harnessiq/tools/attio/operations.py
+++ b/harnessiq/tools/attio/operations.py
@@ -1,4 +1,27 @@
-"""Attio MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/attio/operations.py
+
+What this file does:
+- Exposes the `attio` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Attio MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `attio` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/attio` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `attio` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/browser.py
+++ b/harnessiq/tools/browser.py
@@ -1,4 +1,24 @@
-"""Reusable browser tool definitions and factory helpers."""
+"""
+===============================================================================
+File: harnessiq/tools/browser.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Reusable browser tool definitions and factory helpers.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `build_browser_tool_definitions` and the other exported symbols here
+  through their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/browser_use/__init__.py
+++ b/harnessiq/tools/browser_use/__init__.py
@@ -1,4 +1,27 @@
-"""Browser Use MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/browser_use/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/browser_use`
+  within the HarnessIQ runtime.
+- Browser Use MCP-style tool factory.
+
+Use cases:
+- Import build_browser_use_request_tool_definition, create_browser_use_tools
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/browser_use` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/browser_use` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/browser_use` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.browser_use.operations import (
     build_browser_use_request_tool_definition,

--- a/harnessiq/tools/browser_use/operations.py
+++ b/harnessiq/tools/browser_use/operations.py
@@ -1,4 +1,27 @@
-"""Browser Use MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/browser_use/operations.py
+
+What this file does:
+- Exposes the `browser_use` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Browser Use MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `browser_use` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/browser_use` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `browser_use` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/builtin.py
+++ b/harnessiq/tools/builtin.py
@@ -1,4 +1,29 @@
-"""Small built-in tools used to validate the initial runtime scaffold."""
+"""
+===============================================================================
+File: harnessiq/tools/builtin.py
+
+What this file does:
+- Composes the default built-in tool catalog that every HarnessIQ runtime can
+  start from.
+- This file is the assembly point where generic context, filesystem, reasoning,
+  memory, and validation tool families are stitched together.
+- Small built-in tools used to validate the initial runtime scaffold.
+
+Use cases:
+- Inspect the default baseline tool surface available before agent-specific
+  tools are added.
+- Update this file when adding or reordering a built-in tool family.
+
+How to use it:
+- Import `BUILTIN_TOOLS` or call registry helpers that use it under the hood.
+- Add new built-ins by defining `RegisteredTool` entries or appending family
+  factory output here.
+
+Intent:
+- Make the default runtime surface explicit and deterministic instead of
+  letting built-ins emerge from scattered imports.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/__init__.py
+++ b/harnessiq/tools/context/__init__.py
@@ -1,4 +1,29 @@
-"""Context-window manipulation tool family."""
+"""
+===============================================================================
+File: harnessiq/tools/context/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/context` within
+  the HarnessIQ runtime.
+- Context-window manipulation tool family.
+
+Use cases:
+- Import CONTEXT_COMPACTION_TOOL_KEYS, CONTEXT_INJECT_ASSISTANT_NOTE,
+  CONTEXT_INJECT_CONTEXT_BLOCK, CONTEXT_INJECT_HANDOFF_BRIEF,
+  CONTEXT_INJECT_PROGRESS_MARKER, CONTEXT_INJECT_REPLAY_MEMORY from one stable
+  package entry point.
+- Read this module to understand what `harnessiq/tools/context` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/context` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/context` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/binding.py
+++ b/harnessiq/tools/context/binding.py
@@ -1,4 +1,25 @@
-"""Agent-tool binding helpers for the context tool family."""
+"""
+===============================================================================
+File: harnessiq/tools/context/binding.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Agent-tool binding helpers for the context tool family.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/__init__.py
+++ b/harnessiq/tools/context/definitions/__init__.py
@@ -1,4 +1,28 @@
-"""Registered-tool definitions for the context tool family."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/tools/context/definitions` within the HarnessIQ runtime.
+- Registered-tool definitions for the context tool family.
+
+Use cases:
+- Import create_context_injection_tools, create_context_parameter_tools,
+  create_context_selective_tools, create_context_structural_tools,
+  create_context_summarization_tools from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/context/definitions`
+  intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/context/definitions` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/context/definitions` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .injection import create_context_injection_tools
 from .parameter import create_context_parameter_tools

--- a/harnessiq/tools/context/definitions/catalog.py
+++ b/harnessiq/tools/context/definitions/catalog.py
@@ -1,4 +1,25 @@
-"""Tool definitions for additional catalog context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/catalog.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for additional catalog context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/injection.py
+++ b/harnessiq/tools/context/definitions/injection.py
@@ -1,4 +1,25 @@
-"""Tool definitions for transcript injection context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/injection.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for transcript injection context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/parameter.py
+++ b/harnessiq/tools/context/definitions/parameter.py
@@ -1,4 +1,25 @@
-"""Tool definitions for parameter-zone context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/parameter.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for parameter-zone context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/selective.py
+++ b/harnessiq/tools/context/definitions/selective.py
@@ -1,4 +1,25 @@
-"""Tool definitions for selective context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/selective.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for selective context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/structural.py
+++ b/harnessiq/tools/context/definitions/structural.py
@@ -1,4 +1,25 @@
-"""Tool definitions for structural context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/structural.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for structural context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/definitions/summarization.py
+++ b/harnessiq/tools/context/definitions/summarization.py
@@ -1,4 +1,25 @@
-"""Tool definitions for context summarization tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/definitions/summarization.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Tool definitions for context summarization tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/executors/__init__.py
+++ b/harnessiq/tools/context/executors/__init__.py
@@ -1,4 +1,27 @@
-"""Execution logic for the context tool family."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/tools/context/executors` within the HarnessIQ runtime.
+- Execution logic for the context tool family.
+
+Use cases:
+- Import append_memory_value, overwrite_memory_value, write_once_memory_value
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/context/executors`
+  intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/context/executors` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/context/executors` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .parameter import append_memory_value, overwrite_memory_value, write_once_memory_value
 

--- a/harnessiq/tools/context/executors/catalog.py
+++ b/harnessiq/tools/context/executors/catalog.py
@@ -1,4 +1,25 @@
-"""Additional catalog context-tool executors."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/catalog.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Additional catalog context-tool executors.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -25,6 +46,9 @@ from .. import (
 
 
 def summarize_transcript(runtime: ContextToolRuntime, arguments: dict[str, Any]) -> dict[str, Any]:
+    # The summary payload deliberately separates completed actions, tool results,
+    # and recent errors so a caller can compact the transcript without losing the
+    # pieces of state most useful for the next reasoning step.
     detail = coerce_optional_string(arguments, "detail_level") or "standard"
     parameter_entries, transcript_entries = split_context_window(current_context_window(runtime))
     completed_actions = [entry.get("content", "") for entry in transcript_entries if entry["kind"] in {"assistant", "summary"} and entry.get("content")]
@@ -49,6 +73,9 @@ def summarize_transcript(runtime: ContextToolRuntime, arguments: dict[str, Any])
 
 
 def prune_tool_results(runtime: ContextToolRuntime, arguments: dict[str, Any]) -> dict[str, Any]:
+    # Result pruning preserves the latest matching tool results while replacing
+    # older ones with an explicit marker. That retains the fact that work
+    # happened without paying the full token cost of every historical payload.
     keep_last_n = coerce_non_negative_int(arguments, "keep_last_n", default=3)
     tool_filter = set(coerce_string_list(arguments, "tool_filter"))
     replacement = coerce_optional_string(arguments, "replacement_text") or "[result pruned - content processed]"
@@ -68,6 +95,9 @@ def prune_tool_results(runtime: ContextToolRuntime, arguments: dict[str, Any]) -
 
 
 def estimate_window_pressure(runtime: ContextToolRuntime, arguments: dict[str, Any]) -> dict[str, Any]:
+    # Pressure estimates turn raw token counts into discrete operating guidance
+    # so agents and hooks can make deterministic compaction decisions instead of
+    # guessing from the transcript size alone.
     planned = arguments.get("planned_action_tokens")
     if planned is not None and (isinstance(planned, bool) or not isinstance(planned, int)):
         raise ValueError("The 'planned_action_tokens' argument must be an integer when provided.")
@@ -124,6 +154,9 @@ def handoff_brief(runtime: ContextToolRuntime, arguments: dict[str, Any]) -> dic
 
 
 def collapse_repeated_calls(runtime: ContextToolRuntime, arguments: dict[str, Any]) -> dict[str, Any]:
+    # Repeated tool-call runs often come from retry loops or idempotent probing.
+    # Collapsing exact repeats preserves the latest representative call while
+    # encoding the repetition count as metadata for downstream inspection.
     minimum = coerce_non_negative_int(arguments, "min_repetitions", default=3)
     tool_filter = set(coerce_string_list(arguments, "tool_filter"))
     parameter_entries, transcript_entries = split_context_window(current_context_window(runtime))

--- a/harnessiq/tools/context/executors/injection.py
+++ b/harnessiq/tools/context/executors/injection.py
@@ -1,4 +1,25 @@
-"""Execution logic for transcript injection context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/injection.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Execution logic for transcript injection context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/executors/parameter.py
+++ b/harnessiq/tools/context/executors/parameter.py
@@ -1,4 +1,25 @@
-"""Execution logic for parameter-zone context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/parameter.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Execution logic for parameter-zone context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/executors/selective.py
+++ b/harnessiq/tools/context/executors/selective.py
@@ -1,4 +1,25 @@
-"""Execution logic for selective context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/selective.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Execution logic for selective context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/executors/structural.py
+++ b/harnessiq/tools/context/executors/structural.py
@@ -1,4 +1,25 @@
-"""Execution logic for structural context tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/structural.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Execution logic for structural context tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/executors/summarization.py
+++ b/harnessiq/tools/context/executors/summarization.py
@@ -1,4 +1,25 @@
-"""Execution logic for context summarization tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context/executors/summarization.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Execution logic for context summarization tools.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/context/injection.py
+++ b/harnessiq/tools/context/injection.py
@@ -1,4 +1,25 @@
-"""Compatibility wrapper for transcript injection tool definitions."""
+"""
+===============================================================================
+File: harnessiq/tools/context/injection.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Compatibility wrapper for transcript injection tool definitions.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from .definitions.injection import create_context_injection_tools
 

--- a/harnessiq/tools/context/parameter.py
+++ b/harnessiq/tools/context/parameter.py
@@ -1,4 +1,25 @@
-"""Compatibility wrapper for parameter-zone context tooling."""
+"""
+===============================================================================
+File: harnessiq/tools/context/parameter.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Compatibility wrapper for parameter-zone context tooling.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from .definitions.parameter import create_context_parameter_tools
 from .executors.parameter import append_memory_value, overwrite_memory_value, write_once_memory_value

--- a/harnessiq/tools/context/selective.py
+++ b/harnessiq/tools/context/selective.py
@@ -1,4 +1,25 @@
-"""Compatibility wrapper for selective context tool definitions."""
+"""
+===============================================================================
+File: harnessiq/tools/context/selective.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Compatibility wrapper for selective context tool definitions.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from .definitions.selective import create_context_selective_tools
 

--- a/harnessiq/tools/context/structural.py
+++ b/harnessiq/tools/context/structural.py
@@ -1,4 +1,25 @@
-"""Compatibility wrapper for structural context tool definitions."""
+"""
+===============================================================================
+File: harnessiq/tools/context/structural.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Compatibility wrapper for structural context tool definitions.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from .definitions.structural import create_context_structural_tools
 

--- a/harnessiq/tools/context/summarization.py
+++ b/harnessiq/tools/context/summarization.py
@@ -1,4 +1,25 @@
-"""Compatibility wrapper for summarization context tool definitions."""
+"""
+===============================================================================
+File: harnessiq/tools/context/summarization.py
+
+What this file does:
+- Implements part of the context-tool system that rewrites, summarizes, or
+  annotates an agent context window.
+- Compatibility wrapper for summarization context tool definitions.
+
+Use cases:
+- Use these helpers when a runtime needs deterministic context compaction or
+  injection behavior.
+
+How to use it:
+- Import the definitions or executors from this module through the context-tool
+  catalog rather than wiring ad hoc context mutations inline.
+
+Intent:
+- Keep context-window manipulation explicit and reusable so long-running agents
+  can manage token pressure predictably.
+===============================================================================
+"""
 
 from .definitions.summarization import create_context_summarization_tools
 

--- a/harnessiq/tools/context_compaction.py
+++ b/harnessiq/tools/context_compaction.py
@@ -1,4 +1,24 @@
-"""Context-window compaction helpers and registered tools."""
+"""
+===============================================================================
+File: harnessiq/tools/context_compaction.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Context-window compaction helpers and registered tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `remove_tool_result_entries` and the other exported symbols here through
+  their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/control.py
+++ b/harnessiq/tools/control.py
@@ -1,4 +1,25 @@
-"""Runtime-backed control-flow tools."""
+"""
+===============================================================================
+File: harnessiq/tools/control.py
+
+What this file does:
+- Defines the `ControlToolRuntime` type and the supporting logic it needs in
+  the `harnessiq/tools` module.
+- Runtime-backed control-flow tools.
+
+Use cases:
+- Import `ControlToolRuntime` when composing higher-level HarnessIQ runtime
+  behavior from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/coresignal/__init__.py
+++ b/harnessiq/tools/coresignal/__init__.py
@@ -1,4 +1,27 @@
-"""Coresignal MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/coresignal/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/coresignal`
+  within the HarnessIQ runtime.
+- Coresignal MCP-style tool factory.
+
+Use cases:
+- Import build_coresignal_request_tool_definition, create_coresignal_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/coresignal` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/coresignal` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/coresignal` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.coresignal.operations import (
     build_coresignal_request_tool_definition,

--- a/harnessiq/tools/coresignal/operations.py
+++ b/harnessiq/tools/coresignal/operations.py
@@ -1,4 +1,27 @@
-"""Coresignal MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/coresignal/operations.py
+
+What this file does:
+- Exposes the `coresignal` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Coresignal MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `coresignal` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/coresignal` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `coresignal` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/creatify/__init__.py
+++ b/harnessiq/tools/creatify/__init__.py
@@ -1,4 +1,27 @@
-"""Creatify tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/creatify/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/creatify`
+  within the HarnessIQ runtime.
+- Creatify tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_creatify_request_tool_definition, create_creatify_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/creatify` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/creatify` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/creatify` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.creatify.operations import (
     build_creatify_request_tool_definition,

--- a/harnessiq/tools/creatify/operations.py
+++ b/harnessiq/tools/creatify/operations.py
@@ -1,4 +1,27 @@
-"""Creatify MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/creatify/operations.py
+
+What this file does:
+- Exposes the `creatify` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Creatify MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `creatify` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/creatify` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `creatify` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/eval/__init__.py
+++ b/harnessiq/tools/eval/__init__.py
@@ -1,4 +1,27 @@
-"""Shared evaluation tool factories."""
+"""
+===============================================================================
+File: harnessiq/tools/eval/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/eval` within
+  the HarnessIQ runtime.
+- Shared evaluation tool factories.
+
+Use cases:
+- Import build_evaluate_company_tool_definition, create_evaluate_company_tool
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/eval` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/eval` when you want the supported facade instead
+  of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/eval` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .evaluate_company import (
     build_evaluate_company_tool_definition,

--- a/harnessiq/tools/eval/evaluate_company.py
+++ b/harnessiq/tools/eval/evaluate_company.py
@@ -1,4 +1,24 @@
-"""Public shared evaluation tool for prospecting-style workflows."""
+"""
+===============================================================================
+File: harnessiq/tools/eval/evaluate_company.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools/eval`.
+- Public shared evaluation tool for prospecting-style workflows.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `build_evaluate_company_tool_definition` and the other exported symbols
+  here through their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/exa/__init__.py
+++ b/harnessiq/tools/exa/__init__.py
@@ -1,4 +1,27 @@
-"""Exa tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/exa/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/exa` within the
+  HarnessIQ runtime.
+- Exa tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_exa_request_tool_definition, create_exa_tools from one stable
+  package entry point.
+- Read this module to understand what `harnessiq/tools/exa` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/exa` when you want the supported facade instead
+  of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/exa` explicit, discoverable, and
+  easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.exa.operations import (
     build_exa_request_tool_definition,

--- a/harnessiq/tools/exa/operations.py
+++ b/harnessiq/tools/exa/operations.py
@@ -1,4 +1,27 @@
-"""Exa MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/exa/operations.py
+
+What this file does:
+- Exposes the `exa` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Exa MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `exa` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/exa` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `exa` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/expandi/__init__.py
+++ b/harnessiq/tools/expandi/__init__.py
@@ -1,4 +1,27 @@
-"""Expandi tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/expandi/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/expandi` within
+  the HarnessIQ runtime.
+- Expandi tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_expandi_request_tool_definition, create_expandi_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/expandi` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/expandi` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/expandi` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.expandi.operations import (
     build_expandi_request_tool_definition,

--- a/harnessiq/tools/expandi/operations.py
+++ b/harnessiq/tools/expandi/operations.py
@@ -1,4 +1,27 @@
-"""Expandi MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/expandi/operations.py
+
+What this file does:
+- Exposes the `expandi` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Expandi MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `expandi` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/expandi` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `expandi` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/filesystem.py
+++ b/harnessiq/tools/filesystem.py
@@ -1,4 +1,24 @@
-"""Explicit non-destructive filesystem tools."""
+"""
+===============================================================================
+File: harnessiq/tools/filesystem.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Explicit non-destructive filesystem tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `get_current_directory` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/filesystem_safe.py
+++ b/harnessiq/tools/filesystem_safe.py
@@ -1,4 +1,24 @@
-"""Additive and non-destructive filesystem tools."""
+"""
+===============================================================================
+File: harnessiq/tools/filesystem_safe.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Additive and non-destructive filesystem tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `read_file` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/general_purpose.py
+++ b/harnessiq/tools/general_purpose.py
@@ -1,4 +1,24 @@
-"""General-purpose text, record, and control-flow tools."""
+"""
+===============================================================================
+File: harnessiq/tools/general_purpose.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- General-purpose text, record, and control-flow tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `normalize_whitespace` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/google_drive/__init__.py
+++ b/harnessiq/tools/google_drive/__init__.py
@@ -1,4 +1,27 @@
-"""Google Drive tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/google_drive/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/google_drive`
+  within the HarnessIQ runtime.
+- Google Drive tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_google_drive_request_tool_definition, create_google_drive_tools
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/google_drive` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/google_drive` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/google_drive` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.google_drive.operations import (
     build_google_drive_request_tool_definition,

--- a/harnessiq/tools/google_drive/operations.py
+++ b/harnessiq/tools/google_drive/operations.py
@@ -1,4 +1,27 @@
-"""Google Drive MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/google_drive/operations.py
+
+What this file does:
+- Exposes the `google_drive` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Google Drive MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `google_drive` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/google_drive` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `google_drive` tool surface small, explicit, and separate
+  from provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/hooks/__init__.py
+++ b/harnessiq/tools/hooks/__init__.py
@@ -1,4 +1,27 @@
-"""Runtime hook factories and default policy helpers."""
+"""
+===============================================================================
+File: harnessiq/tools/hooks/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/hooks` within
+  the HarnessIQ runtime.
+- Runtime hook factories and default policy helpers.
+
+Use cases:
+- Import ApprovalPolicy, DEFAULT_APPROVAL_POLICY, HookContext, HookDefinition,
+  HookHandler, HookPhase from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/hooks` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/hooks` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/hooks` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.shared.hooks import (
     ApprovalPolicy,

--- a/harnessiq/tools/hooks/defaults.py
+++ b/harnessiq/tools/hooks/defaults.py
@@ -1,4 +1,24 @@
-"""Default lifecycle hooks and policy helpers."""
+"""
+===============================================================================
+File: harnessiq/tools/hooks/defaults.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools/hooks`.
+- Default lifecycle hooks and policy helpers.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `create_default_hook_tools` and the other exported symbols here through
+  their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/hooks/factory.py
+++ b/harnessiq/tools/hooks/factory.py
@@ -1,4 +1,24 @@
-"""Custom hook creation helpers for Harnessiq."""
+"""
+===============================================================================
+File: harnessiq/tools/hooks/factory.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools/hooks`.
+- Custom hook creation helpers for Harnessiq.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `define_hook_tool` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/hunter/__init__.py
+++ b/harnessiq/tools/hunter/__init__.py
@@ -1,4 +1,27 @@
-"""Hunter tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/hunter/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/hunter` within
+  the HarnessIQ runtime.
+- Hunter tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_hunter_request_tool_definition, create_hunter_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/hunter` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/hunter` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/hunter` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.hunter.operations import (
     build_hunter_request_tool_definition,

--- a/harnessiq/tools/hunter/operations.py
+++ b/harnessiq/tools/hunter/operations.py
@@ -1,4 +1,27 @@
-"""Hunter MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/hunter/operations.py
+
+What this file does:
+- Exposes the `hunter` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Hunter MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `hunter` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/hunter` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `hunter` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from harnessiq.providers.hunter.operations import (
     build_hunter_request_tool_definition,

--- a/harnessiq/tools/inboxapp/__init__.py
+++ b/harnessiq/tools/inboxapp/__init__.py
@@ -1,4 +1,27 @@
-"""InboxApp tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/inboxapp/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/inboxapp`
+  within the HarnessIQ runtime.
+- InboxApp tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_inboxapp_request_tool_definition, create_inboxapp_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/inboxapp` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/inboxapp` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/inboxapp` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.inboxapp.operations import (
     build_inboxapp_request_tool_definition,

--- a/harnessiq/tools/inboxapp/operations.py
+++ b/harnessiq/tools/inboxapp/operations.py
@@ -1,4 +1,27 @@
-"""InboxApp MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/inboxapp/operations.py
+
+What this file does:
+- Exposes the `inboxapp` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- InboxApp MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `inboxapp` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/inboxapp` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `inboxapp` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/instagram.py
+++ b/harnessiq/tools/instagram.py
@@ -1,4 +1,24 @@
-"""Instagram agent tool definitions and runtime handlers."""
+"""
+===============================================================================
+File: harnessiq/tools/instagram.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Instagram agent tool definitions and runtime handlers.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `create_instagram_tools` and the other exported symbols here through
+  their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/instagram/__init__.py
+++ b/harnessiq/tools/instagram/__init__.py
@@ -1,4 +1,28 @@
-"""Instagram tool definitions and factories."""
+"""
+===============================================================================
+File: harnessiq/tools/instagram/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/instagram`
+  within the HarnessIQ runtime.
+- Instagram tool definitions and factories.
+
+Use cases:
+- Import SEARCH_KEYWORD, SearchKeywordHandler,
+  build_search_keyword_tool_definition, create_instagram_tools,
+  create_search_keyword_tool from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/instagram` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/instagram` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/instagram` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.instagram.operations import (
     SEARCH_KEYWORD,

--- a/harnessiq/tools/instagram/operations.py
+++ b/harnessiq/tools/instagram/operations.py
@@ -1,4 +1,27 @@
-"""Public shared Instagram keyword search tool definition and factory."""
+"""
+===============================================================================
+File: harnessiq/tools/instagram/operations.py
+
+What this file does:
+- Exposes the `instagram` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Public shared Instagram keyword search tool definition and factory.
+
+Use cases:
+- Import this module when an agent or registry needs the `instagram` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/instagram` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `instagram` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/instantly/__init__.py
+++ b/harnessiq/tools/instantly/__init__.py
@@ -1,4 +1,27 @@
-"""Instantly tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/instantly/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/instantly`
+  within the HarnessIQ runtime.
+- Instantly tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_instantly_request_tool_definition, create_instantly_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/instantly` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/instantly` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/instantly` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.instantly.operations import (
     build_instantly_request_tool_definition,

--- a/harnessiq/tools/instantly/operations.py
+++ b/harnessiq/tools/instantly/operations.py
@@ -1,4 +1,27 @@
-"""Instantly MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/instantly/operations.py
+
+What this file does:
+- Exposes the `instantly` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Instantly MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `instantly` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/instantly` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `instantly` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/knowt/__init__.py
+++ b/harnessiq/tools/knowt/__init__.py
@@ -1,4 +1,26 @@
-"""Knowt content-creation tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/knowt/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/knowt` within
+  the HarnessIQ runtime.
+- Knowt content-creation tool factory.
+
+Use cases:
+- Import create_knowt_tools from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/knowt` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/knowt` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/knowt` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .operations import create_knowt_tools
 

--- a/harnessiq/tools/knowt/operations.py
+++ b/harnessiq/tools/knowt/operations.py
@@ -1,4 +1,27 @@
-"""Knowt agent tool implementations for the content creation pipeline."""
+"""
+===============================================================================
+File: harnessiq/tools/knowt/operations.py
+
+What this file does:
+- Exposes the `knowt` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Knowt agent tool implementations for the content creation pipeline.
+
+Use cases:
+- Import this module when an agent or registry needs the `knowt` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/knowt` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `knowt` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/leadiq/__init__.py
+++ b/harnessiq/tools/leadiq/__init__.py
@@ -1,4 +1,27 @@
-"""LeadIQ MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/leadiq/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/leadiq` within
+  the HarnessIQ runtime.
+- LeadIQ MCP-style tool factory.
+
+Use cases:
+- Import build_leadiq_request_tool_definition, create_leadiq_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/leadiq` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/leadiq` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/leadiq` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.leadiq.operations import (
     build_leadiq_request_tool_definition,

--- a/harnessiq/tools/leadiq/operations.py
+++ b/harnessiq/tools/leadiq/operations.py
@@ -1,4 +1,27 @@
-"""LeadIQ MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/leadiq/operations.py
+
+What this file does:
+- Exposes the `leadiq` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- LeadIQ MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `leadiq` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/leadiq` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `leadiq` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/leads/__init__.py
+++ b/harnessiq/tools/leads/__init__.py
@@ -1,4 +1,26 @@
-"""Leads agent tool factories."""
+"""
+===============================================================================
+File: harnessiq/tools/leads/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/leads` within
+  the HarnessIQ runtime.
+- Leads agent tool factories.
+
+Use cases:
+- Import create_leads_tools from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/leads` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/leads` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/leads` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .operations import create_leads_tools
 

--- a/harnessiq/tools/leads/operations.py
+++ b/harnessiq/tools/leads/operations.py
@@ -1,4 +1,27 @@
-"""Leads agent tool factory and handlers."""
+"""
+===============================================================================
+File: harnessiq/tools/leads/operations.py
+
+What this file does:
+- Exposes the `leads` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Leads agent tool factory and handlers.
+
+Use cases:
+- Import this module when an agent or registry needs the `leads` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/leads` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `leads` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/lemlist/__init__.py
+++ b/harnessiq/tools/lemlist/__init__.py
@@ -1,4 +1,27 @@
-"""Lemlist tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/lemlist/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/lemlist` within
+  the HarnessIQ runtime.
+- Lemlist tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_lemlist_request_tool_definition, create_lemlist_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/lemlist` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/lemlist` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/lemlist` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.lemlist.operations import (
     build_lemlist_request_tool_definition,

--- a/harnessiq/tools/lemlist/operations.py
+++ b/harnessiq/tools/lemlist/operations.py
@@ -1,4 +1,27 @@
-"""Lemlist MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/lemlist/operations.py
+
+What this file does:
+- Exposes the `lemlist` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Lemlist MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `lemlist` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/lemlist` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `lemlist` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/lusha/__init__.py
+++ b/harnessiq/tools/lusha/__init__.py
@@ -1,4 +1,27 @@
-"""Lusha tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/lusha/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/lusha` within
+  the HarnessIQ runtime.
+- Lusha tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_lusha_request_tool_definition, create_lusha_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/lusha` intends to expose
+  publicly.
+
+How to use it:
+- Import from `harnessiq/tools/lusha` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/lusha` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.lusha.operations import (
     build_lusha_request_tool_definition,

--- a/harnessiq/tools/lusha/operations.py
+++ b/harnessiq/tools/lusha/operations.py
@@ -1,4 +1,27 @@
-"""Lusha MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/lusha/operations.py
+
+What this file does:
+- Exposes the `lusha` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Lusha MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `lusha` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/lusha` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `lusha` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/memory.py
+++ b/harnessiq/tools/memory.py
@@ -1,4 +1,25 @@
-"""Local durable memory tools."""
+"""
+===============================================================================
+File: harnessiq/tools/memory.py
+
+What this file does:
+- Defines the `MemoryToolRuntime` type and the supporting logic it needs in the
+  `harnessiq/tools` module.
+- Local durable memory tools.
+
+Use cases:
+- Import `MemoryToolRuntime` when composing higher-level HarnessIQ runtime
+  behavior from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/mission_driven/__init__.py
+++ b/harnessiq/tools/mission_driven/__init__.py
@@ -1,4 +1,29 @@
-"""Mission-driven harness tool factories."""
+"""
+===============================================================================
+File: harnessiq/tools/mission_driven/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/mission_driven`
+  within the HarnessIQ runtime.
+- Mission-driven harness tool factories.
+
+Use cases:
+- Import build_create_checkpoint_tool_definition,
+  build_initialize_artifact_tool_definition,
+  build_record_updates_tool_definition, create_mission_driven_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/mission_driven` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/mission_driven` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/mission_driven` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .operations import (
     build_create_checkpoint_tool_definition,

--- a/harnessiq/tools/mission_driven/operations.py
+++ b/harnessiq/tools/mission_driven/operations.py
@@ -1,4 +1,27 @@
-"""Tool definitions for the mission-driven harness."""
+"""
+===============================================================================
+File: harnessiq/tools/mission_driven/operations.py
+
+What this file does:
+- Exposes the `mission_driven` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Tool definitions for the mission-driven harness.
+
+Use cases:
+- Import this module when an agent or registry needs the `mission_driven` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/mission_driven` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `mission_driven` tool surface small, explicit, and separate
+  from provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/outreach/__init__.py
+++ b/harnessiq/tools/outreach/__init__.py
@@ -1,4 +1,27 @@
-"""Outreach tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/outreach/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/outreach`
+  within the HarnessIQ runtime.
+- Outreach tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_outreach_request_tool_definition, create_outreach_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/outreach` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/outreach` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/outreach` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.outreach.operations import (
     build_outreach_request_tool_definition,

--- a/harnessiq/tools/outreach/operations.py
+++ b/harnessiq/tools/outreach/operations.py
@@ -1,4 +1,27 @@
-"""Outreach MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/outreach/operations.py
+
+What this file does:
+- Exposes the `outreach` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Outreach MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `outreach` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/outreach` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `outreach` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/paperclip/__init__.py
+++ b/harnessiq/tools/paperclip/__init__.py
@@ -1,4 +1,27 @@
-"""Paperclip tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/paperclip/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/paperclip`
+  within the HarnessIQ runtime.
+- Paperclip tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_paperclip_request_tool_definition, create_paperclip_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/paperclip` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/paperclip` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/paperclip` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.paperclip.operations import (
     build_paperclip_request_tool_definition,

--- a/harnessiq/tools/paperclip/operations.py
+++ b/harnessiq/tools/paperclip/operations.py
@@ -1,4 +1,27 @@
-"""Paperclip MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/paperclip/operations.py
+
+What this file does:
+- Exposes the `paperclip` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Paperclip MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `paperclip` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/paperclip` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `paperclip` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/peopledatalabs/__init__.py
+++ b/harnessiq/tools/peopledatalabs/__init__.py
@@ -1,4 +1,27 @@
-"""People Data Labs MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/peopledatalabs/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/peopledatalabs`
+  within the HarnessIQ runtime.
+- People Data Labs MCP-style tool factory.
+
+Use cases:
+- Import build_peopledatalabs_request_tool_definition,
+  create_peopledatalabs_tools from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/peopledatalabs` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/peopledatalabs` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/peopledatalabs` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.peopledatalabs.operations import (
     build_peopledatalabs_request_tool_definition,

--- a/harnessiq/tools/peopledatalabs/operations.py
+++ b/harnessiq/tools/peopledatalabs/operations.py
@@ -1,4 +1,27 @@
-"""People Data Labs MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/peopledatalabs/operations.py
+
+What this file does:
+- Exposes the `peopledatalabs` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- People Data Labs MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `peopledatalabs` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/peopledatalabs` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `peopledatalabs` tool surface small, explicit, and separate
+  from provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/phantombuster/__init__.py
+++ b/harnessiq/tools/phantombuster/__init__.py
@@ -1,4 +1,27 @@
-"""PhantomBuster MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/phantombuster/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/phantombuster`
+  within the HarnessIQ runtime.
+- PhantomBuster MCP-style tool factory.
+
+Use cases:
+- Import build_phantombuster_request_tool_definition,
+  create_phantombuster_tools from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/phantombuster` intends
+  to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/phantombuster` when you want the supported
+  facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/phantombuster` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.phantombuster.operations import (
     build_phantombuster_request_tool_definition,

--- a/harnessiq/tools/phantombuster/operations.py
+++ b/harnessiq/tools/phantombuster/operations.py
@@ -1,4 +1,27 @@
-"""PhantomBuster MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/phantombuster/operations.py
+
+What this file does:
+- Exposes the `phantombuster` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- PhantomBuster MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `phantombuster` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/phantombuster` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `phantombuster` tool surface small, explicit, and separate
+  from provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/prompting.py
+++ b/harnessiq/tools/prompting.py
@@ -1,4 +1,24 @@
-"""Prompt-generation tools for agent system prompts."""
+"""
+===============================================================================
+File: harnessiq/tools/prompting.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Prompt-generation tools for agent system prompts.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `create_system_prompt` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/prospecting/__init__.py
+++ b/harnessiq/tools/prospecting/__init__.py
@@ -1,4 +1,28 @@
-"""Google Maps prospecting tool definitions and factories."""
+"""
+===============================================================================
+File: harnessiq/tools/prospecting/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/prospecting`
+  within the HarnessIQ runtime.
+- Google Maps prospecting tool definitions and factories.
+
+Use cases:
+- Import COMPLETE_SEARCH, RECORD_LISTING_RESULT, SAVE_QUALIFIED_LEAD,
+  START_SEARCH, ProspectingToolHandler, build_complete_search_tool_definition
+  from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/prospecting` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/prospecting` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/prospecting` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.prospecting.operations import (
     COMPLETE_SEARCH,

--- a/harnessiq/tools/prospecting/operations.py
+++ b/harnessiq/tools/prospecting/operations.py
@@ -1,4 +1,27 @@
-"""Public shared Google Maps prospecting tool definitions and factories."""
+"""
+===============================================================================
+File: harnessiq/tools/prospecting/operations.py
+
+What this file does:
+- Exposes the `prospecting` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Public shared Google Maps prospecting tool definitions and factories.
+
+Use cases:
+- Import this module when an agent or registry needs the `prospecting` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/prospecting` and
+  merge the resulting tools into a registry.
+
+Intent:
+- Keep the public `prospecting` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/proxycurl/__init__.py
+++ b/harnessiq/tools/proxycurl/__init__.py
@@ -1,7 +1,27 @@
-"""Proxycurl MCP-style tool factory.
+"""
+===============================================================================
+File: harnessiq/tools/proxycurl/__init__.py
 
-NOTE: Proxycurl shut down in January 2025 following a LinkedIn lawsuit.
-This package is preserved for reference only.
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/proxycurl`
+  within the HarnessIQ runtime.
+- Proxycurl MCP-style tool factory. NOTE: Proxycurl shut down in January 2025
+  following a LinkedIn lawsuit. This package is preserved for reference only.
+
+Use cases:
+- Import build_proxycurl_request_tool_definition, create_proxycurl_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/proxycurl` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/proxycurl` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/proxycurl` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
 """
 
 from harnessiq.tools.proxycurl.operations import (

--- a/harnessiq/tools/proxycurl/operations.py
+++ b/harnessiq/tools/proxycurl/operations.py
@@ -1,7 +1,28 @@
-"""Proxycurl MCP-style tool factory for the Harnessiq tool layer.
+"""
+===============================================================================
+File: harnessiq/tools/proxycurl/operations.py
 
-NOTE: Proxycurl shut down in January 2025 following a LinkedIn lawsuit.
-This module is preserved for reference only and will not produce live responses.
+What this file does:
+- Exposes the `proxycurl` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Proxycurl MCP-style tool factory for the Harnessiq tool layer. NOTE:
+  Proxycurl shut down in January 2025 following a LinkedIn lawsuit. This module
+  is preserved for reference only and will not produce live responses.
+
+Use cases:
+- Import this module when an agent or registry needs the `proxycurl` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/proxycurl` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `proxycurl` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
 """
 
 from __future__ import annotations

--- a/harnessiq/tools/reasoning/__init__.py
+++ b/harnessiq/tools/reasoning/__init__.py
@@ -1,16 +1,36 @@
-"""Reasoning tools for agent cognitive scaffolding.
+"""
+===============================================================================
+File: harnessiq/tools/reasoning/__init__.py
 
-This package exposes two complementary tool sets:
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/reasoning`
+  within the HarnessIQ runtime.
+- Reasoning tools for agent cognitive scaffolding. This package exposes two
+  complementary tool sets: - Core reasoning tools (``brainstorm``,
+  ``chain_of_thought``, ``critique``) defined in ``reasoning.core`` — three
+  high-level injectable tools for structured ideation, sequential analysis, and
+  self-evaluation. Import via ``from harnessiq.tools.reasoning import
+  brainstorm`` or add to an agent with ``create_reasoning_tools()`` from
+  ``harnessiq.tools``. - Reasoning lens tools (50 cognitive scaffolding lenses)
+  defined in ``reasoning.lenses`` — a broad catalog of named reasoning
+  patterns. The lens factory ``create_reasoning_tools`` exported from this
+  package assembles all 50.
 
-- Core reasoning tools (``brainstorm``, ``chain_of_thought``, ``critique``) defined
-  in ``reasoning.core`` — three high-level injectable tools for structured ideation,
-  sequential analysis, and self-evaluation.  Import via
-  ``from harnessiq.tools.reasoning import brainstorm`` or add to an agent with
-  ``create_reasoning_tools()`` from ``harnessiq.tools``.
+Use cases:
+- Import brainstorm, chain_of_thought, create_injectable_reasoning_tools,
+  critique, REASONING_ABDUCTIVE_REASONING, REASONING_ANALOGY_GENERATION from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/reasoning` intends to
+  expose publicly.
 
-- Reasoning lens tools (50 cognitive scaffolding lenses) defined in
-  ``reasoning.lenses`` — a broad catalog of named reasoning patterns.  The lens
-  factory ``create_reasoning_tools`` exported from this package assembles all 50.
+How to use it:
+- Import from `harnessiq/tools/reasoning` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/reasoning` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
 """
 
 from .core import brainstorm, chain_of_thought, create_injectable_reasoning_tools, critique

--- a/harnessiq/tools/reasoning/core.py
+++ b/harnessiq/tools/reasoning/core.py
@@ -1,4 +1,25 @@
-"""Core injectable reasoning tools: brainstorm, chain_of_thought, and critique."""
+"""
+===============================================================================
+File: harnessiq/tools/reasoning/core.py
+
+What this file does:
+- Implements part of the reasoning-tool surface used to make agent thinking
+  steps more structured and inspectable.
+- Core injectable reasoning tools: brainstorm, chain_of_thought, and critique.
+
+Use cases:
+- Use these helpers when a harness needs explicit reasoning tools instead of
+  relying only on free-form assistant text.
+
+How to use it:
+- Register these tools through the built-in tool catalog or a custom registry
+  composition.
+
+Intent:
+- Expose reasoning support as deterministic tools so the SDK can guide thinking
+  without hiding behavior in prompts alone.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/reasoning/injectable.py
+++ b/harnessiq/tools/reasoning/injectable.py
@@ -1,4 +1,25 @@
-"""Injectable reasoning tools for structured agent reasoning prompt injection."""
+"""
+===============================================================================
+File: harnessiq/tools/reasoning/injectable.py
+
+What this file does:
+- Implements part of the reasoning-tool surface used to make agent thinking
+  steps more structured and inspectable.
+- Injectable reasoning tools for structured agent reasoning prompt injection.
+
+Use cases:
+- Use these helpers when a harness needs explicit reasoning tools instead of
+  relying only on free-form assistant text.
+
+How to use it:
+- Register these tools through the built-in tool catalog or a custom registry
+  composition.
+
+Intent:
+- Expose reasoning support as deterministic tools so the SDK can guide thinking
+  without hiding behavior in prompts alone.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/reasoning/lenses.py
+++ b/harnessiq/tools/reasoning/lenses.py
@@ -1,4 +1,25 @@
-"""Reasoning lens tool definitions, handlers, and factory."""
+"""
+===============================================================================
+File: harnessiq/tools/reasoning/lenses.py
+
+What this file does:
+- Implements part of the reasoning-tool surface used to make agent thinking
+  steps more structured and inspectable.
+- Reasoning lens tool definitions, handlers, and factory.
+
+Use cases:
+- Use these helpers when a harness needs explicit reasoning tools instead of
+  relying only on free-form assistant text.
+
+How to use it:
+- Register these tools through the built-in tool catalog or a custom registry
+  composition.
+
+Intent:
+- Expose reasoning support as deterministic tools so the SDK can guide thinking
+  without hiding behavior in prompts alone.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/records.py
+++ b/harnessiq/tools/records.py
@@ -1,4 +1,24 @@
-"""Deterministic record-transformation tools."""
+"""
+===============================================================================
+File: harnessiq/tools/records.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Deterministic record-transformation tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `filter_records` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/registry.py
+++ b/harnessiq/tools/registry.py
@@ -1,4 +1,32 @@
-"""Deterministic registration and execution helpers for tools."""
+"""
+===============================================================================
+File: harnessiq/tools/registry.py
+
+What this file does:
+- Defines the deterministic in-memory registry that stores executable tool
+  definitions and runs them by public key.
+- Also owns canonical duplicate-key checks and a small but important
+  schema-validation pass before execution.
+- Deterministic registration and execution helpers for tools.
+
+Use cases:
+- Build a runtime tool surface for one harness from built-ins plus
+  agent-specific tools.
+- Inspect or expose the currently registered tool definitions to a model or
+  CLI.
+- Execute a tool call through the same validation path every agent relies on.
+
+How to use it:
+- Call `create_tool_registry(...)` with one or more ordered groups of
+  `RegisteredTool` objects.
+- Use `definitions()` or `inspect()` when surfacing tools to the outside world,
+  and `execute()` for runtime execution.
+
+Intent:
+- Keep tool lookup order, override semantics, and argument validation
+  centralized so the SDK has one predictable execution path.
+===============================================================================
+"""
 
 from __future__ import annotations
 
@@ -23,6 +51,8 @@ class ToolRegistry:
     """A deterministic in-memory registry for executable tools."""
 
     def __init__(self, tools: Iterable[RegisteredTool]) -> None:
+        # Registration order is part of the public runtime contract because the
+        # same order is later exposed to inspection surfaces and model requests.
         ordered_tools = tuple(tools)
         registry: dict[str, RegisteredTool] = {}
         for tool in ordered_tools:
@@ -75,6 +105,9 @@ class ToolRegistry:
 
 def _validate_arguments(definition: ToolDefinition, arguments: ToolArguments) -> None:
     """Apply a small deterministic validation pass for the canonical schema."""
+    # This validator intentionally enforces only the canonical structural rules
+    # shared by every tool: required fields and additional-properties policy.
+    # Deeper semantic validation stays inside the tool implementation itself.
     required_keys = tuple(definition.input_schema.get("required", ()))
     missing_keys = [key for key in required_keys if key not in arguments]
     if missing_keys:
@@ -101,6 +134,9 @@ def create_builtin_registry() -> ToolRegistry:
 
 def merge_tools(*tool_groups: Iterable[RegisteredTool]) -> tuple[RegisteredTool, ...]:
     """Merge ordered tool groups while allowing later groups to override keys."""
+    # Later groups override earlier registrations by key, but the first time a
+    # key appears defines its position in the ordered surface. That lets agents
+    # specialize built-ins without destabilizing tool ordering for the model.
     ordered_keys: list[str] = []
     merged: dict[str, RegisteredTool] = {}
     for tool_group in tool_groups:

--- a/harnessiq/tools/resend.py
+++ b/harnessiq/tools/resend.py
@@ -1,4 +1,24 @@
-"""Compatibility facade for the decomposed Resend tooling surface."""
+"""
+===============================================================================
+File: harnessiq/tools/resend.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Compatibility facade for the decomposed Resend tooling surface.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Import the exported symbols here through their package-level integration
+  points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/resend_catalog.py
+++ b/harnessiq/tools/resend_catalog.py
@@ -1,4 +1,24 @@
-"""Resend operation catalog helpers for tool construction."""
+"""
+===============================================================================
+File: harnessiq/tools/resend_catalog.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Resend operation catalog helpers for tool construction.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `select_resend_operations` and the other exported symbols here through
+  their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/resend_client.py
+++ b/harnessiq/tools/resend_client.py
@@ -1,4 +1,25 @@
-"""Resend client and request-preparation helpers."""
+"""
+===============================================================================
+File: harnessiq/tools/resend_client.py
+
+What this file does:
+- Defines the `ResendClient` type and the supporting logic it needs in the
+  `harnessiq/tools` module.
+- Resend client and request-preparation helpers.
+
+Use cases:
+- Import `ResendClient` when composing higher-level HarnessIQ runtime behavior
+  from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/resend_tool.py
+++ b/harnessiq/tools/resend_tool.py
@@ -1,4 +1,24 @@
-"""Tool-definition and factory wiring for Resend operations."""
+"""
+===============================================================================
+File: harnessiq/tools/resend_tool.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Tool-definition and factory wiring for Resend operations.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `build_resend_request_tool_definition` and the other exported symbols
+  here through their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/runtime_support.py
+++ b/harnessiq/tools/runtime_support.py
@@ -1,4 +1,24 @@
-"""Shared local persistence helpers for stateful tool families."""
+"""
+===============================================================================
+File: harnessiq/tools/runtime_support.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Shared local persistence helpers for stateful tool families.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `resolve_runtime_root` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/salesforge/__init__.py
+++ b/harnessiq/tools/salesforge/__init__.py
@@ -1,4 +1,27 @@
-"""Salesforge MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/salesforge/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/salesforge`
+  within the HarnessIQ runtime.
+- Salesforge MCP-style tool factory.
+
+Use cases:
+- Import build_salesforge_request_tool_definition, create_salesforge_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/salesforge` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/salesforge` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/salesforge` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.salesforge.operations import (
     build_salesforge_request_tool_definition,

--- a/harnessiq/tools/salesforge/operations.py
+++ b/harnessiq/tools/salesforge/operations.py
@@ -1,4 +1,27 @@
-"""Salesforge MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/salesforge/operations.py
+
+What this file does:
+- Exposes the `salesforge` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Salesforge MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `salesforge` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/salesforge` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `salesforge` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/search/__init__.py
+++ b/harnessiq/tools/search/__init__.py
@@ -1,4 +1,27 @@
-"""Shared search tool factories."""
+"""
+===============================================================================
+File: harnessiq/tools/search/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/search` within
+  the HarnessIQ runtime.
+- Shared search tool factories.
+
+Use cases:
+- Import build_search_or_summarize_tool_definition,
+  create_search_or_summarize_tool from one stable package entry point.
+- Read this module to understand what `harnessiq/tools/search` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/search` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/search` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from .search_or_summarize import (
     build_search_or_summarize_tool_definition,

--- a/harnessiq/tools/search/search_or_summarize.py
+++ b/harnessiq/tools/search/search_or_summarize.py
@@ -1,4 +1,24 @@
-"""Public shared search iteration + summarization tool."""
+"""
+===============================================================================
+File: harnessiq/tools/search/search_or_summarize.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools/search`.
+- Public shared search iteration + summarization tool.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `build_search_or_summarize_tool_definition` and the other exported
+  symbols here through their package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/serper/__init__.py
+++ b/harnessiq/tools/serper/__init__.py
@@ -1,4 +1,27 @@
-"""Serper tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/serper/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/serper` within
+  the HarnessIQ runtime.
+- Serper tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_serper_request_tool_definition, create_serper_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/serper` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/serper` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/serper` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.serper.operations import (
     build_serper_request_tool_definition,

--- a/harnessiq/tools/serper/operations.py
+++ b/harnessiq/tools/serper/operations.py
@@ -1,4 +1,27 @@
-"""Serper MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/serper/operations.py
+
+What this file does:
+- Exposes the `serper` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Serper MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `serper` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/serper` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `serper` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/smartlead/__init__.py
+++ b/harnessiq/tools/smartlead/__init__.py
@@ -1,4 +1,27 @@
-"""Smartlead tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/smartlead/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/smartlead`
+  within the HarnessIQ runtime.
+- Smartlead tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_smartlead_request_tool_definition, create_smartlead_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/smartlead` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/smartlead` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/smartlead` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.smartlead.operations import (
     build_smartlead_request_tool_definition,

--- a/harnessiq/tools/smartlead/operations.py
+++ b/harnessiq/tools/smartlead/operations.py
@@ -1,4 +1,27 @@
-"""Smartlead MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/smartlead/operations.py
+
+What this file does:
+- Exposes the `smartlead` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Smartlead MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `smartlead` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/smartlead` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `smartlead` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/snovio/__init__.py
+++ b/harnessiq/tools/snovio/__init__.py
@@ -1,4 +1,27 @@
-"""Snov.io MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/snovio/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/snovio` within
+  the HarnessIQ runtime.
+- Snov.io MCP-style tool factory.
+
+Use cases:
+- Import build_snovio_request_tool_definition, create_snovio_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/snovio` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/snovio` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/snovio` explicit, discoverable,
+  and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.snovio.operations import (
     build_snovio_request_tool_definition,

--- a/harnessiq/tools/snovio/operations.py
+++ b/harnessiq/tools/snovio/operations.py
@@ -1,4 +1,27 @@
-"""Snov.io MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/snovio/operations.py
+
+What this file does:
+- Exposes the `snovio` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Snov.io MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `snovio` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/snovio` and merge the
+  resulting tools into a registry.
+
+Intent:
+- Keep the public `snovio` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/spawn_specialized_subagents/__init__.py
+++ b/harnessiq/tools/spawn_specialized_subagents/__init__.py
@@ -1,4 +1,28 @@
-"""Spawn-specialized-subagents harness tool factories."""
+"""
+===============================================================================
+File: harnessiq/tools/spawn_specialized_subagents/__init__.py
+
+What this file does:
+- Defines the package-level export surface for
+  `harnessiq/tools/spawn_specialized_subagents` within the HarnessIQ runtime.
+- Spawn-specialized-subagents harness tool factories.
+
+Use cases:
+- Import build_integrate_results_tool_definition,
+  build_plan_assignments_tool_definition, build_run_assignment_tool_definition,
+  create_spawn_specialized_subagents_tools from one stable package entry point.
+- Read this module to understand what
+  `harnessiq/tools/spawn_specialized_subagents` intends to expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/spawn_specialized_subagents` when you want the
+  supported facade instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/spawn_specialized_subagents`
+  explicit, discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from .operations import (
     build_integrate_results_tool_definition,

--- a/harnessiq/tools/spawn_specialized_subagents/operations.py
+++ b/harnessiq/tools/spawn_specialized_subagents/operations.py
@@ -1,4 +1,29 @@
-"""Tool definitions for the spawn-specialized-subagents harness."""
+"""
+===============================================================================
+File: harnessiq/tools/spawn_specialized_subagents/operations.py
+
+What this file does:
+- Exposes the `spawn_specialized_subagents` tool family for the HarnessIQ tool
+  layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- Tool definitions for the spawn-specialized-subagents harness.
+
+Use cases:
+- Import this module when an agent or registry needs the
+  `spawn_specialized_subagents` tool definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from
+  `harnessiq/tools/spawn_specialized_subagents` and merge the resulting tools
+  into a registry.
+
+Intent:
+- Keep the public `spawn_specialized_subagents` tool surface small, explicit,
+  and separate from provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/text.py
+++ b/harnessiq/tools/text.py
@@ -1,4 +1,25 @@
-"""Deterministic text tools."""
+"""
+===============================================================================
+File: harnessiq/tools/text.py
+
+What this file does:
+- Defines the `_LinkParser` type and the supporting logic it needs in the
+  `harnessiq/tools` module.
+- Deterministic text tools.
+
+Use cases:
+- Import `_LinkParser` when composing higher-level HarnessIQ runtime behavior
+  from this package.
+
+How to use it:
+- Use the public class and any exported helpers here as the supported entry
+  points for this module.
+
+Intent:
+- Keep this package responsibility encapsulated behind one focused module
+  instead of duplicating the same logic elsewhere.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/validation.py
+++ b/harnessiq/tools/validation.py
@@ -1,4 +1,24 @@
-"""Structured validation tools."""
+"""
+===============================================================================
+File: harnessiq/tools/validation.py
+
+What this file does:
+- Implements focused support logic for `harnessiq/tools`.
+- Structured validation tools.
+
+Use cases:
+- Import this module when sibling runtime code needs the behavior it
+  centralizes.
+
+How to use it:
+- Use `schema_validate` and the other exported symbols here through their
+  package-level integration points.
+
+Intent:
+- Keep related runtime behavior centralized and easier to discover during
+  maintenance.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/zerobounce/__init__.py
+++ b/harnessiq/tools/zerobounce/__init__.py
@@ -1,4 +1,27 @@
-"""ZeroBounce tool registration for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/zerobounce/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/zerobounce`
+  within the HarnessIQ runtime.
+- ZeroBounce tool registration for the Harnessiq tool layer.
+
+Use cases:
+- Import build_zerobounce_request_tool_definition, create_zerobounce_tools from
+  one stable package entry point.
+- Read this module to understand what `harnessiq/tools/zerobounce` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/zerobounce` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/zerobounce` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.zerobounce.operations import (
     build_zerobounce_request_tool_definition,

--- a/harnessiq/tools/zerobounce/operations.py
+++ b/harnessiq/tools/zerobounce/operations.py
@@ -1,4 +1,27 @@
-"""ZeroBounce MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/zerobounce/operations.py
+
+What this file does:
+- Exposes the `zerobounce` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- ZeroBounce MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `zerobounce` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/zerobounce` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `zerobounce` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 

--- a/harnessiq/tools/zoominfo/__init__.py
+++ b/harnessiq/tools/zoominfo/__init__.py
@@ -1,4 +1,27 @@
-"""ZoomInfo MCP-style tool factory."""
+"""
+===============================================================================
+File: harnessiq/tools/zoominfo/__init__.py
+
+What this file does:
+- Defines the package-level export surface for `harnessiq/tools/zoominfo`
+  within the HarnessIQ runtime.
+- ZoomInfo MCP-style tool factory.
+
+Use cases:
+- Import build_zoominfo_request_tool_definition, create_zoominfo_tools from one
+  stable package entry point.
+- Read this module to understand what `harnessiq/tools/zoominfo` intends to
+  expose publicly.
+
+How to use it:
+- Import from `harnessiq/tools/zoominfo` when you want the supported facade
+  instead of reaching through deeper internal modules.
+
+Intent:
+- Keep the public surface for `harnessiq/tools/zoominfo` explicit,
+  discoverable, and easier to maintain.
+===============================================================================
+"""
 
 from harnessiq.tools.zoominfo.operations import (
     build_zoominfo_request_tool_definition,

--- a/harnessiq/tools/zoominfo/operations.py
+++ b/harnessiq/tools/zoominfo/operations.py
@@ -1,4 +1,27 @@
-"""ZoomInfo MCP-style tool factory for the Harnessiq tool layer."""
+"""
+===============================================================================
+File: harnessiq/tools/zoominfo/operations.py
+
+What this file does:
+- Exposes the `zoominfo` tool family for the HarnessIQ tool layer.
+- In most packages this module is the bridge between provider-backed operations
+  and the generic tool registration surface.
+- ZoomInfo MCP-style tool factory for the Harnessiq tool layer.
+
+Use cases:
+- Import this module when an agent or registry needs the `zoominfo` tool
+  definitions.
+- Read it to see which runtime operations are intentionally surfaced as tools.
+
+How to use it:
+- Call the exported factory helpers from `harnessiq/tools/zoominfo` and merge
+  the resulting tools into a registry.
+
+Intent:
+- Keep the public `zoominfo` tool surface small, explicit, and separate from
+  provider implementation details.
+===============================================================================
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add large top-of-file documentation blocks across the live runtime agents, tools, and formalization modules
- add targeted business-logic comment blocks in the core orchestration paths for agent loops, formalization, staged execution, context compaction, mission state, and delegation flows
- regenerate generated docs so README and artifacts/file_index.md stay in sync with the documented source tree

## Verification
- `python -m compileall harnessiq`
- `pytest -q tests/test_docs_sync.py`

## Notes
- I excluded local `memory/` workspace artifacts from this PR and preserved them in a local stash named `preserve-local-memory-artifacts-after-doc-pr`.
- The broader pytest suite still has unrelated pre-existing failures in provider/toolset areas (for example `tests/test_provider_base.py`, `tests/test_providers.py`, `tests/test_sdk_package.py`, and `tests/test_toolset_registry.py`).
