### PR TITLE
Add harnessiq/formalization/roles/ module (RoleSpec + RoleLayer)

### DIFF
--- a/harnessiq/formalization/roles/__init__.py
+++ b/harnessiq/formalization/roles/__init__.py
@@ -1,0 +1,29 @@
+"""
+===============================================================================
+File: harnessiq/formalization/roles/__init__.py
+
+What this file does:
+- Defines the public export surface for harnessiq/formalization/roles.
+- Exposes RoleSpec (persona injection spec) and RoleLayer.
+
+Use cases:
+- Import from harnessiq.formalization.roles when building agents that need
+  an explicit persona injected into the system prompt.
+
+How to use it:
+  from harnessiq.formalization.roles import RoleSpec, RoleLayer
+
+Intent:
+- Keep the public interface for the roles formalization package narrow and
+  explicit.
+===============================================================================
+"""
+
+from .layer import RoleLayer
+from .spec import RolePosition, RoleSpec
+
+__all__ = [
+    "RoleLayer",
+    "RolePosition",
+    "RoleSpec",
+]

--- a/harnessiq/formalization/roles/layer.py
+++ b/harnessiq/formalization/roles/layer.py
@@ -1,0 +1,138 @@
+"""
+===============================================================================
+File: harnessiq/formalization/roles/layer.py
+
+What this file does:
+- Implements RoleLayer, a formalization layer that injects persona descriptions
+  into the system prompt at declared positions.
+- Purely semantic — no tool interaction, no filter_tool_keys logic, no
+  on_tool_result logic.
+
+Use cases:
+- Pass RoleLayer instances via BaseAgent(formalization_layers=[...]) or use the
+  roles= sugar on BaseAgent to have the layer created automatically.
+
+How to use it:
+- Construct with one or more RoleSpec instances. Each spec is injected at its
+  declared position when augment_system_prompt is called.
+
+Intent:
+- Give agents an explicit, inspectable, auditable identity that appears in
+  describe() output and in the context window parameter sections.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Sequence
+from typing import Any
+
+from harnessiq.formalization.base import BaseFormalizationLayer
+from harnessiq.shared.agents import AgentParameterSection
+from harnessiq.shared.formalization import LayerRuleRecord
+
+from .spec import RoleSpec
+
+
+class RoleLayer(BaseFormalizationLayer):
+    """Injects role (persona) descriptions into the system prompt.
+
+    Purely semantic — no tool interaction. Created automatically by BaseAgent
+    when roles= is provided, or constructed directly for explicit control.
+    """
+
+    def __init__(self, roles: Sequence[RoleSpec]) -> None:
+        if not roles:
+            raise ValueError("RoleLayer requires at least one RoleSpec.")
+        self._roles = tuple(roles)
+
+    @property
+    def layer_id(self) -> str:
+        return "RoleLayer"
+
+    # ── Documentation ──────────────────────────────────────────────────────────
+
+    def _describe_identity(self) -> str:
+        names = ", ".join(r.name for r in self._roles)
+        return (
+            f"You are operating under {len(self._roles)} declared role(s): {names}. "
+            f"These define your identity and operating persona for this run."
+        )
+
+    def _describe_contract(self) -> str:
+        lines = ["Act consistently with the role(s) declared below:", ""]
+        for role in self._roles:
+            lines.append(f"[{role.name}] (injected at: {role.position})")
+            lines.append(role.description)
+            lines.append("")
+        return "\n".join(lines).rstrip()
+
+    def _describe_rules(self) -> tuple[LayerRuleRecord, ...]:
+        return tuple(
+            LayerRuleRecord(
+                rule_id=f"ROLE-INJECT-{role.name.upper().replace(' ', '-')}",
+                description=(
+                    f"'{role.name}' role description is injected into the system "
+                    f"prompt at position='{role.position}' via augment_system_prompt."
+                ),
+                enforced_at="augment_system_prompt",
+                enforcement_type="inject",
+            )
+            for role in self._roles
+        )
+
+    def _describe_configuration(self) -> dict[str, Any]:
+        return {
+            "role_count": len(self._roles),
+            "roles": [
+                {
+                    "name": r.name,
+                    "position": r.position,
+                    "marker_text": r.marker_text,
+                    "show_in_parameter_sections": r.show_in_parameter_sections,
+                }
+                for r in self._roles
+            ],
+        }
+
+    # ── System prompt injection ────────────────────────────────────────────────
+
+    def augment_system_prompt(self, prompt: str) -> str:
+        """Inject all roles at their declared positions."""
+        result = prompt
+        for role in self._roles:
+            block = f"[ROLE: {role.name}]\n{role.description}"
+            if role.position == "top":
+                result = block + "\n\n" + result
+            elif role.position == "bottom":
+                result = result + "\n\n" + block
+            elif role.position == "after_marker":
+                if role.marker_text in result:
+                    idx = result.index(role.marker_text) + len(role.marker_text)
+                    result = result[:idx] + "\n\n" + block + result[idx:]
+                else:
+                    warnings.warn(
+                        f"RoleSpec '{role.name}': marker_text '{role.marker_text}' "
+                        f"not found in assembled prompt. Falling back to 'bottom'.",
+                        stacklevel=2,
+                    )
+                    result = result + "\n\n" + block
+        return result
+
+    # ── Context window sections ────────────────────────────────────────────────
+
+    def get_parameter_sections(self) -> tuple[AgentParameterSection, ...]:
+        """Return one parameter section per visible role, plus the standard layer section."""
+        base = super().get_parameter_sections()
+        visible = [r for r in self._roles if r.show_in_parameter_sections]
+        if not visible:
+            return base
+        role_sections = tuple(
+            AgentParameterSection(
+                title=f"Role: {role.name}",
+                content=role.description,
+            )
+            for role in visible
+        )
+        return base + role_sections

--- a/harnessiq/formalization/roles/spec.py
+++ b/harnessiq/formalization/roles/spec.py
@@ -1,0 +1,87 @@
+"""
+===============================================================================
+File: harnessiq/formalization/roles/spec.py
+
+What this file does:
+- Defines RoleSpec, the configuration dataclass for persona injection roles.
+- A role is a named identity description injected into the system prompt at a
+  declared position. It is purely semantic — no tool constraints, no enforcement
+  hooks, no completion logic.
+
+Use cases:
+- Declare the agent's persona by passing RoleSpec instances to RoleLayer or to
+  BaseAgent(roles=[...]).
+
+How to use it:
+- Import RoleSpec from harnessiq.formalization.roles and pass one or more
+  instances when constructing a RoleLayer.
+
+Intent:
+- Keep role configuration as a frozen, self-validating dataclass so persona
+  declarations are explicit, inspectable, and immutable at runtime.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+RolePosition = Literal["top", "bottom", "after_marker"]
+"""Where in the assembled system prompt a role description is injected.
+
+"top"          — prepended before all other content.
+"bottom"       — appended after all other content (including other layers).
+"after_marker" — inserted immediately after the first occurrence of
+                 marker_text in the assembled prompt. Falls back to "bottom"
+                 with a warning when the marker is not found.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class RoleSpec:
+    """Declares one role (persona) for an agent.
+
+    A role is a named identity description injected into the system prompt at
+    a specified position. It is purely semantic — it carries no tool
+    constraints, no enforcement hooks, and no completion logic.
+
+    Note: This is distinct from the existing RoleSpec in
+    harnessiq.formalization.base, which describes behavioral role-switching.
+    This RoleSpec is for persona/identity injection only.
+    """
+
+    name: str
+    """Short display name for this role. Used in describe() output and the
+    parameter section title. Example: 'Senior Python Engineer'.
+    """
+
+    description: str
+    """The persona text injected into the system prompt. Should be written in
+    second person present tense, as if describing the agent's identity to
+    itself.
+    """
+
+    position: RolePosition = "top"
+    """Where in the assembled system prompt to inject the role description."""
+
+    marker_text: str = ""
+    """The marker string to search for when position='after_marker'.
+    Case-sensitive substring match. Must be non-empty when
+    position='after_marker'.
+    """
+
+    show_in_parameter_sections: bool = True
+    """Whether to include the role description in the context window parameter
+    sections in addition to the system prompt injection.
+    """
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("RoleSpec name must not be blank.")
+        if not self.description.strip():
+            raise ValueError("RoleSpec description must not be blank.")
+        if self.position == "after_marker" and not self.marker_text.strip():
+            raise ValueError(
+                "RoleSpec marker_text must be non-empty when position='after_marker'."
+            )

--- a/tests/test_formalization_roles.py
+++ b/tests/test_formalization_roles.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import unittest
+import warnings
+
+from harnessiq.formalization.roles import RoleLayer, RolePosition, RoleSpec
+
+
+class RoleSpecValidationTests(unittest.TestCase):
+    def test_valid_spec_constructs(self) -> None:
+        spec = RoleSpec(name="Researcher", description="You are a researcher.")
+        self.assertEqual(spec.name, "Researcher")
+        self.assertEqual(spec.description, "You are a researcher.")
+        self.assertEqual(spec.position, "top")
+        self.assertEqual(spec.marker_text, "")
+        self.assertTrue(spec.show_in_parameter_sections)
+
+    def test_blank_name_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="name must not be blank"):
+            RoleSpec(name="  ", description="desc")
+
+    def test_blank_description_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="description must not be blank"):
+            RoleSpec(name="Name", description="  ")
+
+    def test_after_marker_with_empty_marker_text_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="marker_text required for after_marker"):
+            RoleSpec(name="Name", description="desc", position="after_marker", marker_text="")
+
+    def test_after_marker_with_whitespace_marker_text_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            RoleSpec(name="Name", description="desc", position="after_marker", marker_text="   ")
+
+    def test_after_marker_with_valid_marker_text(self) -> None:
+        spec = RoleSpec(
+            name="Name",
+            description="desc",
+            position="after_marker",
+            marker_text="[IDENTITY]",
+        )
+        self.assertEqual(spec.marker_text, "[IDENTITY]")
+
+    def test_spec_is_frozen(self) -> None:
+        spec = RoleSpec(name="Name", description="desc")
+        with self.assertRaises((AttributeError, TypeError)):
+            spec.name = "Other"  # type: ignore[misc]
+
+    def test_all_positions_accepted(self) -> None:
+        positions: list[RolePosition] = ["top", "bottom", "after_marker"]
+        for pos in positions:
+            kwargs = {"name": "Name", "description": "desc", "position": pos}
+            if pos == "after_marker":
+                kwargs["marker_text"] = "[M]"
+            RoleSpec(**kwargs)  # must not raise
+
+
+class RoleLayerConstructionTests(unittest.TestCase):
+    def test_empty_roles_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            RoleLayer(roles=[])
+
+    def test_single_role(self) -> None:
+        layer = RoleLayer(roles=[RoleSpec(name="Engineer", description="You are an engineer.")])
+        self.assertEqual(layer.layer_id, "RoleLayer")
+
+    def test_multiple_roles(self) -> None:
+        layer = RoleLayer(
+            roles=[
+                RoleSpec(name="Role A", description="Desc A"),
+                RoleSpec(name="Role B", description="Desc B"),
+            ]
+        )
+        desc = layer.describe()
+        self.assertIn("Role A", desc.identity)
+        self.assertIn("Role B", desc.identity)
+
+
+class RoleLayerAugmentSystemPromptTests(unittest.TestCase):
+    def _make_layer(self, *roles: RoleSpec) -> RoleLayer:
+        return RoleLayer(roles=list(roles))
+
+    def test_position_top_prepends(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.", position="top")
+        layer = self._make_layer(spec)
+        result = layer.augment_system_prompt("Base prompt.")
+        self.assertTrue(result.startswith("[ROLE: Eng]\nYou are an engineer."))
+        self.assertIn("Base prompt.", result)
+
+    def test_position_bottom_appends(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.", position="bottom")
+        layer = self._make_layer(spec)
+        result = layer.augment_system_prompt("Base prompt.")
+        self.assertTrue(result.endswith("[ROLE: Eng]\nYou are an engineer."))
+        self.assertTrue(result.startswith("Base prompt."))
+
+    def test_position_after_marker_inserts_after_marker(self) -> None:
+        spec = RoleSpec(
+            name="Eng",
+            description="You are an engineer.",
+            position="after_marker",
+            marker_text="[TOOLS]",
+        )
+        layer = self._make_layer(spec)
+        prompt = "Preamble.\n[TOOLS]\nMore content."
+        result = layer.augment_system_prompt(prompt)
+        marker_pos = result.index("[TOOLS]")
+        role_pos = result.index("[ROLE: Eng]")
+        self.assertGreater(role_pos, marker_pos)
+        self.assertIn("More content.", result)
+
+    def test_position_after_marker_falls_back_to_bottom_when_missing(self) -> None:
+        spec = RoleSpec(
+            name="Eng",
+            description="You are an engineer.",
+            position="after_marker",
+            marker_text="[MISSING]",
+        )
+        layer = self._make_layer(spec)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = layer.augment_system_prompt("Base prompt.")
+        self.assertTrue(any("not found" in str(w.message) for w in caught))
+        self.assertTrue(result.endswith("[ROLE: Eng]\nYou are an engineer."))
+
+    def test_multiple_roles_applied_in_order(self) -> None:
+        spec_a = RoleSpec(name="A", description="Role A.", position="top")
+        spec_b = RoleSpec(name="B", description="Role B.", position="bottom")
+        layer = self._make_layer(spec_a, spec_b)
+        result = layer.augment_system_prompt("Base.")
+        self.assertTrue(result.startswith("[ROLE: A]"))
+        self.assertTrue(result.endswith("[ROLE: B]\nRole B."))
+
+    def test_empty_prompt_handled(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.", position="top")
+        layer = self._make_layer(spec)
+        result = layer.augment_system_prompt("")
+        self.assertIn("[ROLE: Eng]", result)
+
+
+class RoleLayerParameterSectionsTests(unittest.TestCase):
+    def test_visible_role_appears_in_sections(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.", show_in_parameter_sections=True)
+        layer = RoleLayer(roles=[spec])
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertIn("Role: Eng", titles)
+
+    def test_invisible_role_excluded_from_sections(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.", show_in_parameter_sections=False)
+        layer = RoleLayer(roles=[spec])
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertNotIn("Role: Eng", titles)
+
+    def test_mixed_visibility(self) -> None:
+        spec_a = RoleSpec(name="A", description="Desc A", show_in_parameter_sections=True)
+        spec_b = RoleSpec(name="B", description="Desc B", show_in_parameter_sections=False)
+        layer = RoleLayer(roles=[spec_a, spec_b])
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertIn("Role: A", titles)
+        self.assertNotIn("Role: B", titles)
+
+    def test_section_content_matches_description(self) -> None:
+        spec = RoleSpec(name="Eng", description="You are an engineer.")
+        layer = RoleLayer(roles=[spec])
+        sections = layer.get_parameter_sections()
+        role_section = next(s for s in sections if s.title == "Role: Eng")
+        self.assertEqual(role_section.content, "You are an engineer.")
+
+
+class RoleLayerDescribeTests(unittest.TestCase):
+    def test_describe_renders_correctly(self) -> None:
+        spec = RoleSpec(name="Senior Engineer", description="You are a senior engineer.")
+        layer = RoleLayer(roles=[spec])
+        desc = layer.describe()
+        self.assertEqual(desc.layer_id, "RoleLayer")
+        self.assertIn("Senior Engineer", desc.identity)
+        self.assertIn("Senior Engineer", desc.contract)
+        self.assertEqual(len(desc.rules), 1)
+        rule = desc.rules[0]
+        self.assertEqual(rule.enforced_at, "augment_system_prompt")
+        self.assertEqual(rule.enforcement_type, "inject")
+        self.assertIn("ROLE-INJECT-SENIOR-ENGINEER", rule.rule_id)
+
+    def test_describe_configuration(self) -> None:
+        spec = RoleSpec(name="Eng", description="desc", position="bottom")
+        layer = RoleLayer(roles=[spec])
+        config = layer.describe().configuration
+        self.assertEqual(config["role_count"], 1)
+        self.assertEqual(config["roles"][0]["position"], "bottom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #454

## Summary
- Adds `harnessiq/formalization/roles/` package with `RoleSpec` (persona injection spec, distinct from the existing behavioral-switching `RoleSpec` in `base.py`) and `RoleLayer` (concrete `BaseFormalizationLayer` that injects roles into the system prompt)
- `RoleSpec` supports three injection positions: `top`, `bottom`, `after_marker` with marker fallback + warning
- `RoleLayer.get_parameter_sections()` renders visible roles as labeled context-window sections
- 23 unit tests covering spec validation, augment_system_prompt positions, parameter section visibility, and describe() output

## Test plan
- [ ] `python -m pytest tests/test_formalization_roles.py -v` — 23/23 pass
- [ ] Imports verified: `from harnessiq.formalization.roles import RoleSpec, RoleLayer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)