### PR TITLE
Add harnessiq/formalization/metrics/ module (MetricsLayer)

### DIFF
--- a/harnessiq/formalization/metrics/__init__.py
+++ b/harnessiq/formalization/metrics/__init__.py
@@ -1,0 +1,34 @@
+"""
+===============================================================================
+File: harnessiq/formalization/metrics/__init__.py
+
+What this file does:
+- Defines the public export surface for harnessiq/formalization/metrics.
+
+Use cases:
+  from harnessiq.formalization.metrics import (
+      DeterministicMetricSpec,
+      MetricsLayer,
+      ModelReportedMetricSpec,
+  )
+
+Intent:
+- Keep the public interface for the metrics formalization package narrow and
+  explicit.
+===============================================================================
+"""
+
+from .layer import MetricsLayer
+from .spec import DeterministicMetricSpec, MetricAggregation, MetricValueType, ModelReportedMetricSpec
+from .store import MetricStore
+from .tools import METRICS_REPORT_KEY
+
+__all__ = [
+    "DeterministicMetricSpec",
+    "MetricAggregation",
+    "MetricValueType",
+    "MetricStore",
+    "MetricsLayer",
+    "ModelReportedMetricSpec",
+    "METRICS_REPORT_KEY",
+]

--- a/harnessiq/formalization/metrics/layer.py
+++ b/harnessiq/formalization/metrics/layer.py
@@ -1,0 +1,287 @@
+"""
+===============================================================================
+File: harnessiq/formalization/metrics/layer.py
+
+What this file does:
+- Implements MetricsLayer, a formalization layer that tracks declared metrics
+  and surfaces them live in the context window.
+- Deterministic metrics are updated silently by intercepting tool results.
+- Model-reported metrics are updated when the model calls metrics.report().
+- All metric values are durable — they survive context window resets via
+  MetricStore (disk-backed JSON).
+
+Use cases:
+- Declare metrics to track agent activity quantitatively. Compose with
+  StopCriteriaLayer to gate completion on measurable thresholds.
+
+How to use it:
+- Construct with one or more metric specs and pass to BaseAgent via
+  formalization_layers= or the metrics= sugar parameter.
+
+Intent:
+- Give agents quantifiable, durable progress tracking that is always visible
+  in the context window and always survives resets.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from harnessiq.formalization.base import BaseFormalizationLayer
+from harnessiq.shared.agents import AgentParameterSection
+from harnessiq.shared.formalization import LayerRuleRecord
+from harnessiq.shared.tools import RegisteredTool, ToolResult
+
+from .spec import DeterministicMetricSpec, MetricValueType, ModelReportedMetricSpec
+from .store import MetricStore
+
+
+class MetricsLayer(BaseFormalizationLayer):
+    """Tracks declared metrics and surfaces them live in the context window.
+
+    Deterministic metrics are updated silently by intercepting tool results.
+    Model-reported metrics are updated when the model calls metrics.report().
+    All metrics are durable — they survive context window resets.
+    """
+
+    def __init__(
+        self,
+        metrics: Sequence[DeterministicMetricSpec | ModelReportedMetricSpec],
+    ) -> None:
+        if not metrics:
+            raise ValueError("MetricsLayer requires at least one metric spec.")
+        seen: set[str] = set()
+        for m in metrics:
+            if m.name in seen:
+                raise ValueError(f"Duplicate metric name '{m.name}'.")
+            seen.add(m.name)
+
+        self._deterministic = [m for m in metrics if isinstance(m, DeterministicMetricSpec)]
+        self._model_reported = [m for m in metrics if isinstance(m, ModelReportedMetricSpec)]
+        self._all_specs: dict[str, DeterministicMetricSpec | ModelReportedMetricSpec] = {
+            m.name: m for m in metrics
+        }
+        self._store: MetricStore | None = None
+
+    # ── Public API used by StopCriteriaLayer ──────────────────────────────────
+
+    def get_value(self, metric_name: str) -> MetricValueType | None:
+        """Return the current value of a named metric, or None if not yet initialized."""
+        if self._store is None:
+            return None
+        spec = self._all_specs.get(metric_name)
+        if spec is None:
+            return None
+        return self._store.get(metric_name, spec.initial_value)
+
+    def all_values(self) -> dict[str, MetricValueType]:
+        """Return a snapshot of all current metric values."""
+        if self._store is None:
+            return {}
+        return {
+            name: self._store.get(name, spec.initial_value)
+            for name, spec in self._all_specs.items()
+        }
+
+    # ── Documentation ──────────────────────────────────────────────────────────
+
+    @property
+    def layer_id(self) -> str:
+        return "MetricsLayer"
+
+    def _describe_identity(self) -> str:
+        parts: list[str] = []
+        if self._deterministic:
+            names = ", ".join(s.name for s in self._deterministic)
+            parts.append(f"{len(self._deterministic)} auto-tracked metric(s): {names}")
+        if self._model_reported:
+            names = ", ".join(s.name for s in self._model_reported)
+            parts.append(f"{len(self._model_reported)} self-reported metric(s): {names}")
+        return (
+            f"You are operating with tracked metrics: {'; '.join(parts)}. "
+            f"All metrics are durable and survive context window resets. "
+            f"Current values appear in the Metrics section below."
+        )
+
+    def _describe_contract(self) -> str:
+        lines: list[str] = []
+        if self._model_reported:
+            lines.append(
+                "The following metrics must be reported by you using "
+                "metrics.report(name=..., value=...):"
+            )
+            for spec in self._model_reported:
+                instructions = spec.report_instructions or (
+                    f"Report '{spec.name}' ({spec.value_type}) whenever "
+                    f"{spec.description.lower().rstrip('.')}."
+                )
+                lines.append(f"  {spec.name} ({spec.value_type}): {instructions}")
+        if self._deterministic:
+            lines.append(
+                "\nThe following metrics are tracked automatically "
+                "(you do not need to do anything):"
+            )
+            for spec in self._deterministic:
+                lines.append(f"  {spec.name}: {spec.description}")
+        return "\n".join(lines)
+
+    def _describe_rules(self) -> tuple[LayerRuleRecord, ...]:
+        rules: list[LayerRuleRecord] = []
+        for spec in self._deterministic:
+            patterns = ", ".join(spec.watch_tool_patterns)
+            rules.append(
+                LayerRuleRecord(
+                    rule_id=f"METRIC-TRACK-{spec.name.upper()}",
+                    description=(
+                        f"on_tool_result watches [{patterns}] and calls "
+                        f"extract_value. Non-None results update '{spec.name}' "
+                        f"via aggregation='{spec.aggregation}'."
+                    ),
+                    enforced_at="on_tool_result",
+                    enforcement_type="observe",
+                )
+            )
+        if self._model_reported:
+            rules.append(
+                LayerRuleRecord(
+                    rule_id="METRIC-REPORT-TOOL",
+                    description=(
+                        "metrics.report(name, value) is contributed to the executor. "
+                        "When the model calls it with a declared model-reported metric "
+                        "name, the value is validated and stored."
+                    ),
+                    enforced_at="on_tool_result",
+                    enforcement_type="observe",
+                )
+            )
+        return tuple(rules)
+
+    def _describe_configuration(self) -> dict[str, Any]:
+        return {
+            "metric_count": len(self._all_specs),
+            "metrics": [
+                {
+                    "name": m.name,
+                    "type": (
+                        "deterministic"
+                        if isinstance(m, DeterministicMetricSpec)
+                        else "model_reported"
+                    ),
+                    "description": m.description,
+                    "aggregation": m.aggregation,
+                    "initial_value": m.initial_value,
+                    "visible": m.visible,
+                    "unit": m.unit,
+                }
+                for m in self._all_specs.values()
+            ],
+        }
+
+    # ── Context window — live metric values ───────────────────────────────────
+
+    def get_parameter_sections(self) -> tuple[AgentParameterSection, ...]:
+        base = super().get_parameter_sections()
+        visible = [(name, spec) for name, spec in self._all_specs.items() if spec.visible]
+        if not visible or self._store is None:
+            return base
+
+        lines: list[str] = []
+        for name, spec in visible:
+            value = self._store.get(name, spec.initial_value)
+            unit = f" {spec.unit}" if spec.unit else ""
+            kind = "auto" if isinstance(spec, DeterministicMetricSpec) else "self-reported"
+            lines.append(f"{name}: {value}{unit}  ({spec.description}) [{kind}]")
+
+        model_reported_visible = [s for s in self._model_reported if s.visible]
+        if model_reported_visible:
+            lines.append("")
+            lines.append(
+                'Report model-assessed metrics via: '
+                'metrics.report(name="<metric_name>", value=<value>)'
+            )
+
+        return base + (AgentParameterSection(title="Metrics", content="\n".join(lines)),)
+
+    # ── Tools ──────────────────────────────────────────────────────────────────
+
+    def get_formalization_tools(self) -> tuple[RegisteredTool, ...]:
+        """Contribute metrics.report tool when model-reported metrics are declared."""
+        if not self._model_reported:
+            return ()
+        from .tools import build_metrics_report_tool
+        return (build_metrics_report_tool(self),)
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    def on_agent_prepare(self, *, agent_name: str, memory_path: str) -> None:
+        """Initialize the metric store and seed any metrics not yet persisted."""
+        del agent_name
+        self._store = MetricStore(Path(memory_path))
+        for name, spec in self._all_specs.items():
+            if self._store.get(name, None) is None:
+                self._store.set(name, spec.initial_value)
+
+    def on_tool_result(self, result: ToolResult) -> ToolResult:
+        """Auto-update deterministic metrics by inspecting tool results."""
+        if self._store is None:
+            return result
+
+        from harnessiq.tools.hooks.defaults import is_tool_allowed
+
+        for spec in self._deterministic:
+            if not any(
+                is_tool_allowed(result.tool_key, (p,))
+                for p in spec.watch_tool_patterns
+            ):
+                continue
+            args: dict[str, Any] = {}
+            if hasattr(result, "arguments"):
+                args = result.arguments or {}
+            try:
+                extracted = spec.extract_value(result.tool_key, args, result.output)
+            except Exception:
+                extracted = None
+            if extracted is not None:
+                self._store.apply_aggregation(
+                    spec.name, extracted, spec.aggregation, spec.initial_value
+                )
+
+        return result
+
+    def handle_model_report(self, name: str, value: Any) -> dict[str, Any]:
+        """Called by the metrics.report tool handler to update a model-reported metric."""
+        if self._store is None:
+            return {"error": "MetricsLayer store is not initialized yet."}
+
+        spec = self._all_specs.get(name)
+        if spec is None or not isinstance(spec, ModelReportedMetricSpec):
+            declared = [s.name for s in self._model_reported]
+            return {
+                "error": (
+                    f"'{name}' is not a declared model-reported metric. "
+                    f"Declared model-reported metrics: {declared}."
+                )
+            }
+
+        type_map: dict[str, type | tuple[type, ...]] = {
+            "int": int,
+            "float": (int, float),
+            "bool": bool,
+            "string": str,
+        }
+        expected = type_map.get(spec.value_type, object)
+        if not isinstance(value, expected):
+            return {
+                "error": (
+                    f"Metric '{name}' expects {spec.value_type}, "
+                    f"got {type(value).__name__}."
+                )
+            }
+
+        updated = self._store.apply_aggregation(
+            name, value, spec.aggregation, spec.initial_value
+        )
+        return {"metric": name, "value": updated, "status": "recorded"}

--- a/harnessiq/formalization/metrics/spec.py
+++ b/harnessiq/formalization/metrics/spec.py
@@ -1,0 +1,137 @@
+"""
+===============================================================================
+File: harnessiq/formalization/metrics/spec.py
+
+What this file does:
+- Defines DeterministicMetricSpec and ModelReportedMetricSpec, the
+  configuration dataclasses for metrics tracked by MetricsLayer.
+- DeterministicMetricSpec: metric updated automatically by intercepting tool
+  results via a user-provided extractor callable.
+- ModelReportedMetricSpec: metric updated by the model calling metrics.report.
+
+Use cases:
+- Declare metrics to pass to MetricsLayer or BaseAgent(metrics=[...]).
+
+How to use it:
+- Import DeterministicMetricSpec or ModelReportedMetricSpec from
+  harnessiq.formalization.metrics and pass one or more instances to
+  MetricsLayer.
+
+Intent:
+- Keep metric configuration as frozen, self-validating dataclasses so metric
+  declarations are explicit, inspectable, and immutable at runtime.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+MetricAggregation = Literal["increment", "set", "max", "min", "last"]
+"""How a new measurement is merged into the current metric value.
+
+"increment" — add the new value to the current (default for counts).
+"set"       — replace the current value with the new value.
+"max"       — keep whichever of current/new is larger.
+"min"       — keep whichever of current/new is smaller.
+"last"      — alias for "set", named semantically for time-series-like metrics.
+"""
+
+MetricValueType = int | float | bool | str
+
+
+@dataclass(frozen=True, slots=True)
+class DeterministicMetricSpec:
+    """A metric whose value is updated automatically by intercepting tool results.
+
+    The layer watches every tool result. When a result's tool key matches
+    watch_tool_patterns, the layer calls extract_value with the tool key,
+    its arguments, and its output. If extract_value returns a non-None value,
+    the metric is updated using the declared aggregation.
+
+    The model is never aware this tracking is happening.
+    """
+
+    name: str
+    """Unique metric name. snake_case recommended."""
+
+    description: str
+    """What this metric measures. Shown to the model in the context window."""
+
+    watch_tool_patterns: tuple[str, ...]
+    """Tool key patterns to watch (fnmatch-style, e.g. 'terminal.*')."""
+
+    extract_value: Callable[[str, dict[str, Any], Any], MetricValueType | None]
+    """Callable extracting a measurement from one tool result.
+
+    Signature: (tool_key: str, arguments: dict, output: Any) -> MetricValueType | None
+    Return None to skip updating the metric for this result.
+    """
+
+    aggregation: MetricAggregation = "increment"
+    """How new values are merged into the current metric value."""
+
+    initial_value: MetricValueType = 0
+    """Starting value before any updates."""
+
+    visible: bool = True
+    """Whether this metric appears in the context window parameter section."""
+
+    unit: str = ""
+    """Optional unit label displayed next to the value."""
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("DeterministicMetricSpec name must not be blank.")
+        if not self.description.strip():
+            raise ValueError("DeterministicMetricSpec description must not be blank.")
+        if not self.watch_tool_patterns:
+            raise ValueError("DeterministicMetricSpec watch_tool_patterns must not be empty.")
+        if not callable(self.extract_value):
+            raise ValueError("DeterministicMetricSpec extract_value must be callable.")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelReportedMetricSpec:
+    """A metric whose value is updated by the model calling metrics.report().
+
+    Use this for subjective or self-assessed metrics that the model itself
+    must evaluate — confidence scores, perceived quality ratings, task
+    completion percentage estimates.
+    """
+
+    name: str
+    """Unique metric name."""
+
+    description: str
+    """What this metric measures."""
+
+    value_type: Literal["int", "float", "bool", "string"] = "float"
+    """Expected value type when the model reports this metric."""
+
+    report_instructions: str = ""
+    """Instructions telling the model when and how to report this metric.
+    If blank, a default instruction is generated from description and value_type.
+    """
+
+    initial_value: MetricValueType = 0
+    """Starting value before the model first reports."""
+
+    aggregation: MetricAggregation = "set"
+    """How model-reported values update the current value. Defaults to 'set'
+    because model-reported metrics are typically assessments (current state).
+    """
+
+    visible: bool = True
+    """Whether this metric appears in the context window."""
+
+    unit: str = ""
+    """Optional unit label displayed next to the value."""
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("ModelReportedMetricSpec name must not be blank.")
+        if not self.description.strip():
+            raise ValueError("ModelReportedMetricSpec description must not be blank.")

--- a/harnessiq/formalization/metrics/store.py
+++ b/harnessiq/formalization/metrics/store.py
@@ -1,0 +1,91 @@
+"""
+===============================================================================
+File: harnessiq/formalization/metrics/store.py
+
+What this file does:
+- Implements MetricStore, a durable disk-backed JSON store for metric values.
+- All metric reads and writes go through this object so values survive context
+  window resets (which clear the transcript but not disk state).
+
+Use cases:
+- Used internally by MetricsLayer. Not intended for direct use by agent code.
+
+How to use it:
+- Construct with a memory_path (Path). Reads existing values on init.
+  Call get/set/apply_aggregation to read and update values.
+
+Intent:
+- Keep metric durability simple and explicit — one JSON file, no external
+  dependencies, human-readable on disk.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_STORE_FILENAME = "metrics_store.json"
+
+
+class MetricStore:
+    """Durable disk-backed storage for metric values.
+
+    All reads and writes go through this object. Metrics always survive
+    context window resets because the store is on disk, not in the transcript.
+    """
+
+    def __init__(self, memory_path: Path) -> None:
+        self._path = memory_path / _STORE_FILENAME
+        self._cache: dict[str, Any] = self._load()
+
+    def get(self, name: str, default: Any) -> Any:
+        """Return the current value for name, or default if not yet set."""
+        return self._cache.get(name, default)
+
+    def set(self, name: str, value: Any) -> None:
+        """Set a metric value directly, flushing to disk."""
+        self._cache[name] = value
+        self._flush()
+
+    def apply_aggregation(
+        self,
+        name: str,
+        new_value: Any,
+        aggregation: str,
+        initial: Any,
+    ) -> Any:
+        """Apply an aggregation rule and return the updated value."""
+        current = self._cache.get(name, initial)
+        if aggregation == "increment":
+            updated = (current or 0) + new_value
+        elif aggregation in ("set", "last"):
+            updated = new_value
+        elif aggregation == "max":
+            updated = max(current, new_value)
+        elif aggregation == "min":
+            updated = min(current, new_value) if current is not None else new_value
+        else:
+            updated = new_value
+        self._cache[name] = updated
+        self._flush()
+        return updated
+
+    def all(self) -> dict[str, Any]:
+        """Return a snapshot of all stored metric values."""
+        return dict(self._cache)
+
+    def _load(self) -> dict[str, Any]:
+        if self._path.exists():
+            raw = self._path.read_text(encoding="utf-8").strip()
+            if raw:
+                return json.loads(raw)
+        return {}
+
+    def _flush(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(self._cache, indent=2, default=str),
+            encoding="utf-8",
+        )

--- a/harnessiq/formalization/metrics/tools.py
+++ b/harnessiq/formalization/metrics/tools.py
@@ -1,0 +1,65 @@
+"""
+===============================================================================
+File: harnessiq/formalization/metrics/tools.py
+
+What this file does:
+- Builds the metrics.report RegisteredTool that allows the model to explicitly
+  update model-reported metric values.
+- The tool is contributed to the agent's executor by MetricsLayer when at least
+  one ModelReportedMetricSpec is declared.
+
+Use cases:
+- Used internally by MetricsLayer.get_formalization_tools(). Not intended for
+  direct use by agent code.
+
+Intent:
+- Keep the tool definition and handler factory in a dedicated module so the
+  layer implementation stays focused on lifecycle management.
+===============================================================================
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from harnessiq.shared.tools import RegisteredTool, ToolDefinition
+
+if TYPE_CHECKING:
+    from .layer import MetricsLayer
+
+METRICS_REPORT_KEY = "metrics.report"
+
+
+def build_metrics_report_tool(layer: MetricsLayer) -> RegisteredTool:
+    """Build the metrics.report tool bound to a MetricsLayer instance."""
+    definition = ToolDefinition(
+        key=METRICS_REPORT_KEY,
+        name="report",
+        description=(
+            "Report the current value of a self-assessed or model-reported metric. "
+            "Call this whenever your assessment of a declared metric has changed. "
+            "Only metrics declared as model-reported can be updated this way."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The metric name, exactly as declared.",
+                },
+                "value": {
+                    "description": "The current metric value.",
+                },
+            },
+            "required": ["name", "value"],
+            "additionalProperties": False,
+        },
+    )
+    return RegisteredTool(
+        definition=definition,
+        handler=lambda args: _handle_report(layer, args),
+    )
+
+
+def _handle_report(layer: MetricsLayer, args: dict[str, Any]) -> dict[str, Any]:
+    return layer.handle_model_report(str(args["name"]), args["value"])

--- a/tests/test_formalization_metrics.py
+++ b/tests/test_formalization_metrics.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from harnessiq.formalization.metrics import (
+    DeterministicMetricSpec,
+    MetricsLayer,
+    ModelReportedMetricSpec,
+)
+from harnessiq.formalization.metrics.store import MetricStore
+from harnessiq.shared.tools import ToolResult
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _tool_result(key: str, output: object) -> ToolResult:
+    return ToolResult(tool_key=key, output=output)
+
+
+def _make_deterministic(
+    name: str = "calls",
+    description: str = "Total calls.",
+    patterns: tuple[str, ...] = ("terminal.*",),
+    extractor=None,
+    aggregation: str = "increment",
+    initial_value: object = 0,
+    visible: bool = True,
+) -> DeterministicMetricSpec:
+    if extractor is None:
+        extractor = lambda key, args, out: 1
+    return DeterministicMetricSpec(
+        name=name,
+        description=description,
+        watch_tool_patterns=patterns,
+        extract_value=extractor,
+        aggregation=aggregation,
+        initial_value=initial_value,
+        visible=visible,
+    )
+
+
+def _make_model_reported(
+    name: str = "confidence",
+    description: str = "Confidence score.",
+    value_type: str = "float",
+    initial_value: object = 0.0,
+    visible: bool = True,
+) -> ModelReportedMetricSpec:
+    return ModelReportedMetricSpec(
+        name=name,
+        description=description,
+        value_type=value_type,
+        initial_value=initial_value,
+        visible=visible,
+    )
+
+
+# ── Spec validation ───────────────────────────────────────────────────────────
+
+class DeterministicMetricSpecTests(unittest.TestCase):
+    def test_valid_spec(self) -> None:
+        spec = _make_deterministic()
+        self.assertEqual(spec.name, "calls")
+        self.assertEqual(spec.aggregation, "increment")
+
+    def test_blank_name_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _make_deterministic(name="  ")
+
+    def test_blank_description_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _make_deterministic(description="  ")
+
+    def test_empty_patterns_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _make_deterministic(patterns=())
+
+    def test_non_callable_extract_value_raises(self) -> None:
+        with self.assertRaises((ValueError, TypeError)):
+            DeterministicMetricSpec(
+                name="x",
+                description="x",
+                watch_tool_patterns=("a",),
+                extract_value="not_callable",  # type: ignore[arg-type]
+            )
+
+    def test_spec_is_frozen(self) -> None:
+        spec = _make_deterministic()
+        with self.assertRaises((AttributeError, TypeError)):
+            spec.name = "other"  # type: ignore[misc]
+
+
+class ModelReportedMetricSpecTests(unittest.TestCase):
+    def test_valid_spec(self) -> None:
+        spec = _make_model_reported()
+        self.assertEqual(spec.name, "confidence")
+        self.assertEqual(spec.aggregation, "set")
+        self.assertEqual(spec.value_type, "float")
+
+    def test_blank_name_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _make_model_reported(name="  ")
+
+    def test_blank_description_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _make_model_reported(description="  ")
+
+
+# ── MetricStore ───────────────────────────────────────────────────────────────
+
+class MetricStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._path = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_get_returns_default_for_unknown_key(self) -> None:
+        store = MetricStore(self._path)
+        self.assertEqual(store.get("missing", 99), 99)
+
+    def test_set_and_get(self) -> None:
+        store = MetricStore(self._path)
+        store.set("x", 42)
+        self.assertEqual(store.get("x", 0), 42)
+
+    def test_values_persist_across_instances(self) -> None:
+        store1 = MetricStore(self._path)
+        store1.set("y", 100)
+        store2 = MetricStore(self._path)
+        self.assertEqual(store2.get("y", 0), 100)
+
+    def test_increment_aggregation(self) -> None:
+        store = MetricStore(self._path)
+        store.apply_aggregation("n", 5, "increment", 0)
+        store.apply_aggregation("n", 3, "increment", 0)
+        self.assertEqual(store.get("n", 0), 8)
+
+    def test_set_aggregation_replaces(self) -> None:
+        store = MetricStore(self._path)
+        store.apply_aggregation("n", 5, "set", 0)
+        store.apply_aggregation("n", 3, "set", 0)
+        self.assertEqual(store.get("n", 0), 3)
+
+    def test_max_aggregation(self) -> None:
+        store = MetricStore(self._path)
+        store.apply_aggregation("n", 5, "max", 0)
+        store.apply_aggregation("n", 3, "max", 0)
+        self.assertEqual(store.get("n", 0), 5)
+
+    def test_min_aggregation(self) -> None:
+        store = MetricStore(self._path)
+        # Seed with a high initial value so min tracking is meaningful.
+        store.set("n", 100)
+        store.apply_aggregation("n", 5, "min", 100)
+        store.apply_aggregation("n", 3, "min", 100)
+        self.assertEqual(store.get("n", 0), 3)
+
+    def test_last_aggregation_is_alias_for_set(self) -> None:
+        store = MetricStore(self._path)
+        store.apply_aggregation("n", 10, "last", 0)
+        store.apply_aggregation("n", 7, "last", 0)
+        self.assertEqual(store.get("n", 0), 7)
+
+    def test_all_returns_snapshot(self) -> None:
+        store = MetricStore(self._path)
+        store.set("a", 1)
+        store.set("b", 2)
+        self.assertEqual(store.all(), {"a": 1, "b": 2})
+
+    def test_json_file_written(self) -> None:
+        store = MetricStore(self._path)
+        store.set("x", 123)
+        data = json.loads((self._path / "metrics_store.json").read_text())
+        self.assertEqual(data["x"], 123)
+
+
+# ── MetricsLayer construction ──────────────────────────────────────────────────
+
+class MetricsLayerConstructionTests(unittest.TestCase):
+    def test_empty_metrics_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            MetricsLayer(metrics=[])
+
+    def test_duplicate_name_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            MetricsLayer(metrics=[_make_deterministic(name="x"), _make_deterministic(name="x")])
+
+    def test_layer_id(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic()])
+        self.assertEqual(layer.layer_id, "MetricsLayer")
+
+    def test_mixed_metrics_accepted(self) -> None:
+        layer = MetricsLayer(
+            metrics=[_make_deterministic(name="calls"), _make_model_reported(name="confidence")]
+        )
+        self.assertIsNotNone(layer)
+
+
+# ── MetricsLayer lifecycle ────────────────────────────────────────────────────
+
+class MetricsLayerLifecycleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._memory_path = self._tmpdir.name
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _prepare(self, layer: MetricsLayer) -> None:
+        layer.on_agent_prepare(agent_name="test-agent", memory_path=self._memory_path)
+
+    def test_get_value_returns_none_before_prepare(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(name="x", initial_value=0)])
+        self.assertIsNone(layer.get_value("x"))
+
+    def test_get_value_returns_initial_after_prepare(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(name="x", initial_value=5)])
+        self._prepare(layer)
+        self.assertEqual(layer.get_value("x"), 5)
+
+    def test_get_value_returns_none_for_unknown_metric(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(name="x")])
+        self._prepare(layer)
+        self.assertIsNone(layer.get_value("unknown"))
+
+    def test_all_values_after_prepare(self) -> None:
+        layer = MetricsLayer(
+            metrics=[
+                _make_deterministic(name="a", initial_value=1),
+                _make_model_reported(name="b", initial_value=0.0),
+            ]
+        )
+        self._prepare(layer)
+        vals = layer.all_values()
+        self.assertEqual(vals["a"], 1)
+        self.assertEqual(vals["b"], 0.0)
+
+
+# ── Deterministic metric tracking via on_tool_result ──────────────────────────
+
+class MetricsLayerDeterministicTrackingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._memory_path = self._tmpdir.name
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_and_prepare(self, spec: DeterministicMetricSpec) -> MetricsLayer:
+        layer = MetricsLayer(metrics=[spec])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        return layer
+
+    def test_matching_tool_key_updates_metric(self) -> None:
+        spec = _make_deterministic(
+            name="calls",
+            patterns=("terminal.*",),
+            extractor=lambda k, a, o: 1,
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        self.assertEqual(layer.get_value("calls"), 1)
+
+    def test_non_matching_tool_key_skips(self) -> None:
+        spec = _make_deterministic(
+            name="calls",
+            patterns=("terminal.*",),
+            extractor=lambda k, a, o: 1,
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("artifact.write_json", {}))
+        self.assertEqual(layer.get_value("calls"), 0)
+
+    def test_extractor_returning_none_skips_update(self) -> None:
+        spec = _make_deterministic(
+            name="calls",
+            patterns=("terminal.*",),
+            extractor=lambda k, a, o: None,
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        self.assertEqual(layer.get_value("calls"), 0)
+
+    def test_extractor_exception_skips_update(self) -> None:
+        def bad_extractor(k, a, o):
+            raise RuntimeError("boom")
+        spec = _make_deterministic(
+            name="calls",
+            patterns=("terminal.*",),
+            extractor=bad_extractor,
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        self.assertEqual(layer.get_value("calls"), 0)
+
+    def test_increment_aggregation_accumulates(self) -> None:
+        spec = _make_deterministic(
+            name="calls",
+            patterns=("terminal.*",),
+            extractor=lambda k, a, o: 1,
+            aggregation="increment",
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        self.assertEqual(layer.get_value("calls"), 3)
+
+    def test_on_tool_result_returns_result_unchanged(self) -> None:
+        spec = _make_deterministic(name="x", patterns=("a.*",), extractor=lambda k, a, o: 1)
+        layer = self._make_and_prepare(spec)
+        result = _tool_result("a.run", {"payload": 42})
+        returned = layer.on_tool_result(result)
+        self.assertIs(returned, result)
+
+    def test_wildcard_pattern_matches_multiple_tools(self) -> None:
+        spec = _make_deterministic(
+            name="all_calls",
+            patterns=("*",),
+            extractor=lambda k, a, o: 1,
+        )
+        layer = self._make_and_prepare(spec)
+        layer.on_tool_result(_tool_result("terminal.run", {}))
+        layer.on_tool_result(_tool_result("artifact.write", {}))
+        self.assertEqual(layer.get_value("all_calls"), 2)
+
+
+# ── Model-reported metrics via handle_model_report ───────────────────────────
+
+class MetricsLayerModelReportedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._memory_path = self._tmpdir.name
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_and_prepare(self, spec: ModelReportedMetricSpec) -> MetricsLayer:
+        layer = MetricsLayer(metrics=[spec])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        return layer
+
+    def test_report_float_metric(self) -> None:
+        spec = _make_model_reported(name="confidence", value_type="float", initial_value=0.0)
+        layer = self._make_and_prepare(spec)
+        result = layer.handle_model_report("confidence", 0.85)
+        self.assertEqual(result["status"], "recorded")
+        self.assertAlmostEqual(result["value"], 0.85)
+        self.assertAlmostEqual(layer.get_value("confidence"), 0.85)
+
+    def test_report_int_metric(self) -> None:
+        spec = _make_model_reported(name="score", value_type="int", initial_value=0)
+        layer = self._make_and_prepare(spec)
+        result = layer.handle_model_report("score", 7)
+        self.assertEqual(result["status"], "recorded")
+        self.assertEqual(result["value"], 7)
+
+    def test_report_string_metric(self) -> None:
+        spec = _make_model_reported(name="phase", value_type="string", initial_value="")
+        layer = self._make_and_prepare(spec)
+        result = layer.handle_model_report("phase", "research")
+        self.assertEqual(result["status"], "recorded")
+
+    def test_wrong_type_returns_error(self) -> None:
+        spec = _make_model_reported(name="confidence", value_type="float", initial_value=0.0)
+        layer = self._make_and_prepare(spec)
+        result = layer.handle_model_report("confidence", "not_a_float")
+        self.assertIn("error", result)
+
+    def test_unknown_metric_returns_error(self) -> None:
+        spec = _make_model_reported(name="confidence")
+        layer = self._make_and_prepare(spec)
+        result = layer.handle_model_report("nonexistent", 0.5)
+        self.assertIn("error", result)
+
+    def test_report_deterministic_metric_returns_error(self) -> None:
+        det = _make_deterministic(name="calls")
+        mr = _make_model_reported(name="confidence")
+        layer = MetricsLayer(metrics=[det, mr])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        result = layer.handle_model_report("calls", 1)
+        self.assertIn("error", result)
+
+
+# ── metrics.report tool ───────────────────────────────────────────────────────
+
+class MetricsLayerToolTests(unittest.TestCase):
+    def test_no_tools_when_no_model_reported(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic()])
+        tools = layer.get_formalization_tools()
+        self.assertEqual(len(tools), 0)
+
+    def test_report_tool_contributed_when_model_reported_present(self) -> None:
+        from harnessiq.shared.tools import RegisteredTool
+        layer = MetricsLayer(metrics=[_make_model_reported()])
+        tools = layer.get_formalization_tools()
+        self.assertEqual(len(tools), 1)
+        self.assertIsInstance(tools[0], RegisteredTool)
+        self.assertEqual(tools[0].definition.key, "metrics.report")
+
+
+# ── Parameter sections ────────────────────────────────────────────────────────
+
+class MetricsLayerParameterSectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._memory_path = self._tmpdir.name
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_no_metrics_section_before_prepare(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(visible=True)])
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertNotIn("Metrics", titles)
+
+    def test_metrics_section_after_prepare(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(visible=True)])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertIn("Metrics", titles)
+
+    def test_invisible_metric_excluded(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(name="hidden", visible=False)])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        sections = layer.get_parameter_sections()
+        titles = [s.title for s in sections]
+        self.assertNotIn("Metrics", titles)
+
+    def test_metrics_section_content_includes_unit(self) -> None:
+        spec = DeterministicMetricSpec(
+            name="git_commits",
+            description="Total commits.",
+            watch_tool_patterns=("terminal.*",),
+            extract_value=lambda k, a, o: 1,
+            unit="commits",
+        )
+        layer = MetricsLayer(metrics=[spec])
+        layer.on_agent_prepare(agent_name="agent", memory_path=self._memory_path)
+        sections = layer.get_parameter_sections()
+        metrics_section = next(s for s in sections if s.title == "Metrics")
+        self.assertIn("commits", metrics_section.content)
+
+
+# ── describe() output ─────────────────────────────────────────────────────────
+
+class MetricsLayerDescribeTests(unittest.TestCase):
+    def test_describe_identity_mentions_metric_names(self) -> None:
+        layer = MetricsLayer(
+            metrics=[
+                _make_deterministic(name="calls"),
+                _make_model_reported(name="confidence"),
+            ]
+        )
+        desc = layer.describe()
+        self.assertIn("calls", desc.identity)
+        self.assertIn("confidence", desc.identity)
+
+    def test_describe_rules_for_deterministic(self) -> None:
+        layer = MetricsLayer(metrics=[_make_deterministic(name="calls")])
+        rules = layer.describe().rules
+        rule_ids = [r.rule_id for r in rules]
+        self.assertIn("METRIC-TRACK-CALLS", rule_ids)
+
+    def test_describe_rules_for_model_reported(self) -> None:
+        layer = MetricsLayer(metrics=[_make_model_reported(name="confidence")])
+        rules = layer.describe().rules
+        rule_ids = [r.rule_id for r in rules]
+        self.assertIn("METRIC-REPORT-TOOL", rule_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #455

## Summary
- Adds `harnessiq/formalization/metrics/` package with `DeterministicMetricSpec`, `ModelReportedMetricSpec`, `MetricStore`, `MetricsLayer`, and `build_metrics_report_tool`
- `MetricsLayer.on_tool_result` auto-tracks deterministic metrics by pattern-matching tool keys and calling the user's extractor callable
- All 5 aggregation modes supported: `increment`, `set`, `max`, `min`, `last`
- `MetricStore` provides durable disk-backed JSON persistence — metric values survive context window resets
- `metrics.report` RegisteredTool contributed to executor when model-reported metrics are declared
- `get_parameter_sections()` renders live values with unit labels and kind tags (auto / self-reported)
- 49 unit tests covering spec validation, store aggregations, lifecycle, tracking, reporting, tools, and parameter sections

## Test plan
- [ ] `python -m pytest tests/test_formalization_metrics.py -v` — 49/49 pass
- [ ] Imports verified: `from harnessiq.formalization.metrics import MetricsLayer, DeterministicMetricSpec, ModelReportedMetricSpec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)